### PR TITLE
Fetching issues

### DIFF
--- a/squad/ci/backend/lava.py
+++ b/squad/ci/backend/lava.py
@@ -226,7 +226,7 @@ class Backend(BaseBackend):
         else:
             for result in data['results']:
                 if result['suite'] != 'lava':
-                    suite = result['suite'].split("_", 1)[1]
+                    suite = result['suite'].split("_", 1)[-1]
                     res_name = "%s/%s" % (suite, result['name'])
                     # YAML from LAVA has all values serialized to strings
                     if result['measurement'] == 'None':

--- a/squad/ci/backend/lava.py
+++ b/squad/ci/backend/lava.py
@@ -184,7 +184,7 @@ class Backend(BaseBackend):
 
     def __get_job_logs__(self, job_id):
         log_data = self.proxy.scheduler.job_output(job_id).data.decode('utf-8')
-        log_data_yaml = yaml.load(log_data)
+        log_data_yaml = yaml.load(log_data, Loader=yaml.CLoader)
         returned_log = ""
         for log_entry in log_data_yaml:
             if log_entry['lvl'] == 'target':

--- a/squad/ci/backend/lava.py
+++ b/squad/ci/backend/lava.py
@@ -50,7 +50,7 @@ class Backend(BaseBackend):
 
             if data['status'] in self.complete_statuses:
                 yamldata = self.__get_testjob_results_yaml__(test_job.job_id)
-                data['results'] = yaml.load(yamldata)
+                data['results'] = yaml.load(yamldata, Loader=yaml.CLoader)
 
                 # fetch logs
                 logs = ""

--- a/squad/core/admin.py
+++ b/squad/core/admin.py
@@ -84,8 +84,8 @@ resend_notification.short_description = "Re-send notification"
 class ProjectStatusAdmin(admin.ModelAdmin):
     model = models.ProjectStatus
     ordering = ['-build__datetime']
-    list_display = ['__str__', 'approved', 'notified']
-    list_filter = ['build__project', 'approved', 'notified']
+    list_display = ['__str__', 'finished', 'approved', 'notified']
+    list_filter = ['build__project', 'finished', 'approved', 'notified']
     actions = [approve_project_status, resend_notification]
 
     def get_queryset(self, request):


### PR DESCRIPTION
This PR fixes two issues that we are having in production:

- parsing the structured logs from LAVA is very slow when the the log is large
  enough
- we were getting IndexError due to the assumption that result['suite'] from
  LAVA always contains '_' characters.
 
I'm also including a small change to the ProjectStatus Admin to make it easier
to find ProjectStatus that should have been notified, but weren't.