### PR TITLE
ci: Reimplement poll as a series of fetch operations

### DIFF
--- a/squad/ci/models.py
+++ b/squad/ci/models.py
@@ -30,17 +30,14 @@ class Backend(models.Model):
 
     def poll(self):
         for test_job in self.test_jobs.filter(submitted=True, fetched=False):
-            self.fetch_on_poll(test_job)
-
-    def fetch_on_poll(self, test_job):
-        last = test_job.last_fetch_attempt
-        if last:
-            now = timezone.now()
-            next_poll = last + relativedelta(minutes=self.poll_interval)
-            if now > next_poll:
-                self.fetch(test_job)
-        else:
-            self.fetch(test_job)
+            last = test_job.last_fetch_attempt
+            if last:
+                now = timezone.now()
+                next_poll = last + relativedelta(minutes=self.poll_interval)
+                if now > next_poll:
+                    yield test_job
+            else:
+                yield test_job
 
     def fetch(self, test_job):
         if not test_job.fetched:

--- a/squad/ci/tasks.py
+++ b/squad/ci/tasks.py
@@ -17,7 +17,8 @@ def poll(backend_id=None):
     else:
         backends = Backend.objects.all()
     for backend in backends:
-        backend.poll()
+        for test_job in backend.poll():
+            fetch.delay(test_job.id)
 
 
 @celery.task

--- a/test/ci/test_tasks.py
+++ b/test/ci/test_tasks.py
@@ -32,6 +32,15 @@ class PollTest(TestCase):
         poll.apply(args=[b1.id])
         poll_method.assert_called_once()
 
+    @patch("squad.ci.tasks.fetch")
+    def test_poll_calls_fetch_on_all_test_jobs(self, fetch_method):
+        group = core_models.Group.objects.create(slug='testgroup')
+        project = group.projects.create(slug='testproject')
+        backend = models.Backend.objects.create(name='b1')
+        testjob = backend.test_jobs.create(target=project, submitted=True)
+        poll.apply()
+        fetch_method.delay.assert_called_with(testjob.id)
+
 
 class FetchTest(TestCase):
 


### PR DESCRIPTION
The poll() task was implemented in a way that Backend.poll() would
directly call fetch() on each test job that needs to be polled. However,
poll() has no exception handling, and therefore an issue with one of the
jobs would cause the entire poll operation to be aborted.

The fetch() task, on the other hand, already handles exceptions, and
does the right thing depending on whether the issue is a temporary or a
permanent one.

Convert Backend.poll() into a generator function that will yield all the
test jobs that should be fetched (instead of fetching them directly).
The actual fetching is then triggered in the background by the poll
task, so that each test job will have exceptions handled individually,
and an issue with one test job will not affect the rest of the test jobs
that are being polled.