### PR TITLE
ci: mark proper TestRun status on awkward LAVA failure

### DIFF
--- a/squad/ci/models.py
+++ b/squad/ci/models.py
@@ -63,6 +63,12 @@ class Backend(models.Model):
                     completed = True
                 test_job.can_resubmit = True
 
+            if completed and not tests and not metrics:
+                # test job produced no results
+                # mark it incomplete
+                completed = False
+                test_job.can_resubmit = True
+
             metadata['job_id'] = test_job.job_id
             metadata['job_status'] = test_job.job_status
             if test_job.url is not None:

--- a/test/ci/test_models.py
+++ b/test/ci/test_models.py
@@ -158,6 +158,108 @@ class BackendFetchTest(BackendTestBase):
 
     @patch('django.utils.timezone.now', return_value=NOW)
     @patch('squad.ci.models.Backend.get_implementation')
+    def test_really_fetch_with_empty_results(self, get_implementation, __now__):
+        metadata = {"foo": "bar"}
+        tests = {}
+        metrics = {}
+        results = ('Complete', True, metadata, tests, metrics, "abc")
+
+        impl = MagicMock()
+        impl.fetch = MagicMock(return_value=results)
+        impl.job_url = MagicMock(return_value="http://www.example.com")
+        get_implementation.return_value = impl
+
+        test_job = self.create_test_job(
+            backend=self.backend,
+            definition='foo: 1',
+            build='1',
+            environment='myenv',
+            job_id='999',
+        )
+
+        self.backend.really_fetch(test_job)
+
+        # should not crash
+        test_run = core_models.TestRun.objects.get(
+            build__project=self.project,
+            environment__slug='myenv',
+            build__version='1',
+            job_id='999',
+            job_status='Complete',
+        )
+        self.assertTrue(test_job.can_resubmit)
+        self.assertFalse(test_run.completed)
+
+    @patch('django.utils.timezone.now', return_value=NOW)
+    @patch('squad.ci.models.Backend.get_implementation')
+    def test_really_fetch_with_only_results(self, get_implementation, __now__):
+        metadata = {"foo": "bar"}
+        tests = {"foo": "pass"}
+        metrics = {}
+        results = ('Complete', True, metadata, tests, metrics, "abc")
+
+        impl = MagicMock()
+        impl.fetch = MagicMock(return_value=results)
+        impl.job_url = MagicMock(return_value="http://www.example.com")
+        get_implementation.return_value = impl
+
+        test_job = self.create_test_job(
+            backend=self.backend,
+            definition='foo: 1',
+            build='1',
+            environment='myenv',
+            job_id='999',
+        )
+
+        self.backend.really_fetch(test_job)
+
+        # should not crash
+        test_run = core_models.TestRun.objects.get(
+            build__project=self.project,
+            environment__slug='myenv',
+            build__version='1',
+            job_id='999',
+            job_status='Complete',
+        )
+        self.assertFalse(test_job.can_resubmit)
+        self.assertTrue(test_run.completed)
+
+    @patch('django.utils.timezone.now', return_value=NOW)
+    @patch('squad.ci.models.Backend.get_implementation')
+    def test_really_fetch_with_only_metrics(self, get_implementation, __now__):
+        metadata = {"foo": "bar"}
+        tests = {}
+        metrics = {"foo": 10}
+        results = ('Complete', True, metadata, tests, metrics, "abc")
+
+        impl = MagicMock()
+        impl.fetch = MagicMock(return_value=results)
+        impl.job_url = MagicMock(return_value="http://www.example.com")
+        get_implementation.return_value = impl
+
+        test_job = self.create_test_job(
+            backend=self.backend,
+            definition='foo: 1',
+            build='1',
+            environment='myenv',
+            job_id='999',
+        )
+
+        self.backend.really_fetch(test_job)
+
+        # should not crash
+        test_run = core_models.TestRun.objects.get(
+            build__project=self.project,
+            environment__slug='myenv',
+            build__version='1',
+            job_id='999',
+            job_status='Complete',
+        )
+        self.assertFalse(test_job.can_resubmit)
+        self.assertTrue(test_run.completed)
+
+    @patch('django.utils.timezone.now', return_value=NOW)
+    @patch('squad.ci.models.Backend.get_implementation')
     def test_create_testrun_job_url(self, get_implementation, __now__):
         metadata = {"foo": "bar"}
         tests = {"foo": "pass"}


### PR DESCRIPTION
When LAVA reports TestJob as Complete but doesn't produce any result
this might be a result of LAVA bug. It might also be a legitimate
result, but LAVA CI backend of SQUAD doesn't support it. This patch sets
proper flags on TestJob and TestRun objects so the TestJob can be
resubmitted from UI.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>