### PR TITLE
Fix notifications for CI-based projects

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
 web: ./manage.py runserver
 worker: ./manage.py celery worker --loglevel INFO
-scheduler: ./manage.py celery beat --pidfile=''
+scheduler: ./manage.py celery beat --loglevel WARN --pidfile=''
 listener: ./manage.py listen

--- a/squad/ci/admin.py
+++ b/squad/ci/admin.py
@@ -54,9 +54,14 @@ class TestJobFailureFilter(admin.SimpleListFilter):
 
 
 class TestJobAdmin(admin.ModelAdmin):
-    list_display = ('backend', 'target', 'submitted', 'fetched', 'success', 'last_fetch_attempt', 'job_id',)
+    list_display = ('backend', 'target', 'submitted', 'fetched', 'success', 'last_fetch_attempt', 'job_id_link',)
     list_filter = ('backend', 'target', 'submitted', 'fetched', TestJobFailureFilter)
     actions = [submit_job, fetch_job]
+
+    def job_id_link(self, test_job):
+        return '<a href="%s">%s</a>' % (test_job.url, test_job.job_id)
+    job_id_link.allow_tags = True
+    job_id_link.short_description = 'Job ID ⇒'
 
 
 admin.site.register(Backend, BackendAdmin)

--- a/squad/ci/models.py
+++ b/squad/ci/models.py
@@ -51,6 +51,10 @@ class Backend(models.Model):
 
     def really_fetch(self, test_job):
         implementation = self.get_implementation()
+
+        test_job.last_fetch_attempt = timezone.now()
+        test_job.save()
+
         results = implementation.fetch(test_job)
 
         if results:
@@ -89,8 +93,6 @@ class Backend(models.Model):
             test_job.testrun = testrun
             test_job.fetched = True
 
-        # save test job
-        test_job.last_fetch_attempt = timezone.now()
         test_job.save()
 
     def submit(self, test_job):

--- a/squad/core/tasks/__init__.py
+++ b/squad/core/tasks/__init__.py
@@ -150,7 +150,6 @@ class ReceiveTestRun(object):
 class ParseTestRunData(object):
 
     @staticmethod
-    @transaction.atomic
     def __call__(test_run):
         if test_run.data_processed:
             return
@@ -198,7 +197,6 @@ class PostProcessTestRun(object):
             except Exception as e:
                 logger.error("Plugin postprocessing error: " + str(e) + "\n" + traceback.format_exc())
 
-    @transaction.atomic
     def __call_plugin__(self, plugin, testrun):
         plugin.postprocess_testrun(testrun)
 
@@ -206,7 +204,6 @@ class PostProcessTestRun(object):
 class RecordTestRunStatus(object):
 
     @staticmethod
-    @transaction.atomic
     def __call__(testrun):
         if testrun.status_recorded:
             return
@@ -266,9 +263,10 @@ class ProcessTestRun(object):
 
     @staticmethod
     def __call__(testrun):
-        ParseTestRunData()(testrun)
-        PostProcessTestRun()(testrun)
-        RecordTestRunStatus()(testrun)
+        with transaction.atomic():
+            ParseTestRunData()(testrun)
+            PostProcessTestRun()(testrun)
+            RecordTestRunStatus()(testrun)
         UpdateProjectStatus()(testrun)
 
 

--- a/squad/core/tasks/__init__.py
+++ b/squad/core/tasks/__init__.py
@@ -85,8 +85,9 @@ class ValidateTestRun(object):
 
 class ReceiveTestRun(object):
 
-    def __init__(self, project):
+    def __init__(self, project, update_project_status=True):
         self.project = project
+        self.update_project_status = update_project_status
 
     SPECIAL_METADATA_FIELDS = (
         "build_url",
@@ -144,6 +145,10 @@ class ReceiveTestRun(object):
 
         processor = ProcessTestRun()
         processor(testrun)
+
+        if self.update_project_status:
+            UpdateProjectStatus()(testrun)
+
         return testrun
 
 
@@ -267,7 +272,6 @@ class ProcessTestRun(object):
             ParseTestRunData()(testrun)
             PostProcessTestRun()(testrun)
             RecordTestRunStatus()(testrun)
-        UpdateProjectStatus()(testrun)
 
 
 class ProcessAllTestRuns(object):

--- a/test/core/test_tasks.py
+++ b/test/core/test_tasks.py
@@ -101,7 +101,6 @@ class ProcessTestRunTest(CommonTestCase):
         ProcessTestRun()(self.testrun)
         self.assertEqual(4, self.testrun.tests.count())
         self.assertEqual(5, self.testrun.status.count())
-        self.assertEqual(1, ProjectStatus.objects.filter(build=self.testrun.build).count())
 
     @patch('squad.core.tasks.PostProcessTestRun.__call__')
     def test_postprocess(self, postprocess):
@@ -237,6 +236,18 @@ class ReceiveTestRunTest(TestCase):
         receive('199', 'myenv')
         testrun = TestRun.objects.last()
         self.assertIsNotNone(testrun.job_id)
+
+    def test_update_project_status(self):
+        receive = ReceiveTestRun(self.project)
+        receive('199', 'myenv')
+        testrun = TestRun.objects.last()
+        self.assertEqual(1, ProjectStatus.objects.filter(build=testrun.build).count())
+
+    def test_dont_update_project_status(self):
+        receive = ReceiveTestRun(self.project, update_project_status=False)
+        receive('199', 'myenv')
+        testrun = TestRun.objects.last()
+        self.assertEqual(0, ProjectStatus.objects.filter(build=testrun.build).count())
 
 
 class TestValidateTestRun(TestCase):

--- a/test/integration/test_build_notification_from_ci.py
+++ b/test/integration/test_build_notification_from_ci.py
@@ -1,0 +1,43 @@
+from django.test import TestCase
+from unittest.mock import patch
+
+
+from squad.core.models import Group
+from squad.ci.models import Backend
+
+
+job_status = 'Finished'
+completed = True
+metadata = {'foo': 'bar'}
+tests = {'test1': 'pass'}
+metrics = {'metric1': 1}
+logs = "hello world\nfinished\n"
+
+
+class BuildNotificationFromCI(TestCase):
+
+    @patch('squad.core.tasks.maybe_notify_project_status')
+    @patch('squad.ci.backend.null.Backend.fetch')
+    def test_fetch_triggers_notification(self, fetch, notify):
+        fetch.return_value = (job_status, completed, metadata, tests, metrics, logs)
+
+        group = Group.objects.create(slug='mygroup')
+        project = group.projects.create(slug='myproject')
+        project.subscriptions.create(email='foo@example.com')
+        build = project.builds.create(version='1')
+
+        backend = Backend.objects.create(
+            url='http://example.com',
+            username='foobar',
+            token='mypassword',
+        )
+        testjob = backend.test_jobs.create(
+            target=project,
+            build='1',
+            job_id='123',
+            environment='myenv',
+        )
+        backend.fetch(testjob)
+        status = build.status
+        notify.delay.assert_called_with(status.id)
+        self.assertTrue(status.finished)


### PR DESCRIPTION
When a testjob was fetched, the ProjectStatus would be created *before* the
test job was saved to the database, which would cause `Build.finished` to be
False, and therefore the notification would never go out. To fix that, we delay
updating the project status until after the test job is completely persisted.
An integration test is being added alongside the fix.

There are also some commits doing cleanups and small improvements, moving
things around, etc.