### PR TITLE
ci: mark testjob completed if it produced results

### DIFF
--- a/squad/ci/models.py
+++ b/squad/ci/models.py
@@ -57,6 +57,10 @@ class Backend(models.Model):
 
             test_job.job_status = status
             if not completed:
+                if tests or metrics:
+                    # this means the job produced 'some' results
+                    # and can be reported on
+                    completed = True
                 test_job.can_resubmit = True
 
             metadata['job_id'] = test_job.job_id


### PR DESCRIPTION
If a TestJob produces some results but the metadata suggest it's not
finished properly, mark is as 'completed' and allow resubmit. This way
email notifications engine can cope with jobs that produce results
despite LAVA reporting infrastructure issue.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>