### PR TITLE
core: remove null bytes from TestRun metadata

### DIFF
--- a/squad/core/tasks/__init__.py
+++ b/squad/core/tasks/__init__.py
@@ -99,8 +99,16 @@ class ReceiveTestRun(object):
         validate = ValidateTestRun()
         validate(metadata_file, metrics_file, tests_file)
 
+        metadata_fields = {}
+        data = {}
         if metadata_file:
-            data = json.loads(metadata_file)
+            tmp_data = json.loads(metadata_file)
+            for k, v in tmp_data.items():
+                if isinstance(k, str):
+                    k = k.replace("\x00", "")
+                if isinstance(v, str):
+                    v = v.replace("\x00", "")
+                data.update({k: v})
 
             fields = self.SPECIAL_METADATA_FIELDS
             metadata_fields = {k: data[k] for k in fields if data.get(k)}
@@ -108,9 +116,6 @@ class ReceiveTestRun(object):
             job_id = metadata_fields['job_id']
             if build.test_runs.filter(job_id=job_id).exists():
                 raise exceptions.InvalidMetadata("There is already a test run with job_id %s" % job_id)
-
-        else:
-            metadata_fields = {}
 
         if 'job_id' not in metadata_fields:
             metadata_fields['job_id'] = uuid.uuid4()
@@ -120,7 +125,7 @@ class ReceiveTestRun(object):
             tests_file=tests_file,
             metrics_file=metrics_file,
             log_file=log_file,
-            metadata_file=metadata_file,
+            metadata_file=json.dumps(data),
             completed=completed,
             **metadata_fields
         )

--- a/test/api/tests.py
+++ b/test/api/tests.py
@@ -1,3 +1,4 @@
+import json
 import os
 from io import StringIO
 
@@ -149,7 +150,7 @@ class ApiTest(TestCase):
             }
         )
         t = models.TestRun.objects.last()
-        self.assertEqual(open(metadata_file).read(), t.metadata_file)
+        self.assertEqual(json.loads(open(metadata_file).read()), json.loads(t.metadata_file))
 
     def test_attachment(self):
         self.client.post(

--- a/test/ci/backend/test_lava.py
+++ b/test/ci/backend/test_lava.py
@@ -59,6 +59,10 @@ JOB_METADATA = {
     'key_bar': 'value_bar'
 }
 
+JOB_NULL_METADATA = {
+    '\x00key_foo': '\x00value_foo',
+    'key_bar\x00': 'value_bar\x00'
+}
 
 JOB_DEFINITION = {
     'job_name': 'job_foo',

--- a/test/core/test_tasks.py
+++ b/test/core/test_tasks.py
@@ -137,6 +137,25 @@ class ReceiveTestRunTest(TestCase):
         metadata = json.loads(testrun.metadata_file)
         self.assertEqual(metadata_in, metadata)
 
+    def test_metadata_null_string_values(self):
+        receive = ReceiveTestRun(self.project)
+        metadata_in = {
+            "job_id": "\x008765",
+            "foo": "bar\x00",
+            "ba\x00z": "x\x00yz"
+        }
+        metadata_expected = {
+            "job_id": "8765",
+            "foo": "bar",
+            "baz": "xyz"
+        }
+
+        receive('199', 'myenv', metadata_file=json.dumps(metadata_in))
+        testrun = TestRun.objects.last()
+
+        metadata = json.loads(testrun.metadata_file)
+        self.assertEqual(metadata_expected, metadata)
+
     def test_build_datetime(self):
         receive = ReceiveTestRun(self.project)
 


### PR DESCRIPTION
Because of change in postrges driver behaviour null bytes are no longer
allowed. They were found in metadata received from LAVA. This patch
removes null bytes to avoid database exception.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>