### PR TITLE
core/Build: provide test suites executed by environment

### DIFF
--- a/squad/core/models.py
+++ b/squad/core/models.py
@@ -199,6 +199,22 @@ class Build(models.Model):
     def test_runs_incomplete(self):
         return sum([1 for t in self.test_runs.all() if not t.completed])
 
+    @property
+    def test_suites_by_environment(self):
+        test_runs = self.test_runs.prefetch_related(
+            'tests',
+            'tests__suite',
+            'environment',
+        )
+        result = OrderedDict()
+        envlist = set([t.environment for t in test_runs])
+        for env in sorted(envlist, key=lambda env: env.slug):
+            result[env] = set()
+        for tr in test_runs:
+            for t in tr.tests.all():
+                result[tr.environment].add(t.suite)
+        return result
+
 
 def dict_intersection(d1, d2):
     return {k: d1[k] for k in d1 if (k in d2 and d2[k] == d1[k])}

--- a/test/core/test_build.py
+++ b/test/core/test_build.py
@@ -109,3 +109,21 @@ class BuildTest(TestCase):
     def test_get_or_create_with_version_twice(self):
         self.project.builds.get_or_create(version='1.0-rc1')
         self.project.builds.get_or_create(version='1.0-rc1')
+
+    def test_test_suites_by_environment(self):
+        build = Build.objects.create(project=self.project, version='1.1')
+        env1 = self.project.environments.create(slug='env1')
+        env2 = self.project.environments.create(slug='env2')
+        foo = self.project.suites.create(slug="foo")
+        bar = self.project.suites.create(slug="bar")
+        testrun1 = build.test_runs.create(environment=env1)
+        testrun2 = build.test_runs.create(environment=env2)
+        testrun1.tests.create(suite=foo, name='test1', result=True)
+        testrun1.tests.create(suite=bar, name='test1', result=False)
+        testrun2.tests.create(suite=foo, name='test1', result=True)
+
+        test_suites = build.test_suites_by_environment
+
+        self.assertEqual([env1, env2], list(test_suites.keys()))
+        self.assertEqual(["foo", "bar"], [s.slug for s in test_suites[env1]])
+        self.assertEqual(["foo"], [s.slug for s in test_suites[env2]])


### PR DESCRIPTION
This can be used e.g. in custom email report templates.