### PR TITLE
ci: lava: add artificial boot test result

### DIFF
--- a/squad/ci/backend/lava.py
+++ b/squad/ci/backend/lava.py
@@ -217,6 +217,18 @@ class Backend(BaseBackend):
                         res_value = result['measurement']
                         metrics.update({res_name: float(res_value)})
                 else:
+                    # add artificial 'boot' test result for each test job
+                    if result['name'] == 'auto-login-action':
+                        # by default the boot test is named after the device_type
+                        res_name = "boot/%s" % (definition['device_type'])
+                        res_time_name = "boot/time-%s" % (definition['device_type'])
+                        if 'testsuite' in job_metadata.keys():
+                            # If 'testsuite' metadata key is present in the job
+                            # it's appended to the test name. This way regressions can
+                            # be found with more granularity
+                            res_name = "%s-%s" % (res_name, job_metadata['testsuite'])
+                        results.update({res_name: result['result']})
+                        metrics.update({res_time_name: float(result['measurement'])})
                     if result['name'] == 'job' and result['result'] == 'fail':
                         metadata = result['metadata']
                         test_job.failure = str(metadata)

--- a/test/ci/backend/test_lava.py
+++ b/test/ci/backend/test_lava.py
@@ -13,6 +13,23 @@ from squad.core.models import Group, Project
 
 TEST_RESULTS = [
     {'duration': '',
+     'id': '5089687',
+     'job': '22505',
+     'level': 'None',
+     'logged': '2017-09-05 07:53:07.040871+00:00',
+     'measurement': '29.7200000000',
+     'metadata': {'case': 'auto-login-action',
+                  'definition': 'lava',
+                  'duration': '29.72',
+                  'level': '4.5',
+                  'result': 'pass'},
+     'name': 'auto-login-action',
+     'result': 'pass',
+     'suite': 'lava',
+     'timeout': '',
+     'unit': 'seconds',
+     'url': '/results/testcase/5089687'},
+    {'duration': '',
      'job': '1234',
      'level': 'None',
      'logged': '2017-02-15 11:31:21.973616+00:00',
@@ -77,7 +94,8 @@ JOB_METADATA = {
 
 JOB_DEFINITION = {
     'job_name': 'job_foo',
-    'metadata': JOB_METADATA
+    'metadata': JOB_METADATA,
+    'device_type': 'device_foo'
 }
 
 JOB_DETAILS = {
@@ -191,8 +209,8 @@ class LavaTest(TestCase):
             backend=self.backend)
         status, completed, metadata, results, metrics, logs = lava.fetch(testjob)
 
-        self.assertEqual(len(results), 1)
-        self.assertEqual(len(metrics), 1)
+        self.assertEqual(len(results), 2)
+        self.assertEqual(len(metrics), 2)
         self.assertEqual(10, metrics['DefinitionFoo/case_foo'])
 
     @patch("squad.ci.backend.lava.Backend.__get_job_logs__", return_value="abc")


### PR DESCRIPTION
If 'auto-login-action' is used, it can be associated with boot action.
This way lava backend can identify information about
successful/unsuccessful device boot. auto-login-action duration is
considered as overall boot time.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>