### PR TITLE
Remove comma in metadata_fields

### DIFF
--- a/squad/core/tasks/__init__.py
+++ b/squad/core/tasks/__init__.py
@@ -106,7 +106,7 @@ class ReceiveTestRun(object):
             metrics_file=metrics_file,
             log_file=log_file,
             metadata_file=metadata,
-            **metadata_fields,
+            **metadata_fields
         )
 
         testrun.refresh_from_db()


### PR DESCRIPTION
This fixes invalid syntax error.

Signed-off-by: Luis Araujo <luis.araujo@collabora.co.uk>