### PR TITLE
Upgrade to celery v4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@
 /dist
 /build
 /.metadata.json
+/celerybeat-schedule.db

--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
 web: ./manage.py runserver
-worker: ./manage.py celery worker --loglevel INFO
-scheduler: ./manage.py celery beat --loglevel WARN --pidfile=''
+worker: celery -A squad worker --loglevel INFO
+scheduler: celery -A squad beat --loglevel WARN --pidfile=''
 listener: ./manage.py listen

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -56,9 +56,9 @@ integration:
 +-----------+----------------------------
 | Process   | Command                   |
 +-----------+---------------------------+
-| worker    | squad-admin celery worker |
+| worker    | celery -A squad worker    |
 +-----------+---------------------------+
-| scheduler | squad-admin celery beat   |
+| scheduler | celery -A squad beat      |
 +-----------+---------------------------+
 | listener  | squad-admin listen        |
 +-----------+---------------------------+
@@ -81,10 +81,6 @@ needed:
 * Create ``Backend`` instances for your test execution backends. Go to the
   administration web UI, and under "CI", choose "Backends".
 * For each project, create authentication tokens and subscriptions
-* Under "Djcelery", create "Periodic tasks":
-
-  * ``squad.ci.tasks.poll``: this is that task to  poll results from the
-    backends from time to time. You can schedule this for every 5 minutes;
 
 Further configuration
 ---------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-celery>=3.1,<4.0
+celery
 Django>=1.10,<1.12
 django-celery
 django_filter

--- a/squad/settings.py
+++ b/squad/settings.py
@@ -10,6 +10,7 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/1.9/ref/settings/
 """
 
+from celery.schedules import crontab
 from email.utils import parseaddr
 import os
 import sys
@@ -68,7 +69,6 @@ __apps__ = [
     'whitenoise.runserver_nostatic',
     'django.contrib.staticfiles',
     django_extensions,  # OPTIONAL
-    'djcelery',
     'rest_framework',
     'django_filters',
     'squad.core',
@@ -245,7 +245,12 @@ SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 CELERYD_HIJACK_ROOT_LOGGER = False
 CELERY_ACCEPT_CONTENT = ['json', 'msgpack', 'yaml']
 CELERY_TASK_SERIALIZER = 'msgpack'
-CELERYBEAT_SCHEDULER = 'djcelery.schedulers.DatabaseScheduler'
+CELERYBEAT_SCHEDULE = {
+    'poll-every-hour': {
+        'task': 'squad.ci.tasks.poll',
+        'schedule': crontab(hour='*/1', minute=17),
+    },
+}
 
 REST_FRAMEWORK = {
     'DEFAULT_PERMISSION_CLASSES': [


### PR DESCRIPTION
Support for RDBMS-based periodic tasks is being dropped. It was not being
heavily used, anyway, and can be added back in the future by adding a new
dependency or celery v4.