### PR TITLE
frontend: return 404 on non-existing Build, TestRun, and Attachment

### DIFF
--- a/squad/core/models.py
+++ b/squad/core/models.py
@@ -211,18 +211,6 @@ class Build(models.Model):
         return True
 
     @property
-    def test_runs_total(self):
-        return len(self.test_runs.all())
-
-    @property
-    def test_runs_completed(self):
-        return sum([1 for t in self.test_runs.all() if t.completed])
-
-    @property
-    def test_runs_incomplete(self):
-        return sum([1 for t in self.test_runs.all() if not t.completed])
-
-    @property
     def test_suites_by_environment(self):
         test_runs = self.test_runs.prefetch_related(
             'tests',

--- a/squad/frontend/templates/squad/_builds_table.html
+++ b/squad/frontend/templates/squad/_builds_table.html
@@ -1,10 +1,10 @@
 {% load humanize %}
 {% load squad %}
 <div class='highlight-row'>
-{% for build in builds %}
+{% for status in statuses %}
+{% with build=status.build %}
 <a href="{% build_url build %}">
 <div class="row build">
-    {% with status=build.status %}
     <div class="col-md-2 col-sm-2">
         <strong>
             {{build.version}}
@@ -13,12 +13,12 @@
     <div class='col-md-3 col-sm-3'>
         <div title='Test run status'>
             <i class='fa fa-cog'></i>
-            <span class="badge" data-toggle="tooltip" data-placement="top" title="Total">{{build.test_runs_total}} test runs</span>
-            {% if build.test_runs_completed > 0 %}
-            <span class="badge alert-success" data-toggle="tooltip" data-placement="top" title="Completed">{{build.test_runs_completed}} completed</span>
+            <span class="badge" data-toggle="tooltip" data-placement="top" title="Total">{{status.test_runs_total}} test runs</span>
+            {% if status.test_runs_completed > 0 %}
+            <span class="badge alert-success" data-toggle="tooltip" data-placement="top" title="Completed">{{status.test_runs_completed}} completed</span>
             {% endif %}
-            {% if build.test_runs_incomplete > 0 %}
-            <span class="badge alert-danger" data-toggle="tooltip" data-placement="top" title="Incomplete">{{build.test_runs_incomplete}} incomplete</span>
+            {% if status.test_runs_incomplete > 0 %}
+            <span class="badge alert-danger" data-toggle="tooltip" data-placement="top" title="Incomplete">{{status.test_runs_incomplete}} incomplete</span>
             {% endif %}
         </div>
     </div>
@@ -58,8 +58,8 @@
         </div>
         {% endif %}
     </div>
-    {% endwith %}
 </div>
 </a>
+{% endwith %}
 {% endfor %}
 </div>

--- a/squad/frontend/views.py
+++ b/squad/frontend/views.py
@@ -87,7 +87,15 @@ def builds(request, group_slug, project_slug):
 def build(request, group_slug, project_slug, version):
     group = Group.objects.get(slug=group_slug)
     project = group.projects.get(slug=project_slug)
-    build = project.builds.prefetch_related('test_runs', 'test_runs__status', 'test_runs__status__suite', 'test_runs__status__test_run__environment').get(version=version)
+    build = get_object_or_404(
+        project.builds.prefetch_related(
+            'test_runs',
+            'test_runs__status',
+            'test_runs__status__suite',
+            'test_runs__status__test_run__environment'
+        ),
+        version=version
+    )
 
     context = {
         'project': project,
@@ -103,7 +111,7 @@ def test_run(request, group_slug, project_slug, build_version, job_id):
     group = Group.objects.get(slug=group_slug)
     project = group.projects.get(slug=project_slug)
     build = project.builds.get(version=build_version)
-    test_run = build.test_runs.get(job_id=job_id)
+    test_run = get_object_or_404(build.test_runs, job_id=job_id)
 
     status = test_run.status.by_suite()
 
@@ -142,7 +150,7 @@ def test_run_log(request, group_slug, project_slug, build_version, job_id):
     group = Group.objects.get(slug=group_slug)
     project = group.projects.get(slug=project_slug)
     build = project.builds.get(version=build_version)
-    test_run = build.test_runs.get(job_id=job_id)
+    test_run = get_object_or_404(build.test_runs, job_id=job_id)
 
     if not test_run.log_file:
         raise Http404("No log file available for this test run")
@@ -155,7 +163,7 @@ def test_run_tests(request, group_slug, project_slug, build_version, job_id):
     group = Group.objects.get(slug=group_slug)
     project = group.projects.get(slug=project_slug)
     build = project.builds.get(version=build_version)
-    test_run = build.test_runs.get(job_id=job_id)
+    test_run = get_object_or_404(build.test_runs, job_id=job_id)
 
     filename = '%s_%s_%s_%s_tests.json' % (group.slug, project.slug, build.version, test_run.job_id)
     return __download__(filename, test_run.tests_file)
@@ -166,7 +174,7 @@ def test_run_metrics(request, group_slug, project_slug, build_version, job_id):
     group = Group.objects.get(slug=group_slug)
     project = group.projects.get(slug=project_slug)
     build = project.builds.get(version=build_version)
-    test_run = build.test_runs.get(job_id=job_id)
+    test_run = get_object_or_404(build.test_runs, job_id=job_id)
 
     filename = '%s_%s_%s_%s_metrics.json' % (group.slug, project.slug, build.version, test_run.job_id)
     return __download__(filename, test_run.metrics_file)
@@ -177,7 +185,7 @@ def test_run_metadata(request, group_slug, project_slug, build_version, job_id):
     group = Group.objects.get(slug=group_slug)
     project = group.projects.get(slug=project_slug)
     build = project.builds.get(version=build_version)
-    test_run = build.test_runs.get(job_id=job_id)
+    test_run = get_object_or_404(build.test_runs, job_id=job_id)
 
     filename = '%s_%s_%s_%s_metadata.json' % (group.slug, project.slug, build.version, test_run.job_id)
     return __download__(filename, test_run.metadata_file)
@@ -188,9 +196,9 @@ def attachment(request, group_slug, project_slug, build_version, job_id, fname):
     group = Group.objects.get(slug=group_slug)
     project = group.projects.get(slug=project_slug)
     build = project.builds.get(version=build_version)
-    test_run = build.test_runs.get(job_id=job_id)
+    test_run = get_object_or_404(build.test_runs, job_id=job_id)
 
-    attachment = test_run.attachments.get(filename=fname)
+    attachment = get_object_or_404(test_run.attachments, filename=fname)
     return __download__(attachment.filename, attachment.data)
 
 

--- a/test/frontend/test_basics.py
+++ b/test/frontend/test_basics.py
@@ -44,12 +44,21 @@ class FrontendTest(TestCase):
     def test_project(self):
         self.hit('/mygroup/myproject/')
 
+    def test_project_404(self):
+        self.hit('/mygroup/unexistingproject/', 404)
+
     def test_project_no_build(self):
         self.project.builds.all().delete()
         self.hit('/mygroup/myproject/')
 
     def test_builds(self):
         self.hit('/mygroup/myproject/builds/')
+
+    def test_build_404(self):
+        self.hit('/mygroup/myproject/build/999/', 404)
+
+    def test_test_run_404(self):
+        self.hit('/mygroup/myproject/build/1.0/testrun/999/', 404)
 
     def test_attachment(self):
         data = bytes('text file', 'utf-8')


### PR DESCRIPTION
This avoids unecessary noise with exceptions being generated for
unexisting objects.