### PR TITLE
ci: lava: fail gracefully when LAVA replies with error

### DIFF
--- a/squad/ci/backend/lava.py
+++ b/squad/ci/backend/lava.py
@@ -42,8 +42,16 @@ class Backend(BaseBackend):
         data = self.__get_job_details__(test_job.job_id)
 
         if data['status'] in self.complete_statuses:
-            yamldata = self.__get_testjob_results_yaml__(test_job.job_id)
-            data['results'] = yaml.load(yamldata)
+            try:
+                yamldata = self.__get_testjob_results_yaml__(test_job.job_id)
+                data['results'] = yaml.load(yamldata)
+            except xmlrpclib.Error as e:
+                self.log_error("Error during result fetching")
+                self.log_error(str(e) + "\n" + traceback.format_exc())
+                test_job.failure = str(e) + "\n" + traceback.format_exc()
+                test_job.save()
+                send_admin_email.delay(test_job.pk)
+                return None
 
             # fetch logs
             logs = ""


### PR DESCRIPTION
LAVA sometimes replies with XML-RPC error. In this case there is no
trace that something went wrong. The only indication is that some
results are missing in the frontend. This patch addresses the issue by
failing gracefully, saving error log to the TestJob.failure and sending
admin email notification.

Fixes #97

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>