### PR TITLE
ci: lava: update listener to match new LAVA state machine

### DIFF
--- a/test/ci/backend/test_lava.py
+++ b/test/ci/backend/test_lava.py
@@ -435,7 +435,7 @@ class LavaTest(TestCase):
             name="foo",
         )
 
-        lava.receive_event('foo.com.testjob', {"job": '123', 'status': 'Complete'})
+        lava.receive_event('foo.com.testjob', {"job": '123', 'state': 'Finished', 'health': 'Complete'})
         # this is workaround to LAVA issues
         # it should be removed when LAVA bug is fixed
         fetch.apply_async.assert_called_with(args=[testjob.id], countdown=120)
@@ -474,7 +474,7 @@ class LavaTest(TestCase):
         )
 
         lava.receive_event('foo.com.testjob', {"job": '123'})
-        self.assertEqual('Submitted', TestJob.objects.get(pk=testjob.id).job_status)
+        self.assertEqual('Unknown', TestJob.objects.get(pk=testjob.id).job_status)
 
     def test_lava_log_parsing(self):
         lava = LAVABackend(self.backend)


### PR DESCRIPTION
Due to changes in LAVA state machine, the ZMQ events contain 2 fields
representing jobs status: 'state' and 'health'. 'state' is responsible
for marking the job is running or not. 'health' represents the status of
finished job (Complete, Incomplete, Canceled). This patch adjusts the
logic in lava listener code to work with the new dictionary keys.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>