### PR TITLE
core/notification: clearly identify tests that never passed

### DIFF
--- a/scripts/testdata/submit-test-data
+++ b/scripts/testdata/submit-test-data
@@ -31,6 +31,10 @@ rand() {
 
 # generates a pass with 75% chance
 rand_pass_fail() {
+  if [ -n "${SQUAD_RESULT:-}" ]; then
+    echo "$SQUAD_RESULT"
+    return
+  fi
   if [ "$(rand 4)" -eq 1 ]; then
     echo "fail"
   else

--- a/squad/core/templates/squad/notification/diff.html
+++ b/squad/core/templates/squad/notification/diff.html
@@ -83,9 +83,14 @@ table.table-bordered td.fail {
             <a href="{{settings.BASE_URL}}/{{build.project}}/build/{{build.version}}/testrun/{{test.test_run.job_id}}/log">(log)</a>
             {% endif %}
             {% if test.history.since %}
-              {% with build=test.history.since.test_run.build %}
-              &mdash; failing since build {{build.version}}, from {{build.datetime}}
-              {% endwith %}
+              &mdash;
+              {% if test.history.last_different %}
+                {% with build=test.history.since.test_run.build %}
+                failing since build {{build.version}}, from {{build.datetime}}
+                {% endwith %}
+              {% else %}
+                never passed
+              {% endif %}
             {% endif %}
           </li>
           {% endfor %}

--- a/squad/core/templates/squad/notification/diff.txt
+++ b/squad/core/templates/squad/notification/diff.txt
@@ -24,7 +24,7 @@ Failures
 {% if summary.failures %}
 {% for env, tests in summary.failures.items %}{{env}}:
 {% for test in tests %}
-  * {{test.full_name}} {% if test.history.since %}{% with build=test.history.since.test_run.build %}-- failing since build {{build.version}}, from {{build.datetime}} {% endwith %}{% endif %}{% endfor %}
+  * {{test.full_name}} {% if test.history.since %}-- {% if test.history.last_different %}{% with build=test.history.since.test_run.build %}failing since build {{build.version}}, from {{build.datetime}} {% endwith %}{% else %}never passed{% endif %}{% endif %}{% endfor %}
 {% endfor %}
 {% else %}
 (none)


### PR DESCRIPTION
Example plain text output (HTML output is equivalent):

| Failures
| ------------------------------------------------------------------------
|
| testenv:
|
|   * tgroup1/test1
|   * tgroup1/test2 -- never passed
|   * tgroup1/test3 -- failing since build 6, from July 17, 2017, 2:21 p.m.
|   * tgroup1/test4
|   * tgroup1/test5

Fixes issue #64