### PR TITLE
core/notification: performance improvements

### DIFF
--- a/squad/core/notification.py
+++ b/squad/core/notification.py
@@ -112,7 +112,6 @@ class Notification(object):
                 'squad/notification/diff.txt',
                 context=context,
             )
-            html_message = ''
             html_message = render_to_string(
                 'squad/notification/diff.html',
                 context=context,

--- a/squad/core/notification.py
+++ b/squad/core/notification.py
@@ -67,14 +67,14 @@ class Notification(object):
     def subject(self):
         summary = self.summary
         subject_data = {
-            'project': self.project,
-            'metadata': self.metadata,
+            'build': self.build.version,
             'important_metadata': self.important_metadata,
-            'tests_total': summary.tests_total,
+            'metadata': self.metadata,
+            'project': self.project,
+            'regressions': len(self.comparison.regressions),
             'tests_fail': summary.tests_fail,
             'tests_pass': summary.tests_pass,
-            'regressions': len(self.comparison.regressions),
-            'build': self.build.version,
+            'tests_total': summary.tests_total,
         }
         custom_email_template = self.project.custom_email_template
         if custom_email_template and custom_email_template.subject:
@@ -90,14 +90,14 @@ class Notification(object):
         """
         context = {
             'build': self.build,
-            'metadata': self.metadata,
             'important_metadata': self.important_metadata,
-            'previous_build': self.previous_build,
-            'regressions': self.comparison.regressions,
-            'regressions_grouped_by_suite': self.comparison.regressions_grouped_by_suite,
-            'summary': self.summary,
+            'metadata': self.metadata,
             'notification': self,
+            'previous_build': self.previous_build,
+            'regressions_grouped_by_suite': self.comparison.regressions_grouped_by_suite,
+            'regressions': self.comparison.regressions,
             'settings': settings,
+            'summary': self.summary,
         }
 
         custom_email_template = self.project.custom_email_template

--- a/squad/core/templates/squad/notification/diff.html
+++ b/squad/core/templates/squad/notification/diff.html
@@ -49,16 +49,6 @@
             {% if test.test_run.log_file %}
             <a href="{{settings.BASE_URL}}/{{build.project}}/build/{{build.version}}/testrun/{{test.test_run.job_id}}/log">(log)</a>
             {% endif %}
-            {% if test.history.since %}
-              &mdash;
-              {% if test.history.last_different %}
-                {% with build=test.history.since.test_run.build %}
-                failing since build {{build.version}}, from {{build.datetime}}
-                {% endwith %}
-              {% else %}
-                never passed
-              {% endif %}
-            {% endif %}
           </li>
           {% endfor %}
         </ul>

--- a/squad/core/templates/squad/notification/diff.txt
+++ b/squad/core/templates/squad/notification/diff.txt
@@ -25,7 +25,7 @@ Failures
 {% if summary.failures %}
 {% for env, tests in summary.failures.items %}{{env}}:
 {% for test in tests %}
-  * {{test.full_name}} {% if test.history.since %}-- {% if test.history.last_different %}{% with build=test.history.since.test_run.build %}failing since build {{build.version}}, from {{build.datetime}} {% endwith %}{% else %}never passed{% endif %}{% endif %}{% endfor %}
+  * {{test.full_name}}{% endfor %}
 {% endfor %}
 {% else %}
 (none)


### PR DESCRIPTION
Unfortunately, at the moment there is no good solution to keep the information
on "failing since" for tests that does not require an absurd performance
penalty. So one of the patches here drops that from the default template.