### PR TITLE
ci: run PostProcessTestRun after processing TestJob

### DIFF
--- a/squad/ci/models.py
+++ b/squad/ci/models.py
@@ -4,7 +4,7 @@ from django.utils import timezone
 from dateutil.relativedelta import relativedelta
 
 
-from squad.core.tasks import ReceiveTestRun, UpdateProjectStatus
+from squad.core.tasks import ReceiveTestRun, UpdateProjectStatus, PostProcessTestRun
 from squad.core.models import Project, Build, TestRun, slug_validator
 
 
@@ -94,7 +94,10 @@ class Backend(models.Model):
             test_job.fetched = True
             test_job.fetched_at = timezone.now()
             test_job.save()
-
+            # call postprocess again after assigning test job to test run
+            # it might make the Status obsolete as plugins may add
+            # test cases to test run
+            PostProcessTestRun()(testrun)
             UpdateProjectStatus()(testrun)
 
     def submit(self, test_job):


### PR DESCRIPTION
CTS plugin searches for logs based on TestJob results. Since TestJob was
not 'assigned' to the TestRun before plugin was executed, no logs were
retrieved. This patch forces second execution of the plugins after
TestJob and TestRun have proper state in database.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>