### PR TITLE
core: detect changes from 'fail' to 'pass'

### DIFF
--- a/squad/core/notification.py
+++ b/squad/core/notification.py
@@ -98,8 +98,10 @@ class Notification(object):
             'notification': self,
             'previous_build': self.previous_build,
             'regressions_grouped_by_suite': self.comparison.regressions_grouped_by_suite,
+            'fixes_grouped_by_suite': self.comparison.fixes_grouped_by_suite,
             'known_issues': self.known_issues,
             'regressions': self.comparison.regressions,
+            'fixes': self.comparison.fixes,
             'settings': settings,
             'summary': self.summary,
         }

--- a/test/core/test_comparison.py
+++ b/test/core/test_comparison.py
@@ -122,12 +122,32 @@ class TestComparisonTest(TestCase):
         self.assertEqual(['a'], regressions['myenv'])
         self.assertEqual(['a'], regressions['otherenv'])
 
+    def test_fixes(self):
+        """
+        This test is using builds from different projects because the relevant
+        test data is already prepared in setUp(), but usually regressions is
+        only used when comparing subsequent builds from the same project.
+        """
+        comparison = TestComparison.compare_builds(self.build1, self.build2)
+        fixes = comparison.fixes
+        self.assertEqual(['c'], fixes['myenv'])
+
     def test_regressions_no_previous_build(self):
         comparison = TestComparison.compare_builds(self.build1, None)
         regressions = comparison.regressions
         self.assertEqual({}, regressions)
 
+    def test_fixes_no_previous_build(self):
+        comparison = TestComparison.compare_builds(self.build1, None)
+        fixes = comparison.fixes
+        self.assertEqual({}, fixes)
+
     def test_regressions_no_regressions(self):
         # same build! so no regressions, by definition
         comparison = TestComparison.compare_builds(self.build1, self.build1)
         self.assertEqual({}, comparison.regressions)
+
+    def test_fixes_no_fixes(self):
+        # same build! so no fixes, by definition
+        comparison = TestComparison.compare_builds(self.build1, self.build1)
+        self.assertEqual({}, comparison.fixes)


### PR DESCRIPTION
'fail'->'pass' changes are named 'progression' in SQUAD. The
TestComparison.progression property was introduced to provide means of
reporting such changes

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>