### PR TITLE
Add REST API

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ PyYAML
 pyzmq
 msgpack-python
 Jinja2
+djangorestframework

--- a/squad/api/rest.py
+++ b/squad/api/rest.py
@@ -1,4 +1,6 @@
-from squad.core.models import Project, Build
+from squad.core.models import Project, Build, TestRun, Environment
+from squad.ci.models import Backend, TestJob
+from django.http import HttpResponse
 from rest_framework import routers, serializers, viewsets
 from rest_framework.decorators import detail_route
 from rest_framework.response import Response
@@ -52,6 +54,9 @@ class ProjectViewSet(viewsets.ModelViewSet):
 
 
 class BuildSerializer(serializers.HyperlinkedModelSerializer):
+    testruns = serializers.HyperlinkedIdentityField(view_name='build-testruns')
+    testjobs = serializers.HyperlinkedIdentityField(view_name='build-testjobs')
+
     class Meta:
         model = Build
         fields = '__all__'
@@ -64,7 +69,113 @@ class BuildViewSet(ModelViewSet):
     def get_queryset(self):
         return self.queryset.filter(project__in=self.get_project_ids())
 
+    @detail_route(methods=['get'])
+    def testruns(self, request, pk=None):
+        testruns = self.get_object().test_runs.order_by('-id')
+        page = self.paginate_queryset(testruns)
+        serializer = TestRunSerializer(page, many=True, context={'request': request})
+        return self.get_paginated_response(serializer.data)
+
+    @detail_route(methods=['get'])
+    def testjobs(self, request, pk=None):
+        testjobs = self.get_object().test_jobs.order_by('-id')
+        page = self.paginate_queryset(testjobs)
+        serializer = TestJobSerializer(page, many=True, context={'request': request})
+        return self.get_paginated_response(serializer.data)
+
+
+class EnvironmentSerializer(serializers.HyperlinkedModelSerializer):
+    class Meta:
+        model = Environment
+        fields = '__all__'
+
+
+class EnvironmentViewSet(ModelViewSet):
+    queryset = Environment.objects
+    serializer_class = EnvironmentSerializer
+
+    def get_queryset(self):
+        return self.queryset.filter(project__in=self.get_project_ids())
+
+
+class TestRunSerializer(serializers.HyperlinkedModelSerializer):
+
+    tests_file = serializers.HyperlinkedIdentityField(view_name='testrun-tests-file')
+    metrics_file = serializers.HyperlinkedIdentityField(view_name='testrun-metrics-file')
+    metadata_file = serializers.HyperlinkedIdentityField(view_name='testrun-metadata-file')
+    log_file = serializers.HyperlinkedIdentityField(view_name='testrun-log-file')
+
+    class Meta:
+        model = TestRun
+        fields = '__all__'
+
+
+class TestRunViewSet(ModelViewSet):
+    queryset = TestRun.objects.order_by('-id')
+    serializer_class = TestRunSerializer
+
+    def get_queryset(self):
+        return self.queryset.filter(build__project__in=self.get_project_ids())
+
+    @detail_route(methods=['get'])
+    def tests_file(self, request, pk=None):
+        testrun = self.get_object()
+        return HttpResponse(testrun.tests_file, content_type='application/json')
+
+    @detail_route(methods=['get'])
+    def metrics_file(self, request, pk=None):
+        testrun = self.get_object()
+        return HttpResponse(testrun.metrics_file, content_type='application/json')
+
+    @detail_route(methods=['get'])
+    def metadata_file(self, request, pk=None):
+        testrun = self.get_object()
+        return HttpResponse(testrun.metadata_file, content_type='application/json')
+
+    @detail_route(methods=['get'])
+    def log_file(self, request, pk=None):
+        testrun = self.get_object()
+        return HttpResponse(testrun.log_file, content_type='text/plain')
+
+
+class BackendSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Backend
+        exclude = ('token',)
+
+
+class BackendViewSet(viewsets.ModelViewSet):
+    queryset = Backend.objects.all()
+    serializer_class = BackendSerializer
+
+
+class TestJobSerializer(serializers.HyperlinkedModelSerializer):
+    url = serializers.HyperlinkedIdentityField(view_name='testjob-detail')
+    external_url = serializers.CharField(source='url', read_only=True)
+    definition = serializers.HyperlinkedIdentityField(view_name='testjob-definition')
+
+    class Meta:
+        model = TestJob
+        fields = '__all__'
+
+
+class TestJobViewSet(ModelViewSet):
+    queryset = TestJob.objects.order_by('-id')
+    serializer_class = TestJobSerializer
+
+    def get_queryset(self):
+        return self.queryset.filter(target_build__project__in=self.get_project_ids())
+
+    @detail_route(methods=['get'])
+    def definition(self, request, pk=None):
+        definition = self.get_object().definition
+        return HttpResponse(definition, content_type='text/plain')
+
 
 router = routers.DefaultRouter()
 router.register(r'projects', ProjectViewSet)
 router.register(r'builds', BuildViewSet)
+router.register(r'testjobs', TestJobViewSet)
+router.register(r'testruns', TestRunViewSet)
+router.register(r'environments', EnvironmentViewSet)
+router.register(r'backends', BackendViewSet)

--- a/squad/api/rest.py
+++ b/squad/api/rest.py
@@ -1,0 +1,27 @@
+from squad.core.models import Project
+from rest_framework import routers, serializers, viewsets
+
+
+class ProjectSerializer(serializers.HyperlinkedModelSerializer):
+    class Meta:
+        model = Project
+        fields = (
+            'url',
+            'full_name',
+            'slug',
+            'name',
+            'is_public',
+            'description',
+        )
+
+
+class ProjectViewSet(viewsets.ModelViewSet):
+    queryset = Project.objects
+    serializer_class = ProjectSerializer
+
+    def get_queryset(self):
+        return self.queryset.accessible_to(self.request.user)
+
+
+router = routers.DefaultRouter()
+router.register(r'projects', ProjectViewSet)

--- a/squad/api/rest.py
+++ b/squad/api/rest.py
@@ -1,8 +1,28 @@
-from squad.core.models import Project
+from squad.core.models import Project, Build
 from rest_framework import routers, serializers, viewsets
+from rest_framework.decorators import detail_route
+from rest_framework.response import Response
+
+
+class ModelViewSet(viewsets.ModelViewSet):
+
+    def get_project_ids(self):
+        """
+        Determines which projects the current user is allowed to visualize.
+        Returns a list of project ids to be used in get_queryset() for
+        filtering.
+        """
+        user = self.request.user
+        projects = Project.objects.accessible_to(user).values('id')
+        return [p['id'] for p in projects]
 
 
 class ProjectSerializer(serializers.HyperlinkedModelSerializer):
+
+    builds = serializers.HyperlinkedIdentityField(
+        view_name='project-builds',
+    )
+
     class Meta:
         model = Project
         fields = (
@@ -12,6 +32,7 @@ class ProjectSerializer(serializers.HyperlinkedModelSerializer):
             'name',
             'is_public',
             'description',
+            'builds',
         )
 
 
@@ -22,6 +43,28 @@ class ProjectViewSet(viewsets.ModelViewSet):
     def get_queryset(self):
         return self.queryset.accessible_to(self.request.user)
 
+    @detail_route(methods=['get'])
+    def builds(self, request, pk=None):
+        builds = self.get_object().builds.order_by('-datetime')
+        page = self.paginate_queryset(builds)
+        serializer = BuildSerializer(page, many=True, context={'request': request})
+        return self.get_paginated_response(serializer.data)
+
+
+class BuildSerializer(serializers.HyperlinkedModelSerializer):
+    class Meta:
+        model = Build
+        fields = '__all__'
+
+
+class BuildViewSet(ModelViewSet):
+    queryset = Build.objects.all()
+    serializer_class = BuildSerializer
+
+    def get_queryset(self):
+        return self.queryset.filter(project__in=self.get_project_ids())
+
 
 router = routers.DefaultRouter()
 router.register(r'projects', ProjectViewSet)
+router.register(r'builds', BuildViewSet)

--- a/squad/api/urls.py
+++ b/squad/api/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url
+from django.conf.urls import include, url
 from django.shortcuts import redirect
 
 
@@ -12,6 +12,7 @@ from squad.core.models import slug_pattern
 
 urlpatterns = [
     url(r'^$', lambda request: redirect('/')),
+    url(r'^auth/', include('rest_framework.urls', namespace='rest_framework')),
     url(r'^submit/(%s)/(%s)/(%s)/(%s)' % ((slug_pattern,) * 4), views.add_test_run),
     url(r'^submitjob/(%s)/(%s)/(%s)/(%s)' % ((slug_pattern,) * 4), ci.submit_job),
     url(r'^watchjob/(%s)/(%s)/(%s)/(%s)' % ((slug_pattern,) * 4), ci.watch_job),

--- a/squad/api/urls.py
+++ b/squad/api/urls.py
@@ -5,13 +5,14 @@ from django.shortcuts import redirect
 from . import views
 from . import data
 from . import ci
+from . import rest
 
 
 from squad.core.models import slug_pattern
 
 
 urlpatterns = [
-    url(r'^$', lambda request: redirect('/')),
+    url(r'^', include(rest.router.urls)),
     url(r'^auth/', include('rest_framework.urls', namespace='rest_framework')),
     url(r'^submit/(%s)/(%s)/(%s)/(%s)' % ((slug_pattern,) * 4), views.add_test_run),
     url(r'^submitjob/(%s)/(%s)/(%s)/(%s)' % ((slug_pattern,) * 4), ci.submit_job),

--- a/squad/settings.py
+++ b/squad/settings.py
@@ -69,6 +69,7 @@ __apps__ = [
     'django.contrib.staticfiles',
     django_extensions,  # OPTIONAL
     'djcelery',
+    'rest_framework',
     'squad.core',
     'squad.api',
     'squad.frontend',
@@ -239,5 +240,11 @@ CELERYD_HIJACK_ROOT_LOGGER = False
 CELERY_ACCEPT_CONTENT = ['json', 'msgpack', 'yaml']
 CELERY_TASK_SERIALIZER = 'msgpack'
 CELERYBEAT_SCHEDULER = 'djcelery.schedulers.DatabaseScheduler'
+
+REST_FRAMEWORK = {
+    'DEFAULT_PERMISSION_CLASSES': [
+        'rest_framework.permissions.DjangoModelPermissionsOrAnonReadOnly'
+    ]
+}
 
 exec(open(os.getenv('SQUAD_EXTRA_SETTINGS', '/dev/null')).read())

--- a/squad/settings.py
+++ b/squad/settings.py
@@ -244,7 +244,9 @@ CELERYBEAT_SCHEDULER = 'djcelery.schedulers.DatabaseScheduler'
 REST_FRAMEWORK = {
     'DEFAULT_PERMISSION_CLASSES': [
         'rest_framework.permissions.DjangoModelPermissionsOrAnonReadOnly'
-    ]
+    ],
+    'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
+    'PAGE_SIZE': 50,
 }
 
 exec(open(os.getenv('SQUAD_EXTRA_SETTINGS', '/dev/null')).read())

--- a/test/api/test_rest.py
+++ b/test/api/test_rest.py
@@ -1,0 +1,73 @@
+import json
+from test.api import APIClient
+from django.test import TestCase
+from squad.core import models
+from squad.ci import models as ci_models
+
+
+class RestApiTest(TestCase):
+
+    def setUp(self):
+        self.group = models.Group.objects.create(slug='mygroup')
+        self.project = self.group.projects.create(slug='myproject')
+        self.build = self.project.builds.create(version='1')
+        self.environment = self.project.environments.create(slug='myenv')
+        self.testrun = self.build.test_runs.create(environment=self.environment, build=self.build)
+        self.backend = ci_models.Backend.objects.create(name='foobar')
+        self.testjob = self.build.test_jobs.create(
+            definition="foo: bar",
+            backend=self.backend,
+            target=self.project,
+            target_build=self.build,
+            build='1',
+            environment='myenv',
+            testrun=self.testrun
+        )
+
+    def hit(self, url):
+        response = self.client.get(url)
+        self.assertEqual(200, response.status_code)
+        text = response.content.decode('utf-8')
+        if response['Content-Type'] == 'application/json':
+            return json.loads(text)
+        else:
+            return text
+
+    def test_root(self):
+        self.hit('/api/')
+
+    def test_projects(self):
+        data = self.hit('/api/projects/')
+        self.assertEqual(1, len(data['results']))
+
+    def test_project_builds(self):
+        data = self.hit('/api/projects/%d/builds/' % self.project.id)
+        self.assertEqual(1, len(data['results']))
+
+    def test_builds(self):
+        data = self.hit('/api/builds/')
+        self.assertEqual(1, len(data['results']))
+
+    def test_build_testruns(self):
+        data = self.hit('/api/builds/%d/testruns/' % self.build.id)
+        self.assertEqual(1, len(data['results']))
+
+    def test_build_testjobs(self):
+        data = self.hit('/api/builds/%d/testjobs/' % self.build.id)
+        self.assertEqual(1, len(data['results']))
+
+    def test_testjob(self):
+        data = self.hit('/api/testjobs/%d/' % self.testjob.id)
+        self.assertEqual('myenv', data['environment'])
+
+    def test_testjob_definition(self):
+        data = self.hit('/api/testjobs/%d/definition/' % self.testjob.id)
+        self.assertEqual('foo: bar', data)
+
+    def test_backends(self):
+        data = self.hit('/api/backends/')
+        self.assertEqual('foobar', data['results'][0]['name'])
+
+    def test_environments(self):
+        data = self.hit('/api/environments/')
+        self.assertEqual('myenv', data['results'][0]['slug'])


### PR DESCRIPTION
This is a basic implementation of a REST API using Django REST Framework. The
API root, /api, provides a browsable interface when accessed with a web
browser, and it can also display documentation. The actual documentation and
changes to make the API browser match the overall SQUAD layout (CSS, etc) will
be the subject of a subsequent pull request.