### PR TITLE
ci: lava: fetch job logs in LAVA backend

### DIFF
--- a/squad/ci/backend/lava.py
+++ b/squad/ci/backend/lava.py
@@ -63,7 +63,11 @@ class Backend(BaseBackend):
         if data['status'] in self.complete_statuses:
             yamldata = self.__get_testjob_results_yaml__(test_job.job_id)
             data['results'] = yaml.load(yamldata)
-            return self.__parse_results__(data, test_job)
+
+            # fetch logs
+            logs = self.__get_job_logs__(test_job.job_id)
+
+            return self.__parse_results__(data, test_job) + (logs,)
 
     def listen(self):
         listener_url = self.get_listener_url()
@@ -174,6 +178,10 @@ class Backend(BaseBackend):
 
     def __get_job_details__(self, job_id):
         return self.proxy.scheduler.job_details(job_id)
+
+    def __get_job_logs__(self, job_id):
+        job_finished, data = self.proxy.scheduler.job_output(job_id)
+        return data
 
     def __get_testjob_results_yaml__(self, job_id):
         return self.proxy.results.get_testjob_results_yaml(job_id)

--- a/squad/ci/backend/null.py
+++ b/squad/ci/backend/null.py
@@ -55,8 +55,8 @@ class Backend(object):
         assumed that the job has been properly submited before, i.e. it has a
         proper id.
 
-        The return value must be a tuple (status, metadata, tests, metrics),
-        where status is a string, all other elements are dictionaries.
+        The return value must be a tuple (status, metadata, tests, metrics, logs),
+        where status and logs are strings, metadata, tests and metrics are dictionaries.
         """
         pass
 

--- a/squad/ci/models.py
+++ b/squad/ci/models.py
@@ -53,7 +53,7 @@ class Backend(models.Model):
 
         if results:
             # create TestRun
-            status, metadata, tests, metrics = results
+            status, metadata, tests, metrics, logs = results
 
             test_job.job_status = status
 
@@ -67,6 +67,7 @@ class Backend(models.Model):
                 metadata_file=json.dumps(metadata),
                 tests_file=json.dumps(tests),
                 metrics_file=json.dumps(metrics),
+                log_file=logs,
             )
             test_job.testrun = testrun
             test_job.fetched = True

--- a/test/ci/backend/test_lava.py
+++ b/test/ci/backend/test_lava.py
@@ -102,9 +102,10 @@ class LavaTest(TestCase):
         self.assertEqual('1234', lava.submit(testjob))
         __submit__.assert_called_with("foo: 1\n")
 
+    @patch("squad.ci.backend.lava.Backend.__get_job_logs__", return_value=(True, "abc"))
     @patch("squad.ci.backend.lava.Backend.__get_job_details__", return_value=JOB_DETAILS)
     @patch("squad.ci.backend.lava.Backend.__get_testjob_results_yaml__", return_value=TEST_RESULTS_YAML)
-    def test_fetch_basics(self, get_results, get_details):
+    def test_fetch_basics(self, get_results, get_details, get_logs):
         lava = LAVABackend(None)
         testjob = TestJob(
             job_id='9999',
@@ -126,25 +127,27 @@ class LavaTest(TestCase):
 
         get_results.assert_not_called()
 
+    @patch("squad.ci.backend.lava.Backend.__get_job_logs__", return_value=(True, "abc"))
     @patch("squad.ci.backend.lava.Backend.__get_job_details__", return_value=JOB_DETAILS)
     @patch("squad.ci.backend.lava.Backend.__get_testjob_results_yaml__", return_value=TEST_RESULTS_YAML)
-    def test_parse_results_metadata(self, get_results, get_details):
+    def test_parse_results_metadata(self, get_results, get_details, get_logs):
         lava = LAVABackend(None)
         testjob = TestJob(
             job_id='1234',
             backend=self.backend)
-        status, metadata, results, metrics = lava.fetch(testjob)
+        status, metadata, results, metrics, logs = lava.fetch(testjob)
 
         self.assertEqual(JOB_METADATA, metadata)
 
+    @patch("squad.ci.backend.lava.Backend.__get_job_logs__", return_value=(True, "abc"))
     @patch("squad.ci.backend.lava.Backend.__get_job_details__", return_value=JOB_DETAILS)
     @patch("squad.ci.backend.lava.Backend.__get_testjob_results_yaml__", return_value=TEST_RESULTS_YAML)
-    def test_parse_results(self, get_results, get_details):
+    def test_parse_results(self, get_results, get_details, get_logs):
         lava = LAVABackend(None)
         testjob = TestJob(
             job_id='1234',
             backend=self.backend)
-        status, metadata, results, metrics = lava.fetch(testjob)
+        status, metadata, results, metrics, logs = lava.fetch(testjob)
 
         self.assertEqual(len(results), 1)
         self.assertEqual(len(metrics), 1)

--- a/test/ci/test_models.py
+++ b/test/ci/test_models.py
@@ -112,7 +112,7 @@ class BackendFetchTest(BackendTestBase):
         metadata = {"foo": "bar"}
         tests = {"foo": "pass"}
         metrics = {"bar": 1}
-        results = ('Complete', metadata, tests, metrics)
+        results = ('Complete', metadata, tests, metrics, "abc")
 
         impl = MagicMock()
         impl.fetch = MagicMock(return_value=results)


### PR DESCRIPTION
Job logs are now fetched during data processing and are added to the
TestRun object.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>