### PR TITLE
api: add 'badges' endpoint to project object

### DIFF
--- a/doc/intro.rst
+++ b/doc/intro.rst
@@ -203,6 +203,26 @@ When sending a proper metadata JSON file, other fields may also be
 submitted. They will be stored, but will not be handled in any specific
 way.
 
+
+Badges
+~~~~~~
+
+SQUAD offers project badges that can be used in the webpages
+
+::
+
+  https://<squad_instance_tld>/group/project/badge
+
+The colour of the badge matches the passed/failed condition.
+Following colours are presented:
+
+  * green (#5cb85c) when there are no failed results
+  * orange (#f0ad4e) when there are both passed and failed results
+  * red (#d9534f) when there are no passed results
+
+If there are no results, the badge colour is grey (#999)
+
+
 CI loop integration (optional)
 ------------------------------
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,5 @@ PyYAML
 pyzmq
 requests
 sqlparse
+svgwrite
 whitenoise

--- a/squad/frontend/urls.py
+++ b/squad/frontend/urls.py
@@ -18,6 +18,7 @@ urlpatterns = [
     url(r'^_/settings/', include(user_settings.urls)),
     url(r'^(%s)/$' % slug_pattern, views.group, name='group'),
     url(r'^(%s)/(%s)/$' % ((slug_pattern,) * 2), views.project, name='project'),
+    url(r'^(%s)/(%s)/badge$' % ((slug_pattern,) * 2), views.project_badge, name='project_badge'),
     url(r'^(%s)/(%s)/tests/(.+)$' % ((slug_pattern,) * 2), tests.test_history, name='test_history'),
     url(r'^(%s)/(%s)/metrics/$' % ((slug_pattern,) * 2), views.metrics, name='metrics'),
     url(r'^(%s)/(%s)/builds/$' % ((slug_pattern,) * 2), views.builds, name='builds'),

--- a/squad/frontend/views.py
+++ b/squad/frontend/views.py
@@ -2,6 +2,7 @@ from collections import defaultdict
 import json
 import mimetypes
 import os
+import svgwrite
 
 from django.db.models import Count, Case, When, Q
 from django.core.paginator import Paginator
@@ -68,6 +69,83 @@ def project(request, group_slug, project_slug):
         'extra_metadata': extra_metadata,
     }
     return render(request, 'squad/project.html', context)
+
+
+@auth
+def project_badge(request, group_slug, project_slug):
+    group = Group.objects.get(slug=group_slug)
+    project = group.projects.get(slug=project_slug)
+
+    status = ProjectStatus.objects.filter(
+        build__project=project,
+        finished=True
+    ).order_by("-build__datetime").first()
+
+    title_text = project.slug
+    if request.GET and 'title' in request.GET.keys():
+        title_text = request.GET['title']
+
+    badge_text = "no results found"
+    if status:
+        badge_text = "pass: %s, fail: %s, skip: %s" % \
+            (status.tests_pass, status.tests_fail, status.tests_skip)
+
+    badge_colour = "#999"
+
+    pass_rate = -1
+    if status and (status.tests_pass or status.tests_fail or status.tests_skip):
+        pass_rate = 100 * float(status.tests_pass) / \
+            float(status.tests_pass + status.tests_fail + status.tests_skip)
+        badge_colour = "#f0ad4e"
+        if status.tests_fail == 0:
+            badge_colour = "#5cb85c"
+        if status.tests_pass == 0:
+            badge_colour = "#d9534f"
+
+    if request.GET:
+        if 'passrate' in request.GET.keys() and pass_rate != -1:
+            badge_text = "%.2f%%" % (pass_rate)
+        elif 'metrics' in request.GET.keys() and status is not None and status.has_metrics:
+            badge_text = str(status.metrics_summary)
+            badge_colour = "#5cb85c"
+
+    font_size = 110
+    character_width = font_size / 2
+    padding_width = character_width
+    title_width = len(title_text) * character_width + 2 * padding_width
+    title_x = title_width / 2 + padding_width
+    badge_width = len(badge_text) * character_width + 2 * padding_width
+    badge_x = badge_width / 2 + 3 * padding_width + title_width
+    total_width = (title_width + badge_width + 4 * padding_width) / 10
+
+    dwg = svgwrite.Drawing("test_badge.svg", (total_width, 20))
+    a = dwg.add(dwg.clipPath())
+    a.add(dwg.rect(rx=3, size=(total_width, 20), fill="#fff"))
+    b = dwg.add(dwg.linearGradient(end=(0, 1), id="b"))
+    b.add_stop_color(0, "#bbb", 0.1)
+    b.add_stop_color(1, None, 0.1)
+    g1 = dwg.add(dwg.g(clip_path=a.get_funciri()))
+    g1.add(
+        dwg.path(
+            fill="#555",
+            d=['M0', '0h', '%sv' % ((2 * padding_width + title_width) / 10), '20H', '0z']))
+    g1.add(
+        dwg.path(
+            fill=badge_colour,
+            d=['M%s' % ((2 * padding_width + title_width) / 10), '0h', '%sv' % ((2 * padding_width + badge_width) / 10), '20H', '%sz' % ((2 * padding_width + title_width) / 10)]))
+    g1.add(
+        dwg.path(
+            fill=b.get_funciri(),
+            d=['M0', '0h', '%sv' % total_width, '20H', '0z']))
+
+    g2 = dwg.add(dwg.g(fill="#fff", text_anchor="middle", font_family="monospace", font_size=font_size))
+    g2.add(dwg.text(title_text, x=[title_x], y=[150], fill="#010101", fill_opacity=".3", transform="scale(.1)", textLength=title_width))
+    g2.add(dwg.text(title_text, x=[title_x], y=[140], transform="scale(.1)", textLength=title_width))
+    g2.add(dwg.text(badge_text, x=[badge_x], y=[150], fill="#010101", fill_opacity=".3", transform="scale(.1)", textLength=badge_width))
+    g2.add(dwg.text(badge_text, x=[badge_x], y=[140], transform="scale(.1)", textLength=badge_width))
+    badge = dwg.tostring()
+
+    return HttpResponse(badge, content_type="image/svg+xml")
 
 
 @auth

--- a/test/frontend/test_basics.py
+++ b/test/frontend/test_basics.py
@@ -44,6 +44,9 @@ class FrontendTest(TestCase):
     def test_project(self):
         self.hit('/mygroup/myproject/')
 
+    def test_project_badge(self):
+        self.hit('/mygroup/myproject/badge')
+
     def test_project_404(self):
         self.hit('/mygroup/unexistingproject/', 404)
 


### PR DESCRIPTION
'badges' endpoint will help rendering project badges with services like
shields.io. It currently has a problem with dynamically chaning colours
but otherwise works. Implementation details and interaction with
shields.io are described in the docs.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>