### PR TITLE
ci: lava: introduce artificial delay in fetching results

### DIFF
--- a/squad/ci/backend/lava.py
+++ b/squad/ci/backend/lava.py
@@ -247,4 +247,6 @@ class Backend(BaseBackend):
                     len(db_test_job_list) == 1:
                 job = db_test_job_list[0]
                 self.log_info("scheduling fetch for job %s" % job.job_id)
-                fetch.delay(job.id)
+                # introduce 2 min delay to allow LAVA for storing all results
+                # this workaround should be removed once LAVA issue is fixed
+                fetch.apply_async(args=[job.id], countdown=120)

--- a/test/ci/backend/test_lava.py
+++ b/test/ci/backend/test_lava.py
@@ -324,7 +324,11 @@ class LavaTest(TestCase):
         )
 
         lava.receive_event('foo.com.testjob', {"job": '123', 'status': 'Complete'})
-        fetch.delay.assert_called_with(testjob.id)
+        # this is workaround to LAVA issues
+        # it should be removed when LAVA bug is fixed
+        fetch.apply_async.assert_called_with(args=[testjob.id], countdown=120)
+        # proper solution below
+        # fetch.fetch.assert_called_with(testjob.id)
 
     def test_receive_event_no_testjob(self):
         backend = MagicMock()


### PR DESCRIPTION
In order to work around the (possible) LAVA issue with saving results,
artificial delay in LAVA backend is introduced. It should give LAVA
enough time to save results in case there are plenty of them. This patch
should be reverted once LAVA problem is fixed or other source of this
issue is identified

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>