### PR TITLE
frontend: display model.name instead of model.slug

### DIFF
--- a/squad/frontend/templates/squad/_project_list.html
+++ b/squad/frontend/templates/squad/_project_list.html
@@ -8,7 +8,7 @@
     <a href="{% project_url project %}">
     <div class="col-md-4 col-sm-4">
         <strong>
-            {% if not hide_group %}{{project.group.slug}}/{% endif %}{{project.slug}}
+            {% if not hide_group %}{{project.group.name}}/{% endif %}{{project.name}}
         </strong>
         {% if project.description%}
         <div class='description-{{project.id}}'>

--- a/squad/frontend/templates/squad/build-nav.html
+++ b/squad/frontend/templates/squad/build-nav.html
@@ -1,7 +1,7 @@
 {% load squad %}
 <h1>
-    <a class="h1 text-primary" href="{% group_url project.group %}">{{project.group}}</a>
-    » <a class="h1 text-primary" href="{% project_url project %}">{{project.slug}}</a>
+    <a class="h1 text-primary" href="{% group_url project.group %}">{{project.group.name}}</a>
+    » <a class="h1 text-primary" href="{% project_url project %}">{{project.name}}</a>
     » <a class="h1 text-primary" href="{% build_url build %}">Build {{build.version}}</a>
 </h1>
 

--- a/squad/frontend/templates/squad/group.html
+++ b/squad/frontend/templates/squad/group.html
@@ -4,7 +4,7 @@
 {% load static %}
 
 {% block content %}
-<h1>{{group.slug}}</h1>
+<h1>{{group.name}}</h1>
 
 <p>
 {{group.description|default:""}}

--- a/squad/frontend/templates/squad/index.html
+++ b/squad/frontend/templates/squad/index.html
@@ -12,7 +12,7 @@
     <a href="{% group_url group %}">
     <div class="col-md-3 col-sm-3">
         <strong>
-            {{group.slug}}
+            {{group.name}}
         </strong>
     </div>
     <div class="col-md-6 col-sm-6">

--- a/squad/frontend/templates/squad/project-nav.html
+++ b/squad/frontend/templates/squad/project-nav.html
@@ -1,7 +1,7 @@
 {% load squad %}
 <h1>
-  <a class="h1 text-primary" href="{% group_url project.group %}">{{project.group}}</a>
-  » <a class="h1 text-primary" href="{% project_url project %}">{{project.slug}}</a>
+  <a class="h1 text-primary" href="{% group_url project.group %}">{{project.group.name}}</a>
+  » <a class="h1 text-primary" href="{% project_url project %}">{{project.name}}</a>
   {{pagetitle}}
 </h1>
 <ul class="nav nav-tabs">

--- a/squad/frontend/templates/squad/test_run.html
+++ b/squad/frontend/templates/squad/test_run.html
@@ -5,8 +5,8 @@
 
 {% load squad %}
 <h1>
-    <a href="{% group_url project.group %}">{{project.group}}</a>
-    » <a href="{% project_url project %}">{{project.slug}}</a>
+    <a href="{% group_url project.group %}">{{project.group.name}}</a>
+    » <a href="{% project_url project %}">{{project.name}}</a>
     » <a href="{% build_url build %}">Build {{build.version}}</a>
     »
     Test run {{test_run.job_id}}

--- a/squad/frontend/templates/squad/test_run_suite_metrics.html
+++ b/squad/frontend/templates/squad/test_run_suite_metrics.html
@@ -3,8 +3,8 @@
 {% block content %}
 
 <h1>
-    <a href="{% group_url project.group %}">{{project.group}}</a>
-    » <a href="{% project_url project %}">{{project.slug}}</a>
+    <a href="{% group_url project.group %}">{{project.group.name}}</a>
+    » <a href="{% project_url project %}">{{project.name}}</a>
     » <a href="{% build_url build %}">Build {{build.version}}</a>
     » <a href="{% project_url test_run %}">Test run {{test_run.job_id}}</a>
     » Test results for {{suite}}

--- a/squad/frontend/templates/squad/test_run_suite_tests.html
+++ b/squad/frontend/templates/squad/test_run_suite_tests.html
@@ -3,8 +3,8 @@
 {% block content %}
 
 <h1>
-    <a href="{% group_url project.group %}">{{project.group}}</a>
-    » <a href="{% project_url project %}">{{project.slug}}</a>
+    <a href="{% group_url project.group %}">{{project.group.name}}</a>
+    » <a href="{% project_url project %}">{{project.name}}</a>
     » <a href="{% build_url build %}">Build {{build.version}}</a>
     » <a href="{% project_url test_run %}">Test run {{test_run.job_id}}</a>
     » Test results for {{suite}}


### PR DESCRIPTION
This patch changes how the UI displays the object names. Instead of
displaying 'slug', 'name' is displayed. This allows for more free-form
strings to be displayed in the UI. Since 'name' fields are mandatory
for Group and Project objects there is no need to make the defaults.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>