### PR TITLE
core/notification: don't spam admins

### DIFF
--- a/squad/core/notification.py
+++ b/squad/core/notification.py
@@ -172,9 +172,6 @@ class PreviewNotification(Notification):
         html = sub("<body>", "<body>\n" + html_banner, html)
         return (txt, html)
 
-    def mark_as_notified(self):
-        pass
-
 
 def send_status_notification(status, project=None):
     project = project or status.build.project

--- a/test/core/test_notification.py
+++ b/test/core/test_notification.py
@@ -182,9 +182,6 @@ class TestSendUnmoderatedNotification(TestModeratedNotifications):
         html = mail.outbox[0].alternatives[0][0]
         self.assertTrue(html.find('needs to be approved') >= 0)
 
-    def test_does_not_mark_as_notified(self):
-        self.assertFalse(self.status.notified)
-
 
 class TestSendApprovedNotification(TestModeratedNotifications):
 


### PR DESCRIPTION
If preview notifications don't get marked as already notified, admins
will receive one email per test job after the project timeout has
passed. We only want the admins to be notified once.

When a moderated notification is approved, the final notitification is
sent unconditionally, so it's OK to mark the project status as notified
as sent when sending the preview.