### PR TITLE
frontend: display testjob.failure if available

### DIFF
--- a/squad/frontend/templates/squad/testjob.html
+++ b/squad/frontend/templates/squad/testjob.html
@@ -2,6 +2,11 @@
 {% load squad %}
 
 {% block content %}
-<h3>The URL for requested test job ({{ testjob_id }}) doesn't yet exist.</h3>
+<h3>The URL for requested test job ({{ testjob.id }}) doesn't yet exist.</h3>
+{% if testjob.failure %}
+<p>TestJob submission failed</p>
+<pre>{{ testjob.failure }}</pre>
+{% else %}
 <p>Please try again later</p>
+{% endif %}
 {% endblock %}

--- a/squad/frontend/views.py
+++ b/squad/frontend/views.py
@@ -249,6 +249,6 @@ def test_job(request, testjob_id):
     else:
         # display some description page
         context = {
-            'testjob_id': testjob_id
+            'testjob': testjob
         }
         return render(request, 'squad/testjob.html', context)


### PR DESCRIPTION
In case test job doesn't have URL but has some failure registered, the
failure is presented to the user.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>