### PR TITLE
core: fix update of ProjectStatus objects

### DIFF
--- a/squad/core/models.py
+++ b/squad/core/models.py
@@ -481,6 +481,8 @@ class ProjectStatus(models.Model, TestSummaryBase):
             status.metrics_summary = metrics_summary.value
             status.last_updated = now
             status.finished = build.finished
+            status.build = build
+            status.save()
         return status
 
     def __str__(self):

--- a/squad/core/tasks/__init__.py
+++ b/squad/core/tasks/__init__.py
@@ -226,10 +226,10 @@ class RecordTestRunStatus(object):
         testrun.status_recorded = True
         testrun.save()
 
-        status = ProjectStatus.create_or_update(testrun.build)
-        if status.finished:
+        projectstatus = ProjectStatus.create_or_update(testrun.build)
+        if projectstatus.finished:
             try:
-                notify_project_status.delay(status.id)
+                notify_project_status.delay(projectstatus.id)
             except OSError as e:
                 # can't request background task for some reason; log the error
                 # and continue.

--- a/test/core/test_project_status.py
+++ b/test/core/test_project_status.py
@@ -102,7 +102,11 @@ class ProjectStatusTest(TestCase):
         self.assertEqual(2, status.tests_pass)
         self.assertEqual(1, status.tests_fail)
         self.assertEqual(1, status.tests_skip)
+        self.assertEqual(status.tests_pass, build.status.tests_pass)
+        self.assertEqual(status.tests_fail, build.status.tests_fail)
+        self.assertEqual(status.tests_skip, build.status.tests_skip)
         self.assertAlmostEqual(5.0, status.metrics_summary)
+        self.assertEqual(status.metrics_summary, build.status.metrics_summary)
 
     def test_populates_last_updated(self):
         build = self.create_build('1', datetime=h(10))


### PR DESCRIPTION
When new results arrive, ProjectStatus object is updated and saved to
database. So all updates are preserved. Before this patch all updates
were lost because ProjectStatus wasn't saved to database.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>