### PR TITLE
core/notifications: retry if ProjectStatus id does not exist (yet)

### DIFF
--- a/squad/core/tasks/notification.py
+++ b/squad/core/tasks/notification.py
@@ -1,3 +1,4 @@
+from django.db.models import Max
 from squad.celery import app as celery
 from squad.core.models import Project, ProjectStatus
 from squad.core.notification import send_notification, send_status_notification
@@ -12,7 +13,14 @@ def notify_project(project_id):
     send_notification(project)
 
 
-@celery.task
-def notify_project_status(status_id):
-    status = ProjectStatus.objects.get(pk=status_id)
-    send_status_notification(status)
+@celery.task(bind=True)
+def notify_project_status(self, status_id):
+    try:
+        status = ProjectStatus.objects.get(pk=status_id)
+        send_status_notification(status)
+    except ProjectStatus.DoesNotExist as not_found:
+        last_id = ProjectStatus.objects.all().aggregate(Max('id'))['id__max']
+        if not last_id or status_id > last_id:
+            # our id is larger than the latest, the object was probably created
+            # by another process but not commited to the database yet.
+            raise self.retry(exc=not_found, countdown=30)  # retry in 30s

--- a/test/core/test_tasks_notification.py
+++ b/test/core/test_tasks_notification.py
@@ -1,4 +1,5 @@
 from unittest.mock import patch, MagicMock, call
+from celery.exceptions import Retry
 from django.test import TestCase
 from django.utils import timezone
 
@@ -29,3 +30,10 @@ class TestNotificationTasks(TestCase):
         notify_project_status(status.id)
 
         send_status_notification.assert_called_with(status)
+
+    @patch('squad.core.tasks.notification.notify_project_status.retry')
+    def test_retry_if_project_status_does_not_exist(self, retry):
+        retry.return_value = Retry()
+
+        with self.assertRaises(Retry):
+            notify_project_status(666)


### PR DESCRIPTION
In some cases there could be a timing issue with notifications: a
ProjectStatus is created and a notification is triggered. The
notification request is handled by a worker process before the process
that requested the notification was able to commit the changes to the
database, and the new object is not yet visible to the worker process.

This assumes that id is autoincremented, otherwise a request for a
really unexisting ProjectStatus object would stay in a infinite loop.