### PR TITLE
core: Build: check expected test runs even with CI jobs

### DIFF
--- a/squad/core/models.py
+++ b/squad/core/models.py
@@ -276,9 +276,13 @@ class Build(models.Model):
         # dependency on squad.ci, what in theory violates our architecture.
         testjobs = self.test_jobs
         if testjobs.count() > 0:
-            # If this build has CI jobs, then it's finished if there are no
-            # outstanding test jobs.
-            return testjobs.filter(fetched=False).count() == 0
+            if testjobs.filter(fetched=False).count() > 0:
+                # a build that has pending CI jobs is NOT finished
+                return False
+            else:
+                # carry on, and check whether the number of expected test runs
+                # per environment is satisfied.
+                pass
 
         # builds with no CI jobs are finished when each environment has
         # received the expected amount of test runs


### PR DESCRIPTION
Use case: 3 builds with 3 fast LAVA test jobs. Depending on the timing
of the builds, one or two builds will run and finish, the lava jobs will
finish, and notification will go out before the 3rd build has finished.

Build.finished would return without checking expected test runs when CI
(say, LAVA) jobs are involved.

Instead, we now return False (i.e. build is not finished) immediately if
there are any pending CI jobs, but if not, we still perform the checks
for the expected number of test runs for each environment.

The existing test case needed to be improved to create a more realistic
scenario, and a new test case for this use case has been added.