### PR TITLE
Instant notifications

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -83,9 +83,6 @@ needed:
 * Under "Djcelery", create "Periodic tasks":
   * ``squad.ci.tasks.poll``: this is that task to  poll results from the
     backends from time to time. You can schedule this for every 5 minutes;
-  * ``squad.core.tasks.notification.notify_all_projects``: this is the task
-    that sends email notifications about changes in test status. You probably
-    want to schedule this for once or twice a day.
 
 Further configuration
 ---------------------

--- a/squad/core/tasks/__init__.py
+++ b/squad/core/tasks/__init__.py
@@ -13,7 +13,7 @@ from squad.core.statistics import geomean
 from . import exceptions
 
 
-from .notification import notify_project
+from .notification import notify_project, notify_project_status
 
 
 test_parser = JSONTestDataParser

--- a/squad/core/tasks/__init__.py
+++ b/squad/core/tasks/__init__.py
@@ -13,7 +13,7 @@ from squad.core.statistics import geomean
 from . import exceptions
 
 
-from .notification import notify_project, notify_all_projects
+from .notification import notify_project
 
 
 test_parser = JSONTestDataParser

--- a/squad/core/tasks/notification.py
+++ b/squad/core/tasks/notification.py
@@ -1,6 +1,6 @@
 from squad.celery import app as celery
-from squad.core.models import Project
-from squad.core.notification import send_notification
+from squad.core.models import Project, ProjectStatus
+from squad.core.notification import send_notification, send_status_notification
 
 
 import logging
@@ -10,3 +10,9 @@ import logging
 def notify_project(project_id):
     project = Project.objects.get(pk=project_id)
     send_notification(project)
+
+
+@celery.task
+def notify_project_status(status_id):
+    status = ProjectStatus.objects.get(pk=status_id)
+    send_status_notification(status)

--- a/squad/core/tasks/notification.py
+++ b/squad/core/tasks/notification.py
@@ -10,9 +10,3 @@ import logging
 def notify_project(project_id):
     project = Project.objects.get(pk=project_id)
     send_notification(project)
-
-
-@celery.task
-def notify_all_projects():
-    for project in Project.objects.all():
-        notify_project.delay(project.id)

--- a/test/core/test_tasks.py
+++ b/test/core/test_tasks.py
@@ -82,6 +82,14 @@ class RecordTestRunStatusTest(CommonTestCase):
         self.assertEqual(1, Status.objects.filter(suite=None).count())
         self.assertEqual(1, ProjectStatus.objects.filter(build=self.testrun.build).count())
 
+    @patch('squad.core.tasks.notify_project_status')
+    def test_sends_notification(self, notify_project_status):
+        ParseTestRunData()(self.testrun)
+        RecordTestRunStatus()(self.testrun)
+
+        status = ProjectStatus.objects.last()
+        notify_project_status.delay.assert_called_with(status.id)
+
 
 class ProcessTestRunTest(CommonTestCase):
 

--- a/test/core/test_tasks_notification.py
+++ b/test/core/test_tasks_notification.py
@@ -3,7 +3,7 @@ from django.test import TestCase
 
 
 from squad.core.models import Group
-from squad.core.tasks.notification import notify_project, notify_all_projects
+from squad.core.tasks.notification import notify_project
 
 
 class TestNotificationTasks(TestCase):
@@ -17,11 +17,3 @@ class TestNotificationTasks(TestCase):
     def test_notify_project(self, send_notification):
         notify_project.apply(args=[self.project1.id])
         send_notification.assert_called_with(self.project1)
-
-    @patch("squad.core.tasks.notification.notify_project.delay")
-    def test_notify_all_projects(self, notify_project):
-        notify_all_projects.apply()
-        notify_project.assert_has_calls([
-            call(self.project1.id),
-            call(self.project2.id),
-        ])

--- a/test/core/test_tasks_notification.py
+++ b/test/core/test_tasks_notification.py
@@ -1,9 +1,10 @@
 from unittest.mock import patch, MagicMock, call
 from django.test import TestCase
+from django.utils import timezone
 
 
-from squad.core.models import Group
-from squad.core.tasks.notification import notify_project
+from squad.core.models import Group, ProjectStatus
+from squad.core.tasks.notification import notify_project, notify_project_status
 
 
 class TestNotificationTasks(TestCase):
@@ -17,3 +18,14 @@ class TestNotificationTasks(TestCase):
     def test_notify_project(self, send_notification):
         notify_project.apply(args=[self.project1.id])
         send_notification.assert_called_with(self.project1)
+
+    @patch("squad.core.tasks.notification.send_status_notification")
+    def test_notify_project_status(self, send_status_notification):
+        build = self.project1.builds.create(datetime=timezone.now())
+        environment = self.project1.environments.create(slug='env')
+        build.test_runs.create(environment=environment)
+
+        status = ProjectStatus.create_or_update(build)
+        notify_project_status(status.id)
+
+        send_status_notification.assert_called_with(status)


### PR DESCRIPTION
These changes make notifications be sent as soon as there is enough data,
instead of relying on scheduled celery recurring task.