### PR TITLE
frontend: floating table headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 /squad/frontend/static/lodash.js
 /squad/frontend/static/chartjs
 /squad/frontend/static/jquery.js
+/squad/frontend/static/floatThread
 /squad/frontend/static/download.status
 /static
 /.tests

--- a/squad/frontend/static/download.conf
+++ b/squad/frontend/static/download.conf
@@ -5,3 +5,4 @@ chartjs/Chart.bundle.js   https://github.com/chartjs/Chart.js/releases/download/
 font-awesome              http://http.debian.net/debian/pool/main/f/fonts-font-awesome/fonts-font-awesome_4.7.0~dfsg.orig.tar.gz a59bc27ace9906ae09cc8a49aac3b70899e0ae70
 lodash.js                 https://raw.githubusercontent.com/lodash/lodash/4.17.4/dist/lodash.js                 d8e7e155b43e7edcabc46682a809836a68444b01
 jquery.js                 https://code.jquery.com/jquery-3.2.1.js                                               fd81582bf1b15e6747472df880ca822c362a97d1
+floatThread               https://github.com/mkoryak/floatThead/archive/2.0.3.zip                               d7112698ed5bf14f953fdef6252fdd9950af90bf

--- a/squad/frontend/static/main.css
+++ b/squad/frontend/static/main.css
@@ -94,6 +94,10 @@ table.test-results th:hover {
   background-color: rgb(221,221,221);
 }
 
+thead {
+  background: white
+}
+
 body {
   background: #f9f9f9;
 }

--- a/squad/frontend/static/squad/table.js
+++ b/squad/frontend/static/squad/table.js
@@ -1,0 +1,3 @@
+$('table').floatThead({
+    position: 'auto'
+});

--- a/squad/frontend/templates/squad/base.html
+++ b/squad/frontend/templates/squad/base.html
@@ -77,6 +77,8 @@
     <script type="text/javascript" src="{% static "angularjs/angular.js" %}"></script>
     <script type="text/javascript" src="{% static "lodash.js" %}"></script>
     <script type="text/javascript" src="{% static "chartjs/Chart.bundle.js" %}"></script>
+    <script type="text/javascript" src="{% static "floatThread/dist/jquery.floatThead.js" %}"></script>
+    <script type="text/javascript" src='{% static "squad/table.js" %}'></script>
     {% block javascript %}{% endblock %}
 
   </body>

--- a/squad/frontend/templates/squad/test_history.html
+++ b/squad/frontend/templates/squad/test_history.html
@@ -11,13 +11,13 @@
 
   <table class='table table-bordered test-results'>
 
-    <tr>
+    <thead>
       <th>Build</th>
       <th>Date</th>
       {% for environment in history.environments %}
       <th>{{environment.slug}}</th>
       {% endfor %}
-    </tr>
+    </thead>
 
     {% for build, results in history.results.items %}
     <tr>

--- a/squad/frontend/templates/squad/tests.html
+++ b/squad/frontend/templates/squad/tests.html
@@ -17,12 +17,12 @@
         </form>
       </td>
     </tr>
-    <tr>
+    <thead>
       <th>Test</th>
       {% for env in results.environments %}
       <th>{{env}}</th>
       {% endfor %}
-    </tr>
+    </thead>
   {% if results %}
   {% for test in results.failures %}
   <tr id='test-{{test.name|slugify}}' ng-show="match('test-{{test.name|slugify}}')">


### PR DESCRIPTION
Table headers are floating. It's easier to see the environment if the
list of results is long.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>