### PR TITLE
core: fix failed testjob notification templates

### DIFF
--- a/squad/core/templates/squad/notification/failed_test_jobs.html
+++ b/squad/core/templates/squad/notification/failed_test_jobs.html
@@ -7,7 +7,7 @@
     <li>Project: {{project}}</li>
     <li>
         Build:
-        <a href="{{settings.BASE_URL}}/{{project.slug}}/build/{{build.version}}/">{{settings.BASE_URL}}/{{project.slug}}/build/{{build.version}}/</a>
+        <a href="{{settings.BASE_URL}}/{{project.group.slug}}/{{project.slug}}/build/{{build.version}}/">{{settings.BASE_URL}}/{{project.group.slug}}/{{project.slug}}/build/{{build.version}}/</a>
     </li>
 </ul>
 

--- a/squad/core/templates/squad/notification/failed_test_jobs.txt
+++ b/squad/core/templates/squad/notification/failed_test_jobs.txt
@@ -2,7 +2,7 @@ Build information
 -----------------
 
 Project: {{project}}
-Build: {{settings.BASE_URL}}/{{project.slug}}/build/{{build.version}}/
+Build: {{settings.BASE_URL}}/{{project.group.slug}}/{{project.slug}}/build/{{build.version}}/
 
 Failed test jobs
 ----------------


### PR DESCRIPTION
The templates were missing "group" in the URL and produced invalid
links.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>