### PR TITLE
core: add ProjectStatus to admin interface

### DIFF
--- a/squad/core/admin.py
+++ b/squad/core/admin.py
@@ -44,6 +44,11 @@ class ProjectAdmin(admin.ModelAdmin):
     actions = [force_notify_project]
 
 
+class ProjectStatusAdmin(admin.ModelAdmin):
+    model = models.ProjectStatus
+
+
 admin.site.register(models.Group)
 admin.site.register(models.Project, ProjectAdmin)
 admin.site.register(models.Token, TokenAdmin)
+admin.site.register(models.ProjectStatus, ProjectStatusAdmin)

--- a/squad/core/models.py
+++ b/squad/core/models.py
@@ -401,7 +401,7 @@ class ProjectStatus(models.Model):
         ).order_by('datetime')
 
     def __str__(self):
-        return 'Build %s; created at %s' % (self.build, self.created_at)
+        return 'Project: %s; Build %s; created at %s' % (self.build.project, self.build, self.created_at)
 
 
 class Subscription(models.Model):


### PR DESCRIPTION
This allows deleting ProjectStatus object and re-triggering the email
notifications.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>