### PR TITLE
ci: lava: fix case when LAVA fails to provide error_type

### DIFF
--- a/squad/ci/backend/lava.py
+++ b/squad/ci/backend/lava.py
@@ -329,8 +329,9 @@ class Backend(BaseBackend):
                         metadata = result['metadata']
                         test_job.failure = str(metadata)
                         test_job.save()
+                        error_type = metadata.get('error_type', None)
                         # detect jobs failed because of infrastructure issues
-                        if metadata['error_type'] in ['Infrastructure', 'Lava', 'Job']:
+                        if error_type in ['Infrastructure', 'Lava', 'Job']:
                             completed = False
                         # automatically resubmit in some cases
                         infra_messages_re_list = []
@@ -342,7 +343,7 @@ class Backend(BaseBackend):
                                 # ignore incorrect expressions
                                 self.log_debug("'%s' is not a valid regex" % message_re)
                                 continue
-                        if metadata['error_type'] in ['Infrastructure', 'Job', 'Test'] and \
+                        if error_type in ['Infrastructure', 'Job', 'Test'] and \
                                 len(infra_messages_re_list) > 0:
                             for regex in infra_messages_re_list:
                                 if regex.search(metadata['error_msg']) is not None and \


### PR DESCRIPTION
It might be a bug in LAVA but in some cases metadata for 'job' result is
empty. This causes exception when trying to retrieve 'error_type' from
metadata dictionary. This patch removes the exception and prevents
resubmission of such jobs.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>