### PR TITLE
ci: lava: parse LAVA log using incremental parser

### DIFF
--- a/test/ci/backend/example-lava-log.yaml
+++ b/test/ci/backend/example-lava-log.yaml
@@ -1,0 +1,7 @@
+- {"dt": "2018-02-16T18:16:46.738008", "lvl": "info", "msg": "info message ..."}
+- {"dt": "2018-02-16T18:16:46.738008", "lvl": "debug", "msg": "debug message ..."}
+- {"dt": "2018-02-16T18:16:46.738008", "lvl": "warning", "msg": "warning message ..."}
+- {"dt": "2018-02-16T18:16:46.738008", "lvl": "results", "msg": "results message ..."}
+- {"dt": "2018-02-16T18:16:46.738008", "lvl": "input", "msg": "input message ..."}
+- {"dt": "2018-02-16T18:16:46.738008", "lvl": "target", "msg": "target message ..."}
+- {"dt": "2018-02-16T18:16:46.738008", "lvl": "feedback", "msg": "feedback message ..."}

--- a/test/ci/backend/test_lava.py
+++ b/test/ci/backend/test_lava.py
@@ -1,6 +1,7 @@
 from django.core import mail
 from django.test import TestCase
 from mock import patch, MagicMock
+import os
 import yaml
 import xmlrpc
 
@@ -474,3 +475,10 @@ class LavaTest(TestCase):
 
         lava.receive_event('foo.com.testjob', {"job": '123'})
         self.assertEqual('Submitted', TestJob.objects.get(pk=testjob.id).job_status)
+
+    def test_lava_log_parsing(self):
+        lava = LAVABackend(self.backend)
+        log_data = open(os.path.join(os.path.dirname(__file__), 'example-lava-log.yaml')).read()
+        log = lava.__parse_log__(log_data)
+        self.assertIn("target message", log)
+        self.assertNotIn("info message", log)


### PR DESCRIPTION
LAVA presents the log as YAML document. We're only interested in the
'device' level logs. So all other logs are discarded. In other to do
this operation, YAML content has to be parsed. Loading the whole log
into memory caused OoM issues in the past. This patch uses incremental
parsing approach in order to avoid loading full yaml to memory.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>