### PR TITLE
core/notification: include only important metadata in emails

### DIFF
--- a/squad/core/notification.py
+++ b/squad/core/notification.py
@@ -52,6 +52,10 @@ class Notification(object):
             return dict()
 
     @property
+    def important_metadata(self):
+        return self.build.important_metadata
+
+    @property
     def summary(self):
         return self.build.test_summary
 
@@ -65,6 +69,7 @@ class Notification(object):
         subject_data = {
             'project': self.project,
             'metadata': self.metadata,
+            'important_metadata': self.important_metadata,
             'tests_total': summary.tests_total,
             'tests_fail': summary.tests_fail,
             'tests_pass': summary.tests_pass,

--- a/squad/core/templates/squad/notification/diff.html
+++ b/squad/core/templates/squad/notification/diff.html
@@ -288,8 +288,8 @@ td.fail {
     <div class='row'><div class='col-3 key'>Skipped: </div>  <div class='col-9'>{{summary.tests_skip}}  </div></div>
     <div class='row'><div class='col-3 key'>Build:   </div>  <div class='col-9'>{{build.version}}       </div></div>
     <div class='row'><div class='col-12 key'> <a href="{{settings.BASE_URL}}/{{build.project}}/build/{{build.version}}">See details</a> </div></div>
-    {% if metadata %}
-      {% for key, value in metadata.items %}
+    {% if important_metadata %}
+    {% for key, value in important_metadata.items %}
       <div class='row'>
         <div class='col-3 key'>{{key}}</div>
         <div class='col-9'>{{value|metadata_value|urlize}}</div>

--- a/squad/core/templates/squad/notification/diff.txt
+++ b/squad/core/templates/squad/notification/diff.txt
@@ -6,7 +6,7 @@ Skipped: {{summary.tests_skip}}
 Build:   {{build.version}}
 Details: {{settings.BASE_URL}}/{{build.project}}/build/{{build.version}}
 
-{% for key, value in metadata.items %}{{key}}: {{value|metadata_txt:key}}
+{% for key, value in important_metadata.items %}{{key}}: {{value|metadata_txt:key}}
 {% endfor %}
 
 Regressions{%if previous_build %} (compared to build {{previous_build.version}}){% endif %}


### PR DESCRIPTION
The full metadata is still available for use in custom templates, for
example.