### PR TITLE
api: minor fixes to make API more uniform

### DIFF
--- a/squad/api/rest.py
+++ b/squad/api/rest.py
@@ -55,7 +55,7 @@ class UserGroupSerializer(serializers.HyperlinkedModelSerializer):
 
     class Meta:
         model = UserGroup
-        fields = ('id', 'name',)
+        fields = ('id', 'name', 'url')
 
 
 class UserGroupViewSet(viewsets.ModelViewSet):
@@ -74,7 +74,7 @@ class GroupSerializer(serializers.HyperlinkedModelSerializer):
     id = serializers.IntegerField()
     user_groups = serializers.HyperlinkedRelatedField(
         many=True,
-        queryset=UserGroup.objects,
+        read_only=True,
         view_name='usergroups-detail')
 
     class Meta:
@@ -432,7 +432,9 @@ class TestJobViewSet(ModelViewSet):
         return HttpResponse(definition, content_type='text/plain')
 
 
-class EmailTemplateSerializer(serializers.ModelSerializer):
+class EmailTemplateSerializer(serializers.HyperlinkedModelSerializer):
+
+    id = serializers.IntegerField()
 
     class Meta:
         model = EmailTemplate


### PR DESCRIPTION
The most important change is to make user_groups field of Group object
read_only. This prevents from accidentally removing all user groups when
making update. Other changes make the serializers more uniform across
all API.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>