### PR TITLE
core/comparison: avoid extra, slow database query

### DIFF
--- a/squad/core/comparison.py
+++ b/squad/core/comparison.py
@@ -76,16 +76,12 @@ class TestComparison(object):
             self.results[test.full_name][key] = test.status
 
     def __all_tests__(self):
-        data = Test.objects.filter(
-            test_run__build__project__in=[b.project for b in self.builds]
-        ).order_by(
-            'suite__slug',
-            'name',
-        ).values(
-            'suite__slug',
-            'name',
-        ).distinct()
-        return sorted([join_name(item['suite__slug'], item['name']) for item in data])
+        test_set = set()
+        for build in self.builds:
+            for testrun in build.test_runs.all():
+                for test in testrun.tests.all():
+                    test_set.add(test.full_name)
+        return sorted(test_set)
 
     __diff__ = None
 

--- a/test/core/test_comparison.py
+++ b/test/core/test_comparison.py
@@ -62,6 +62,7 @@ class TestComparisonTest(TestCase):
             'd/e': 'pass',
         })
 
+        self.build0 = self.project1.builds.first()
         self.build1 = self.project1.builds.last()
         self.build2 = self.project2.builds.last()
 
@@ -76,7 +77,7 @@ class TestComparisonTest(TestCase):
         self.assertEqual(['myenv', 'otherenv'], comp.environments[self.build2])
 
     def test_tests_are_sorted(self):
-        comp = compare(self.build1, self.build2)
+        comp = compare(self.build0, self.build1)
         self.assertEqual(['a', 'b', 'c', 'd/e', 'z'], list(comp.results.keys()))
 
     def test_test_results(self):


### PR DESCRIPTION
By that point we already have all the needed data loaded, so there is no
point in making an extra query to the database. Also, there were serious
flaws in that query:

- it selected *all* tests ever executed for all *projects* involved in
  the comparison, which is way too broad and will hit *a lot* of data.
- it also applied a distinct(), what is not efficient in this case

One of the test cases was actually wrong, and is now fixed.