### PR TITLE
frontend: remove _.castArray from JS code

### DIFF
--- a/squad/frontend/static/squad/charts.js
+++ b/squad/frontend/static/squad/charts.js
@@ -223,7 +223,8 @@ function ChartsController($scope, $http, $location) {
             environment.line_color = colors[i][0]
             environment.fill_color = colors[i][1]
         })
-        _.each(_.castArray(params.environment), function(param) {
+        /*_.each(_.castArray(params.environment), function(param) {*/
+        _.each(params.environment, function(param) {
             var env = _.find($scope.environments, function(env)  { return env.name == param})
             if (env) {
                 env.selected = true
@@ -237,7 +238,8 @@ function ChartsController($scope, $http, $location) {
             }
         })
         $scope.selectedMetrics = _.filter($scope.metrics, function(metric) {
-            var found = _.find(_.castArray(params.metric), function(param) { return param == metric.name })
+            /*var found = _.find(_.castArray(params.metric), function(param) { return param == metric.name })*/
+            var found = _.find(params.metric, function(param) { return param == metric.name })
             return found
         })
 


### PR DESCRIPTION
_.castArray is only available from lodash 4.4.0. We're using 2.4.1. This
is a temporary solution to allow the charts to work. It might cause some
side effects.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>