### PR TITLE
core: modify test_suites_by_environment to provide test count

### DIFF
--- a/squad/core/models.py
+++ b/squad/core/models.py
@@ -232,12 +232,20 @@ class Build(models.Model):
         result = OrderedDict()
         envlist = set([t.environment for t in test_runs])
         for env in sorted(envlist, key=lambda env: env.slug):
-            result[env] = set()
+            result[env] = dict()
         for tr in test_runs:
             for t in tr.tests.all():
-                result[tr.environment].add(t.suite)
+                if t.suite in result[tr.environment].keys():
+                    result[tr.environment][t.suite][t.status] += 1
+                else:
+                    result[tr.environment].setdefault(t.suite, {'fail': 0, 'pass': 0, 'skip': 0})
+                    result[tr.environment][t.suite][t.status] += 1
         for env in result.keys():
-            result[env] = sorted(result[env], key=lambda suite: suite.slug)
+            # there should only be one key in the most nested dict
+            result[env] = sorted(
+                result[env].items(),
+                key=lambda suite_dict: suite_dict[0].slug)
+
         return result
 
 

--- a/test/core/test_build.py
+++ b/test/core/test_build.py
@@ -139,8 +139,8 @@ class BuildTest(TestCase):
         test_suites = build.test_suites_by_environment
 
         self.assertEqual([env1, env2], list(test_suites.keys()))
-        self.assertEqual(["bar", "foo"], [s.slug for s in test_suites[env1]])
-        self.assertEqual(["foo"], [s.slug for s in test_suites[env2]])
+        self.assertEqual(["bar", "foo"], [s[0].slug for s in test_suites[env1]])
+        self.assertEqual(["foo"], [s[0].slug for s in test_suites[env2]])
 
     def test_important_metadata_default(self):
         project = Project()


### PR DESCRIPTION
Build method test_suites_by_environment will not only provide sorted
list of environments for each build but also test counts
(pass,fail,skip) for each testsuite in each environment

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>