### PR TITLE
Make test history and test comparison more complete

### DIFF
--- a/squad/core/comparison.py
+++ b/squad/core/comparison.py
@@ -53,12 +53,11 @@ class TestComparison(object):
     @classmethod
     def compare_projects(cls, *projects):
         builds = [p.builds.last() for p in projects]
+        builds = [b for b in builds if b]
         return cls.compare_builds(*builds)
 
     def __extract_results__(self):
         for build in self.builds:
-            if not build:
-                continue
             test_runs = list(build.test_runs.all())
             environments = [t.environment for t in test_runs]
             self.environments[build] = sorted(set(environments), key=lambda e: e.id)

--- a/squad/core/comparison.py
+++ b/squad/core/comparison.py
@@ -15,16 +15,16 @@ class TestComparison(object):
     The best way to think about this is to think of the table you want as
     result:
 
-   +-------+---------------+---------------+
-   |       |    build 1    |    build 2    |
-   +       +-------+-------+-------+-------+
-   |       | env 1 | env 2 | env 1 | env 2 |
-   +-------+-------+-------+-------+-------+
-   | test1 |       |       |       |       |
-   | test2 |       |       |       |       |
-   | test3 |       |       |       |       |
-   | test4 |       |       |       |       |
-   +-------+-------+-------+-------+-------+
+    +-------+---------------+---------------+
+    |       |    build 1    |    build 2    |
+    +       +-------+-------+-------+-------+
+    |       | env 1 | env 2 | env 1 | env 2 |
+    +-------+-------+-------+-------+-------+
+    | test1 |       |       |       |       |
+    | test2 |       |       |       |       |
+    | test3 |       |       |       |       |
+    | test4 |       |       |       |       |
+    +-------+-------+-------+-------+-------+
 
     `builds` is the list of builds (the top header row)
 

--- a/squad/core/history.py
+++ b/squad/core/history.py
@@ -22,22 +22,19 @@ class TestHistory(object):
             suite__slug=suite,
             name=test_name,
             test_run__build__project=project,
-        ).order_by(
-            '-test_run__build__created_at',
-            'test_run__environment_id'
         )
         Test.prefetch_related(tests)
 
         environments = OrderedDict()
         results = OrderedDict()
+        for build in project.builds.order_by('-version').all():
+            results[build] = {}
+
         for test in tests:
             build = test.test_run.build
             environment = test.test_run.environment
 
             environments[environment] = True
-
-            if build not in results:
-                results[build] = {}
             results[build][environment] = TestResult(test)
 
         self.environments = list(environments.keys())

--- a/test/core/test_comparison.py
+++ b/test/core/test_comparison.py
@@ -24,6 +24,10 @@ class TestComparisonTest(TestCase):
         self.project1 = self.group.projects.create(slug='project1')
         self.project2 = self.group.projects.create(slug='project2')
 
+        self.receive_test_run(self.project1, '0', 'myenv', {
+            'z': 'pass',
+        })
+
         self.receive_test_run(self.project1, '1', 'myenv', {
             'a': 'pass',
             'b': 'pass',
@@ -77,7 +81,7 @@ class TestComparisonTest(TestCase):
 
     def test_tests(self):
         comp = compare(self.build1, self.build2)
-        self.assertEqual(['a', 'b', 'c', 'd/e'], sorted(comp.results.keys()))
+        self.assertEqual(['a', 'b', 'c', 'd/e', 'z'], sorted(comp.results.keys()))
 
     def test_test_results(self):
         comp = compare(self.build1, self.build2)

--- a/test/core/test_history.py
+++ b/test/core/test_history.py
@@ -17,6 +17,11 @@ class TestHistoryTest(TestCase):
         self.group = models.Group.objects.create(slug='mygruop')
         self.project1 = self.group.projects.create(slug='project1')
 
+        self.receive_test_run(self.project1, '0', 'env1', {
+            'foo/bar': 'fail',
+            # missing `root` on purpose
+        })
+
         self.receive_test_run(self.project1, '1', 'env1', {
             'foo/bar': 'fail',
             'root': 'fail',
@@ -66,3 +71,9 @@ class TestHistoryTest(TestCase):
         self.assertEqual('pass', history.results[build1][env2].status)
         self.assertEqual('pass', history.results[build2][env1].status)
         self.assertEqual('fail', history.results[build2][env2].status)
+
+    def test_displays_all_builds(self):
+        build0 = self.project1.builds.get(version='0')
+        history = TestHistory(self.project1, 'root')
+
+        self.assertIn(build0, history.results)


### PR DESCRIPTION
These changes will make it easier to spot case where a given test has no
results in some builds. This can be caused by issue with the builds that make
the test job fail before any tests are executed, so we miss results for them.

The test history page will now list all builds, not only the ones in which
there were results for the test in question.

Test comparison page will now list all tests from all projects, not only the
tests that were present in the builds being compared.