### PR TITLE
api/ci: check whether the submitted request is valid

### DIFF
--- a/test/api/test_ci.py
+++ b/test/api/test_ci.py
@@ -38,6 +38,21 @@ class CiApiTest(TestCase):
             ).count()
         )
 
+    def test_invalid_backend_test_run(self):
+        args = {
+            'backend': 'lava.foo',
+            'definition': 'foo: 1',
+        }
+        r = self.client.post('/api/submitjob/mygroup/myproject/1/myenv', args)
+        self.assertEqual(400, r.status_code)
+
+    def test_missing_definition_test_run(self):
+        args = {
+            'backend': 'lava'
+        }
+        r = self.client.post('/api/submitjob/mygroup/myproject/1/myenv', args)
+        self.assertEqual(400, r.status_code)
+
     def test_accepts_definition_as_file_upload(self):
         args = {
             'backend': 'lava',


### PR DESCRIPTION
When request doens't contain required fields, 400 response is returned
instead of 500.

fixes #19

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>