### PR TITLE
core: fetch project and group for Test

### DIFF
--- a/squad/core/models.py
+++ b/squad/core/models.py
@@ -453,6 +453,8 @@ class Test(models.Model):
             'test_run',
             'test_run__environment',
             'test_run__build',
+            'test_run__build__project',
+            'test_run__build__project__group',
         )
 
     class History(object):


### PR DESCRIPTION
On my tests, the response time of a single request to the test history
page is cut in half.

Test.prefetch_related is used to load the associated objects for a list
of tests, what happens for example in the "test history" page. Not
preloading project and group data causes a N+1 query situation that
makes the test history page brutally slow.