### PR TITLE
lava: fix resubmit() function

### DIFF
--- a/squad/ci/backend/lava.py
+++ b/squad/ci/backend/lava.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import requests
+import ssl
 import traceback
 import yaml
 import xmlrpc
@@ -49,6 +50,8 @@ class Backend(BaseBackend):
                 raise TemporarySubmissionIssue(str(fault))
             else:
                 raise SubmissionIssue(str(fault))
+        except ssl.SSLError as fault:
+            raise SubmissionIssue(str(fault))
 
     def fetch(self, test_job):
         try:
@@ -73,6 +76,8 @@ class Backend(BaseBackend):
                 raise TemporaryFetchIssue(str(fault))
             else:
                 raise FetchIssue(str(fault))
+        except ssl.SSLError as fault:
+            raise FetchIssue(str(fault))
 
     def listen(self):
         listener_url = self.get_listener_url()

--- a/squad/ci/backend/lava.py
+++ b/squad/ci/backend/lava.py
@@ -154,7 +154,6 @@ class Backend(BaseBackend):
                 new_test_job_name = self.__lava_job_name(test_job.definition)
             new_test_job = TestJob(
                 backend=self.data,
-                testrun=test_job.testrun,
                 definition=test_job.definition,
                 target=test_job.target,
                 build=test_job.build,


### PR DESCRIPTION
When resubmitting the job, old test run was assigned to new test job.
This created confusion in the web UI. This patch makes the testrun field
in TestJob object empty when resubmitting. Fixes #228.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>