### PR TITLE
api: add REST API for email templates

### DIFF
--- a/squad/api/rest.py
+++ b/squad/api/rest.py
@@ -1,4 +1,4 @@
-from squad.core.models import Project, ProjectStatus, Build, TestRun, Environment, Test, Metric
+from squad.core.models import Project, ProjectStatus, Build, TestRun, Environment, Test, Metric, EmailTemplate
 from squad.ci.models import Backend, TestJob
 from django.http import HttpResponse
 from rest_framework import routers, serializers, views, viewsets
@@ -333,6 +333,22 @@ class TestJobViewSet(ModelViewSet):
         return HttpResponse(definition, content_type='text/plain')
 
 
+class EmailTemplateSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = EmailTemplate
+        fields = '__all__'
+
+
+class EmailTemplateViewSet(viewsets.ModelViewSet):
+    """
+    List of email templates used.
+    """
+    queryset = EmailTemplate.objects.all()
+    serializer_class = EmailTemplateSerializer
+    filter_fields = ('name',)
+
+
 router = APIRouter()
 router.register(r'projects', ProjectViewSet)
 router.register(r'builds', BuildViewSet)
@@ -340,3 +356,4 @@ router.register(r'testjobs', TestJobViewSet)
 router.register(r'testruns', TestRunViewSet)
 router.register(r'environments', EnvironmentViewSet)
 router.register(r'backends', BackendViewSet)
+router.register(r'emailtemplates', EmailTemplateViewSet)

--- a/test/api/test_rest.py
+++ b/test/api/test_rest.py
@@ -24,6 +24,11 @@ class RestApiTest(TestCase):
             environment='myenv',
             testrun=self.testrun
         )
+        self.emailtemplate = models.EmailTemplate.objects.create(
+            name="fooTemplate",
+            subject="abc",
+            plain_text="def",
+        )
 
     def hit(self, url):
         response = self.client.get(url)
@@ -79,3 +84,7 @@ class RestApiTest(TestCase):
     def test_environments(self):
         data = self.hit('/api/environments/')
         self.assertEqual('myenv', data['results'][0]['slug'])
+
+    def test_email_template(self):
+        data = self.hit('/api/emailtemplates/')
+        self.assertEqual('fooTemplate', data['results'][0]['name'])


### PR DESCRIPTION
This will allow to view and change the custom email templates without
accessing admin UI.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>