### PR TITLE
frontend: add shortcut to latest finished build

### DIFF
--- a/test/frontend/test_basics.py
+++ b/test/frontend/test_basics.py
@@ -60,6 +60,14 @@ class FrontendTest(TestCase):
     def test_build_404(self):
         self.hit('/mygroup/myproject/build/999/', 404)
 
+    def test_build_latest_finished(self):
+        self.hit('/mygroup/myproject/build/latest-finished/')
+
+    def test_build_latest_finished_404(self):
+        self.group.projects.create(slug='otherproject')
+        self.hit('/mygroup/otherproject/')
+        self.hit('/mygroup/otherproject/build/latest-finished/', 404)
+
     def test_test_run_build_404(self):
         self.hit('/mygroup/myproject/build/2.0.missing/testrun/999/', 404)
 


### PR DESCRIPTION
My motivation for having this is to be able to automate some performance
benchmarks against the build page, without needing to hardcode a build.