### PR TITLE
frontend: fix group template

### DIFF
--- a/squad/frontend/templates/squad/group.html
+++ b/squad/frontend/templates/squad/group.html
@@ -12,6 +12,7 @@
         <th>Metrics</th>
     </tr>
     {% for project in projects %}
+    {% with status=project.status %}
     <tr>
         <td>
             <a href="{% project_url project %}">
@@ -19,8 +20,8 @@
             </a>
         </td>
         <td>
-            {{project.status.test_run.datetime}}
-            <em>{{project.status.test_run.datetime|naturaltime}}</em>
+            {{status.last_updated}}
+            <em>{{status.last_updated|naturaltime}}</em>
         </td>
         <td>
             <div class="progress">
@@ -35,6 +36,8 @@
         <td>
             {{project.status.metrics_summary}}
         </td>
-        {% endfor %}
+        {% endwith %}
+    </tr>
+    {% endfor %}
 </table>
 {% endblock %}


### PR DESCRIPTION
Group template last updated column now uses the proper status object.
This commit fixes #70

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>