### PR TITLE
api: fix TestSerializer

### DIFF
--- a/squad/api/rest.py
+++ b/squad/api/rest.py
@@ -205,7 +205,7 @@ class TestSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Test
-        exclude = ('id', 'name', 'suite', 'test_run',)
+        exclude = ('id', 'suite', 'test_run',)
 
 
 class MetricSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
Remove 'name' from excluded fields as this was causing server crash.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>