### PR TITLE
notifications: add missing important metadata dict

### DIFF
--- a/squad/core/notification.py
+++ b/squad/core/notification.py
@@ -91,6 +91,7 @@ class Notification(object):
         context = {
             'build': self.build,
             'metadata': self.metadata,
+            'important_metadata': self.important_metadata,
             'previous_build': self.previous_build,
             'regressions': self.comparison.regressions,
             'regressions_grouped_by_suite': self.comparison.regressions_grouped_by_suite,


### PR DESCRIPTION
important_metadata dictionary is added to the notification context.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>