### PR TITLE
frontend: optimize build listings

### DIFF
--- a/squad/core/models.py
+++ b/squad/core/models.py
@@ -211,18 +211,6 @@ class Build(models.Model):
         return True
 
     @property
-    def test_runs_total(self):
-        return len(self.test_runs.all())
-
-    @property
-    def test_runs_completed(self):
-        return sum([1 for t in self.test_runs.all() if t.completed])
-
-    @property
-    def test_runs_incomplete(self):
-        return sum([1 for t in self.test_runs.all() if not t.completed])
-
-    @property
     def test_suites_by_environment(self):
         test_runs = self.test_runs.prefetch_related(
             'tests',

--- a/squad/frontend/templates/squad/_builds_table.html
+++ b/squad/frontend/templates/squad/_builds_table.html
@@ -1,10 +1,10 @@
 {% load humanize %}
 {% load squad %}
 <div class='highlight-row'>
-{% for build in builds %}
+{% for status in statuses %}
+{% with build=status.build %}
 <a href="{% build_url build %}">
 <div class="row build">
-    {% with status=build.status %}
     <div class="col-md-2 col-sm-2">
         <strong>
             {{build.version}}
@@ -13,12 +13,12 @@
     <div class='col-md-3 col-sm-3'>
         <div title='Test run status'>
             <i class='fa fa-cog'></i>
-            <span class="badge" data-toggle="tooltip" data-placement="top" title="Total">{{build.test_runs_total}} test runs</span>
-            {% if build.test_runs_completed > 0 %}
-            <span class="badge alert-success" data-toggle="tooltip" data-placement="top" title="Completed">{{build.test_runs_completed}} completed</span>
+            <span class="badge" data-toggle="tooltip" data-placement="top" title="Total">{{status.test_runs_total}} test runs</span>
+            {% if status.test_runs_completed > 0 %}
+            <span class="badge alert-success" data-toggle="tooltip" data-placement="top" title="Completed">{{status.test_runs_completed}} completed</span>
             {% endif %}
-            {% if build.test_runs_incomplete > 0 %}
-            <span class="badge alert-danger" data-toggle="tooltip" data-placement="top" title="Incomplete">{{build.test_runs_incomplete}} incomplete</span>
+            {% if status.test_runs_incomplete > 0 %}
+            <span class="badge alert-danger" data-toggle="tooltip" data-placement="top" title="Incomplete">{{status.test_runs_incomplete}} incomplete</span>
             {% endif %}
         </div>
     </div>
@@ -58,8 +58,8 @@
         </div>
         {% endif %}
     </div>
-    {% endwith %}
 </div>
 </a>
+{% endwith %}
 {% endfor %}
 </div>


### PR DESCRIPTION
The build listings were way too expensive, consuming too much memory and
taking too long to run. This change drastically reduces both the number
of database queries and the amount of RAM needed to render the pages.