### PR TITLE
api: allow for baseline selection with build/<id>/email API

### DIFF
--- a/squad/core/notification.py
+++ b/squad/core/notification.py
@@ -19,10 +19,11 @@ class Notification(object):
     not need to be sent.
     """
 
-    def __init__(self, status):
+    def __init__(self, status, previous=None):
         self.status = status
         self.build = status.build
-        previous = status.get_previous()
+        if previous is None:
+            previous = status.get_previous()
         self.previous_build = previous and previous.build or None
 
     __comparison__ = None


### PR DESCRIPTION
The email rendering API now allows for selecting custom comparison
baseline. The keyword is 'baseline' and the value should be Build object
ID. In case when Build with given ID doesn't exist HTTP 500 is returned.
Builds from different projects can be compared.

Fixes #303

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>