### PR TITLE
core: add support for test case variants

### DIFF
--- a/doc/intro.rst
+++ b/doc/intro.rst
@@ -114,8 +114,11 @@ when downcased is not either ``"pass"`` or ``"fail"`` will be mapped to
 Tests can be grouped in test suites. For that, the test name must be
 prefixed with the suite name and a slash (``/``). Therefore, slashes are
 reserved characters in this context, and cannot be used in test names.
-Suite names can have embedded slashes in them; so "foo/bar" means suite
-"foo", test "bar"; and "foo/bar/baz" means suite "foo/bar", test "baz".
+There is one exception to this rule. If test name contains square brackets
+(``[``, ``]``) they are considered as test variant. The string inside
+brackets can contain slashes. Suite names can have embedded slashes in
+them; so "foo/bar" means suite "foo", test "bar"; and "foo/bar/baz" means
+suite "foo/bar", test "baz".
 
 Example:
 
@@ -127,7 +130,9 @@ Example:
       "testsuite1/test1": "pass",
       "testsuite1/test2": "fail",
       "testsuite2/subgroup1/testA": "pass",
-      "testsuite2/subgroup2/testA": "pass"
+      "testsuite2/subgroup2/testA": "pass",
+      "testsuite2/subgroup2/testA[variant/one]": "pass",
+      "testsuite2/subgroup2/testA[variant/two]": "pass"
     }
 
 Metrics

--- a/squad/core/utils.py
+++ b/squad/core/utils.py
@@ -18,8 +18,20 @@ def parse_name(input_name):
 
     parts = input_name.split('/')
     if len(parts) > 1:
-        group_name = '/'.join(parts[0:-1])
-        name = parts[-1]
+        # if test name is in format suite/complex.name[some/test/variant]
+        # don't split the name in brackets
+        # this is workaround for some CTS test names
+        if parts[-1].endswith("]"):
+            index = len(parts) - 1
+            # find index of the part that contains opening bracket
+            for part in reversed(parts):
+                if "[" in part:
+                    index = parts.index(part)
+            group_name = '/'.join(parts[0:index])
+            name = '/'.join(parts[index:])
+        else:
+            group_name = '/'.join(parts[0:-1])
+            name = parts[-1]
 
     if group_name == '' or group_name is None:
         group_name = '/'


### PR DESCRIPTION
In some cases (Android CTS) test come with different variants. Test
variants are identified with [foo] at the end of the test name. The
string in the brackets can contain slashes.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>