### PR TITLE
RFC: Bootstrap4

### DIFF
--- a/squad/api/renderers.py
+++ b/squad/api/renderers.py
@@ -1,0 +1,20 @@
+from rest_framework.renderers import BrowsableAPIRenderer
+
+
+class BrowsableAPIRendererWithoutForms(BrowsableAPIRenderer):
+    """Renders the browsable api, but excludes the forms."""
+
+    def get_context(self, *args, **kwargs):
+        ctx = super().get_context(*args, **kwargs)
+        ctx['display_edit_forms'] = False
+        return ctx
+
+    def show_form_for_method(self, view, method, request, obj):
+        """We never want to do this! So just return False."""
+        return False
+
+    def get_rendered_html_form(self, data, view, method, request):
+        """Why render _any_ forms at all. This method should return
+        rendered HTML, so let's simply return an empty string.
+        """
+        return ""

--- a/squad/frontend/static/download.conf
+++ b/squad/frontend/static/download.conf
@@ -1,6 +1,6 @@
 # DESTINATION             SOURCE                                                                                SHA1SUM
 angularjs                 http://code.angularjs.org/1.6.6/angular-1.6.6.zip                                     5731a2c2bdbba7077812bb76300b625a07be353e
-bootstrap                 https://github.com/twbs/bootstrap/releases/download/v3.3.7/bootstrap-3.3.7-dist.zip   e6b1000b94e835ffd37f4c6dcbdad43f4b48a02a
+bootstrap                 https://github.com/twbs/bootstrap/releases/download/v4.1.3/bootstrap-4.1.3-dist.zip   db2df8bcd8f935b1af05d188856662b9c31d87f5
 chartjs/Chart.bundle.js   https://github.com/chartjs/Chart.js/releases/download/v2.7.0/Chart.bundle.js          345ebf1ec2b69db24cfbda8e7ad61516086c3848
 font-awesome              http://http.debian.net/debian/pool/main/f/fonts-font-awesome/fonts-font-awesome_4.7.0~dfsg.orig.tar.gz a59bc27ace9906ae09cc8a49aac3b70899e0ae70
 lodash.js                 https://raw.githubusercontent.com/lodash/lodash/4.17.4/dist/lodash.js                 d8e7e155b43e7edcabc46682a809836a68444b01
@@ -8,3 +8,4 @@ jquery.js                 https://code.jquery.com/jquery-3.2.1.js               
 floatThread               https://github.com/mkoryak/floatThead/archive/2.0.3.zip                               d7112698ed5bf14f953fdef6252fdd9950af90bf
 select2.js/select2.min.js https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.5/js/select2.min.js                42fe805a338908436c5c326dbf7e9aec0c8484c7
 select2.js/select2.css    https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.5/css/select2.css                  03f47309050b0691af394398f394065e8dd38503
+popper.js 				  https://github.com/FezVrasta/popper.js/archive/v1.14.4.zip							31ea49a7926da005c4650b811eb6f09d4af6d8ca

--- a/squad/frontend/templates/rest_framework/api.html
+++ b/squad/frontend/templates/rest_framework/api.html
@@ -6,28 +6,27 @@
 
 {% block bootstrap_theme %}
     <link rel="stylesheet" href="{% static "bootstrap/css/bootstrap.css" %}">
-    <link rel="stylesheet" href="{% static "bootstrap/css/bootstrap-theme.css" %}">
     <link rel="stylesheet" href="{% static "font-awesome/css/font-awesome.css" %}">
     <link rel="stylesheet" href="{% static "main.css" %}">
 {% endblock %}
-{% block bootstrap_navbar_variant %}navbar-default{% endblock %}
 
-{% block branding %}
-<a class='navbar-brand' rel="nofollow" href='{% url "home" %}'>
-    <span class="fa fa-line-chart" aria-hidden="true"></span>
-    {% site_name %}
-</a>
-<ul class="nav navbar-nav">
-    <li class="{% active 'home'%}"><a href="{% url 'home' %}">Explore</a></li>
-    <li class="{% active 'compare_projects' %}"><a href="{% url 'compare_projects' %}">Compare</a></li>
-    <li class="{% active 'api-root' %}"><a href="{% url 'api-root' %}">API</a></li>
-</ul>
+{% block navbar %}
+  {% include "squad/_navbar.html" %}
+{% endblock navbar %}
+
+{% block breadcrumbs %}
+  <ul class="breadcrumb">
+    {% for breadcrumb_name, breadcrumb_url in breadcrumblist %}
+      {% if forloop.last %}
+        <li class="breadcrumb-item active"><a href="{{ breadcrumb_url }}">{{ breadcrumb_name }}</a></li>
+      {% else %}
+        <li class="breadcrumb-item"><a href="{{ breadcrumb_url }}">{{ breadcrumb_name }}</a></li>
+      {% endif %}
+    {% empty %}
+      {% block breadcrumbs_empty %}&nbsp;{% endblock breadcrumbs_empty %}
+    {% endfor %}
+  </ul>
 {% endblock %}
-
-{% block userlinks %}
-    {% include "squad/_user_menu.html" %}
-{% endblock %}
-
 
 {% block body %}
     {{block.super}}
@@ -41,3 +40,8 @@
     </footer>
     </div><!-- id="wrapper" -->
 {% endblock %}
+
+{% block script %}
+{{ block.super }}
+      <script src="{% static "bootstrap/js/bootstrap.min.js" %}"></script>
+{% endblock script %}

--- a/squad/frontend/templates/rest_framework/pagination/numbers.html
+++ b/squad/frontend/templates/rest_framework/pagination/numbers.html
@@ -1,0 +1,47 @@
+<ul class="pagination" style="margin: 5px 0 10px 0">
+  {% if previous_url %}
+    <li class="page-item">
+      <a class="page-link" href="{{ previous_url }}" aria-label="Previous">
+        <span aria-hidden="true">&laquo;</span>
+      </a>
+    </li>
+  {% else %}
+    <li class="page-item disabled">
+      <a class="page-link" href="#" aria-label="Previous">
+        <span aria-hidden="true">&laquo;</span>
+      </a>
+    </li>
+  {% endif %}
+
+  {% for page_link in page_links %}
+    {% if page_link.is_break %}
+      <li class="page-item disabled">
+        <a class="page-link" href="#"><span aria-hidden="true">&hellip;</span></a>
+      </li>
+    {% else %}
+      {% if page_link.is_active %}
+        <li class="page-item active">
+          <a class="page-link" href="{{ page_link.url }}">{{ page_link.number }}</a>
+        </li>
+      {% else %}
+        <li>
+          <a class="page-link" href="{{ page_link.url }}">{{ page_link.number }}</a>
+        </li>
+      {% endif %}
+    {% endif %}
+  {% endfor %}
+
+  {% if next_url %}
+    <li class="page-item">
+      <a class="page-link" href="{{ next_url }}" aria-label="Next">
+        <span aria-hidden="true">&raquo;</span>
+      </a>
+    </li>
+  {% else %}
+    <li class="page-item disabled">
+      <a class="page-link" href="#" aria-label="Next">
+        <span aria-hidden="true">&raquo;</span>
+      </a>
+    </li>
+  {% endif %}
+</ul>

--- a/squad/frontend/templates/rest_framework/pagination/previous_and_next.html
+++ b/squad/frontend/templates/rest_framework/pagination/previous_and_next.html
@@ -1,0 +1,21 @@
+<ul class="pagination">
+  {% if previous_url %}
+    <li class="page-item previous">
+      <a class="page-link" href="{{ previous_url }}">&laquo; Previous</a>
+    </li>
+  {% else %}
+    <li class="page-item previous disabled">
+      <a class="page-link" href="#">&laquo; Previous</a>
+    </li>
+  {% endif %}
+
+  {% if next_url %}
+    <li class="page-item next">
+      <a class="page-link" href="{{ next_url }}">Next &raquo;</a>
+    </li>
+  {% else %}
+    <li class="page-item next disabled">
+      <a class="page-link" href="#">Next &raquo;</a>
+    </li>
+  {% endif %}
+</ul>

--- a/squad/frontend/templates/squad/_builds_table.html
+++ b/squad/frontend/templates/squad/_builds_table.html
@@ -8,8 +8,8 @@
     <div class="col-md-2 col-sm-2">
         {% include "squad/_unfinished_build.html" %}
         <span>
-            <i class="fa fa-exclamation-triangle text-danger popover-regressions {% if not status.get_regressions %}hidden{% endif %}"></i>
-            <button title="Regressions" class="hidden">
+            <i class="fa fa-exclamation-triangle text-danger popover-regressions" {% if not status.get_regressions %}hidden{% endif %}></i>
+            <button title="Regressions" hidden>
                 {% for regression_key, regression_value in status.get_regressions.items %}
                 <div>
                     <h3>{{ regression_key }}</h3>
@@ -23,8 +23,8 @@
             </button>
         </span>
         <span>
-            <i class="fa fa-check-circle text-success popover-fixes {% if not status.get_fixes %}hidden{% endif %}"></i>
-            <button title="Fixes" class="hidden">
+            <i class="fa fa-check-circle text-success popover-fixes" {% if not status.get_fixes %}hidden{% endif %}></i>
+            <button title="Fixes" hidden>
                 {% for fix_key, fix_value in status.get_fixes.items %}
                 <div>
                     <h3>{{ fix_key }}</h3>

--- a/squad/frontend/templates/squad/_navbar.html
+++ b/squad/frontend/templates/squad/_navbar.html
@@ -1,0 +1,25 @@
+{% load squad %}
+    <nav id='navbar' class="navbar navbar-expand-lg navbar-light bg-light">
+      <div class="container container-fluid">
+        <button class="navbar-toggler" type="button" data-toggle="collapse" data-target=".navbar-collapse" aria-controls=".navbar-collapse" aria-expanded="false" aria-label="Toggle navigation">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+        <a class="navbar-brand" href="/">
+          <span class="fa fa-line-chart" aria-hidden="true"></span>
+          {% site_name %}
+        </a>
+
+        <div class="collapse navbar-collapse">
+          <ul class="nav navbar-nav mr-auto">
+            <li class="nav-item {% active 'home'%}"><a class="nav-link" href="{% url 'home' %}">Explore</a></li>
+            <li class="nav-item {% active 'compare_projects' %}"><a class="nav-link" href="{% url 'compare_projects' %}">Compare</a></li>
+            <li class="nav-item {% active 'compare_test' %}"><a class="nav-link" href="{% url 'compare_test' %}">Compare Test</a></li>
+            <li class="nav-item {% active 'api-root' %}"><a class="nav-link" href="{% url 'api-root' %}">API</a></li>
+          </ul>
+
+          <ul class="nav navbar-nav">
+            {% include "squad/_user_menu.html" %}
+          </ul>
+        </div>
+      </div>
+    </nav>

--- a/squad/frontend/templates/squad/_pagination.html
+++ b/squad/frontend/templates/squad/_pagination.html
@@ -4,34 +4,34 @@
     <ul class="pagination">
         {% with page_list=items|get_page_list %}
         {% if page_list.link_first %}
-        <li>
-            <a href="?page=1" aria-label="page 1">
+        <li class="page-item">
+            <a class="page-link" href="?page=1" aria-label="page 1">
                 <span aria-hidden="true">1</span>
             </a>
         </li>
         {% endif %}
 
         {% if page_list.head_ellipsis %}
-        <li class='disabled'>
+        <li class='page-item disabled'>
             <span aria-hidden="true">...</span>
         </li>
         {% endif %}
 
         {% for page in page_list.pages %}
-        <li {% if items.number == page %}class="active"{% endif %}>
-            <a href="?page={{page}}" aria-label="page {{page}}">{{page}}</a>
+        <li class="page-item {% if items.number == page %}active{% endif %}">
+            <a class="page-link" href="?page={{page}}" aria-label="page {{page}}">{{page}}</a>
         </li>
         {% endfor %}
 
         {% if page_list.tail_ellipsis %}
-        <li class='disabled'>
+        <li class='page-item disabled'>
             <span aria-hidden="true">...</span>
         </li>
         {% endif %}
 
         {% if page_list.link_last %}
-        <li>
-            <a href="?page={{ items.paginator.num_pages }}" aria-label="page {{items.paginator.num_pages}}">
+        <li class="page-item">
+            <a class="page-link" href="?page={{ items.paginator.num_pages }}" aria-label="page {{items.paginator.num_pages}}">
                 <span aria-hidden="true">{{items.paginator.num_pages}}</span>
             </a>
         </li>

--- a/squad/frontend/templates/squad/_project_list.html
+++ b/squad/frontend/templates/squad/_project_list.html
@@ -3,9 +3,9 @@
 
 <div class='highlight-row'>
 {% for project in projects %}
+<a href="{% project_url project %}">
 <div class="row row-bordered project">
     {% with status=project.status %}
-    <a href="{% project_url project %}">
     <div class="col-md-4 col-sm-4">
         <strong>
             {% if not hide_group %}{{project.group.name}}/{% endif %}{{project.name}}
@@ -55,7 +55,6 @@
         </div>
         {% endif %}
     </div>
-    </a>
 
     {% if project.description and project.description|length > 50 %}
     <div class='description-{{project.id}} description col-md-12 col-sm-12' style='display: none'>
@@ -66,5 +65,6 @@
 
     {% endwith %}
 </div>
+</a>
 {% endfor %}
 </div>

--- a/squad/frontend/templates/squad/_user_menu.html
+++ b/squad/frontend/templates/squad/_user_menu.html
@@ -1,23 +1,23 @@
 {% load squad %}
 {% if user.is_authenticated %}
-  <li>
+  <li class="nav-item dropdown">
       <a class="dropdown-toggle" type="button" id="dropdownMenu1" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
         <img src="{% avatar_url user.email 20 %}" class='avatar-sm'/>
         <span class="caret"></span>
       </a>
-      <ul class="dropdown-menu" aria-labelledby="dropdownMenu1">
+      <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenu1">
         <li><div>Signed in as <strong>{{ user.username }}</strong></div></li> <!-- FIXME -->
         {% if user.is_staff %}
-          <li role="separator" class="divider"></li>
-          <li><a href="/admin/">Administration</a></li>
+          <div class="dropdown-divider"></div>
+          <li><a class="nav-link" href="/admin/">Administration</a></li>
         {% endif %}
-        <li role="separator" class="divider"></li>
-        <li><a href="{% url 'settings-home' %}">Settings</a></li>
-        <li><a href="/logout">Sign out</a></li>
+        <div class="dropdown-divider"></div>
+        <li><a class="nav-link" href="{% url 'settings-home' %}">Settings</a></li>
+        <li><a class="nav-link" href="/logout">Sign out</a></li>
       </ul>
   </li>
 {% else %}
   <li>
-    <a href="/login/?next={{request.path}}"><i class='fa fa-sign-in'></i> Log in</a>
+    <a class="nav-link" href="/login/?next={{request.path}}"><i class='fa fa-sign-in'></i> Log in</a>
   </li>
 {% endif %}

--- a/squad/frontend/templates/squad/base.html
+++ b/squad/frontend/templates/squad/base.html
@@ -11,7 +11,6 @@
     <link rel="shortcut icon"  href="{% static "favicon.ico" %}"/>
 
     <link rel="stylesheet" href="{% static "bootstrap/css/bootstrap.css" %}">
-    <link rel="stylesheet" href="{% static "bootstrap/css/bootstrap-theme.css" %}">
     <link rel="stylesheet" href="{% static "font-awesome/css/font-awesome.css" %}">
     <link rel="stylesheet" href="{% static "main.css" %}">
     {% block styles %}{% endblock %}
@@ -20,34 +19,9 @@
   <body>
 
     <div id='wrapper'>
-    <nav id='navbar' class="navbar navbar-default">
-      <div class="container container-fluid">
-        <!-- .btn-navbar is used as the toggle for collapsed navbar content -->
-        <a class="btn btn-navbar navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
-          <span class="icon-bar"></span>
-          <span class="icon-bar"></span>
-          <span class="icon-bar"></span>
-        </a>
-        <div class="navbar-header">
-          <a class="navbar-brand" href="/">
-            <span class="fa fa-line-chart" aria-hidden="true"></span>
-            {% site_name %}
-          </a>
-        </div>
-
-        <ul class="nav navbar-nav collapse navbar-collapse">
-          <li class="{% active 'home'%}"><a href="{% url 'home' %}">Explore</a></li>
-          <li class="{% active 'compare_projects' %}"><a href="{% url 'compare_projects' %}">Compare</a></li>
-          <li class="{% active 'compare_test' %}"><a href="{% url 'compare_test' %}">Compare Test</a></li>
-          <li class="{% active 'api-root' %}"><a href="{% url 'api-root' %}">API</a></li>
-        </ul>
-
-        <ul class="nav navbar-nav collapse navbar-collapse navbar-right">
-          {% include "squad/_user_menu.html" %}
-        </ul>
-
-      </div>
-    </nav>
+    {% block navbar %}
+      {% include "squad/_navbar.html" %}
+    {% endblock navbar %}
 
     <div id="main-content">
       <div class="container">
@@ -70,6 +44,7 @@
     </div><!-- id="wrapper" -->
 
     <script type="text/javascript" src="{% static "jquery.js" %}"></script>
+    <script type="text/javascript" src="{% static "popper.js/dist/popper.min.js" %}"></script>
     <script type="text/javascript" src="{% static "bootstrap/js/bootstrap.js" %}"></script>
     <script type="text/javascript" src="{% static "angularjs/angular.js" %}"></script>
     <script type="text/javascript" src="{% static "lodash.js" %}"></script>

--- a/squad/frontend/templates/squad/build-nav.html
+++ b/squad/frontend/templates/squad/build-nav.html
@@ -1,34 +1,40 @@
 {% load squad %}
-<h2 class="page-header well">
-    <a class="h2 text-primitive" href="{% group_url project.group %}">{{project.group.name}}</a>
-    » <a class="h2 text-primitive" href="{% project_url project %}">{{project.name}}</a>
-    » {% include "squad/_unfinished_build.html" %} <a class="h2 text-primary" href="{% build_url build %}">Build {{build.version}}</a>
-</h2>
+<div class="card bg-light mb-3">
+  <div class="card-header">
+    <h2>
+        <a class="h2 text-dark" href="{% group_url project.group %}">{{project.group.name}}</a>
+        » <a class="h2 text-dark" href="{% project_url project %}">{{project.name}}</a>
+        » {% include "squad/_unfinished_build.html" %} <a class="h2 text-primary" href="{% build_url build %}">Build {{build.version}}</a>
+    </h2>
+  </div>
+  <div class="card-body">
 
-<ul class="page-header nav nav-pills">
-    {% with url_name=request.resolver_match.url_name %}
+    <ul class="page-header nav nav-pills">
+        {% with url_name=request.resolver_match.url_name %}
 
-    <li role="presentation" {% if url_name == 'build' %}class="active"{% endif %}>
-        <a href="{% build_url build %}">
-            Build summary
-        </a>
-    </li>
-    <li role="presentation" {% if url_name == 'tests' or url_name == 'test_history' %}class="active"{% endif %}>
-        <a href="{% build_section_url build 'tests' %}">
-            All test results
-        </a>
-    </li>
-    {% if build.test_jobs.count %}
-    {% load filter_jobs %}
-    <li role="presentation" {% if url_name == 'testjobs' %}class="active"{% endif %}>
-        <a href="{% build_section_url build 'testjobs' %}">
-            Test jobs
-        {% for i in build|filter_jobs %}
-        <span class="badge badge-{{ i.0 }}" data-toggle="tooltip" data-placement="top" title="{{ i.0 }}">{{ i.1 }}</span>
-        {% endfor %}
-        </a>
-    </li>
-    {% endif %}
+        <li class="nav-item" >
+            <a class="nav-link {% if url_name == 'build' %}active{% endif %}"  href="{% build_url build %}">
+                Build summary
+            </a>
+        </li>
+        <li class="nav-item" >
+            <a class="nav-link {% if url_name == 'tests' or url_name == 'test_history' %}active{% endif %}"  href="{% build_section_url build 'tests' %}">
+                All test results
+            </a>
+        </li>
+        {% if build.test_jobs.count %}
+        {% load filter_jobs %}
+        <li class="nav-item">
+            <a class="nav-link {% if url_name == 'testjobs' %}active{% endif %}"  href="{% build_section_url build 'testjobs' %}">
+                Test jobs
+            {% for i in build|filter_jobs %}
+            <span class="badge badge-{{ i.0 }}" data-toggle="tooltip" data-placement="top" title="{{ i.0 }}">{{ i.1 }}</span>
+            {% endfor %}
+            </a>
+        </li>
+        {% endif %}
 
-    {% endwith %}
-</ul>
+        {% endwith %}
+    </ul>
+  </div>
+</div>

--- a/squad/frontend/templates/squad/compare.html
+++ b/squad/frontend/templates/squad/compare.html
@@ -12,20 +12,21 @@
 
   <div class='row'>
 	<div class='col-md-4'>
-	  <div class='panel panel-default'>
-        <div class='panel-heading'>
+	  <div class='card'>
+        <div class='card-header'>
           Projects
         </div>
-        <div class='panel-body'>
+        <div class='card-body'>
           <div class='metric-selected' ng-repeat="selectedProject in selectedProjects">
-            <small><span ng-bind="selectedProject.full_name"></span></small>
-            <a class='pull-right label label-default' ng-click='removeProject(selectedProject)'><strong>×</strong></a>
+              <small>{{ selectedProject.full_name }}</small>
+              <a class='pull-right' ng-click='removeProject(selectedProject)'><span class='badge badge-secondary'><strong>×</strong></span></a>
           </div>
 
-          <div class="input-group">
+          <div class="input-group mb-3">
             <input class="form-control" ng-model="project" ng-change="doProjectSearch()"></input>
-            <span class="input-group-addon"><i class="fa fa-search"></i></span>
-
+            <div class="input-group-append">
+              <span class="input-group-text"><i class="fa fa-search"></i></span>
+            </div>
             <div id="projects-dropdown" class="col-md-12 dropdown-menu">
               <div class="search-dropdown-display" ng-repeat="project in projects" ng-click="addProject(project)" ng-model="project">
                 <span ng-bind="project.full_name"></span>
@@ -36,19 +37,21 @@
       </div>
 	</div>
 	<div class='col-md-4'>
-	  <div class='panel panel-default'>
-		<div class='panel-heading'>
+	  <div class='card'>
+		<div class='card-header'>
 		  Suite
 		</div>
-        <div class='panel-body'>
+        <div class='card-body'>
           <div class='metric-selected'>
             <small><span ng-bind="selectedSuite"></span></small>
-            <a class='pull-right label label-default' ng-click='removeSuite()' ng-hide="selectedSuite == undefined"><strong>×</strong></a>
+            <a class='pull-right' ng-click='removeSuite()' ng-hide="selectedSuite == undefined"><span class='badge badge-secondary'><strong>×</strong></span></a>
           </div>
 
-          <div class="input-group">
+          <div class="input-group mb-3">
             <input class="form-control" ng-model="suite" ng-change="doSuiteSearch()"></input>
-            <span class="input-group-addon"><i class="fa fa-search"></i></span>
+            <div class="input-group-append">
+              <span class="input-group-text"><i class="fa fa-search"></i></span>
+            </div>
             <div id="suites-dropdown" class="col-md-12 dropdown-menu">
               <div class="search-dropdown-display" ng-repeat="suite in suites" ng-click="addSuite(suite)" ng-model="suite">
                 <span ng-bind="suite"></span>
@@ -60,19 +63,21 @@
 	</div>
 
 	<div class='col-md-4'>
-	  <div class='panel panel-default'>
-		<div class='panel-heading'>
+	  <div class='card'>
+		<div class='card-header'>
 		  Test
 		</div>
-        <div class='panel-body'>
+        <div class='card-body'>
           <div class='metric-selected'>
             <small><span ng-bind="selectedTest"></span></small>
-            <a class='pull-right label label-default' ng-click='removeTest()' ng-hide="selectedTest == undefined"><strong>×</strong></a>
+            <a class='pull-right' ng-click='removeTest()' ng-hide="selectedTest == undefined"><span class='badge badge-secondary'><strong>×</strong></span></a>
           </div>
 
-          <div class="input-group">
+          <div class="input-group mb-3">
             <input class="form-control" ng-model="test" ng-change="doTestSearch()"></input>
-            <span class="input-group-addon"><i class="fa fa-search"></i></span>
+            <div class="input-group-append">
+              <span class="input-group-text"><i class="fa fa-search"></i></span>
+            </div>
             <div id="tests-dropdown" class="col-md-12 dropdown-menu">
               <div class="search-dropdown-display" ng-repeat="test in tests" ng-click="addTest(test)" ng-model="test">
                 <span ng-bind="test"></span>

--- a/squad/frontend/templates/squad/compare.html
+++ b/squad/frontend/templates/squad/compare.html
@@ -24,7 +24,7 @@
 
           <div class="input-group">
             <input class="form-control" ng-model="project" ng-change="doProjectSearch()"></input>
-            <span class="input-group-addon"><i class="glyphicon glyphicon-search"></i></span>
+            <span class="input-group-addon"><i class="fa fa-search"></i></span>
 
             <div id="projects-dropdown" class="col-md-12 dropdown-menu">
               <div class="search-dropdown-display" ng-repeat="project in projects" ng-click="addProject(project)" ng-model="project">
@@ -48,7 +48,7 @@
 
           <div class="input-group">
             <input class="form-control" ng-model="suite" ng-change="doSuiteSearch()"></input>
-            <span class="input-group-addon"><i class="glyphicon glyphicon-search"></i></span>
+            <span class="input-group-addon"><i class="fa fa-search"></i></span>
             <div id="suites-dropdown" class="col-md-12 dropdown-menu">
               <div class="search-dropdown-display" ng-repeat="suite in suites" ng-click="addSuite(suite)" ng-model="suite">
                 <span ng-bind="suite"></span>
@@ -72,7 +72,7 @@
 
           <div class="input-group">
             <input class="form-control" ng-model="test" ng-change="doTestSearch()"></input>
-            <span class="input-group-addon"><i class="glyphicon glyphicon-search"></i></span>
+            <span class="input-group-addon"><i class="fa fa-search"></i></span>
             <div id="tests-dropdown" class="col-md-12 dropdown-menu">
               <div class="search-dropdown-display" ng-repeat="test in tests" ng-click="addTest(test)" ng-model="test">
                 <span ng-bind="test"></span>

--- a/squad/frontend/templates/squad/group.html
+++ b/squad/frontend/templates/squad/group.html
@@ -4,7 +4,9 @@
 {% load static %}
 
 {% block content %}
-<h2 class="page-header well">{{group.name}}</h2>
+<div class="card bg-light mb-3">
+  <div class="card-header"><h2>{{group.name}}</h2></div>
+</div>
 
 <p>
 {{group.description|default:""}}

--- a/squad/frontend/templates/squad/index.html
+++ b/squad/frontend/templates/squad/index.html
@@ -4,30 +4,29 @@
 {% load static %}
 
 {% block content %}
-<h2 class="page-header well">All groups</h2>
-
+<div class="card bg-light mb-3">
+  <div class="card-header"><h2>All groups</h2></div>
+</div>
 <div class='highlight-row'>
 {% for group in groups %}
-<div class="row row-bordered project">
-    <a href="{% group_url group %}">
-    <div class="col-md-3 col-sm-3">
-        <strong>
-            {{group.name}}
-        </strong>
-    </div>
-    <div class="col-md-6 col-sm-6">
-        <p>
-        {{group.description|default:""|truncatechars_html:250}}
-        </p>
-    </div>
-    <div class="col-md-3 col-sm-3">
-        <span class="badge" data-toggle="tooltip" data-placement="top" title="">{{group.project_count}}</span>
-        projects
-    </div>
-    </a>
-</div>
+<a href="{% group_url group %}">
+	<div class="row row-bordered project">
+		<div class="col-3">
+			<strong>
+				{{group.name}}
+			</strong>
+		</div>
+		<div class="col-6">
+			<p>
+			{{group.description|default:""|truncatechars_html:250}}
+			</p>
+		</div>
+		<div class="col-3">
+			<span class="badge" data-toggle="tooltip" data-placement="top" title="">{{group.project_count}}</span>
+			projects
+		</div>
+	</div>
+</a>
 {% endfor %}
 </div>
-
-
 {% endblock %}

--- a/squad/frontend/templates/squad/metrics.html
+++ b/squad/frontend/templates/squad/metrics.html
@@ -12,8 +12,8 @@
     <form><!-- TODO -->
 
       {% verbatim %}
-      <div class='panel panel-default'>
-        <div class='panel-heading'>
+      <div class='card'>
+        <div class='card-header'>
           <span ng-show='getEnvironmentIds().length > 0'>
             Environment
           </span>
@@ -21,7 +21,7 @@
             <strong>Select environment(s)</strong>
           </span>
           <span class='pull-right'>
-            <small><a style='cursor: pointer' ng-click='toggleEnvironments()'>toggle all</a></small>
+			<small><a style='cursor: pointer' ng-click='toggleEnvironments()'><span class='badge badge-secondary'>toggle all</span></a></small>
           </span>
         </div>
         <ul class='list-group'>
@@ -40,14 +40,14 @@
         </ul>
       </div>
 
-      <div class='panel panel-default' ng-show='getEnvironmentIds().length > 0'>
-        <div class='panel-heading'>
+      <div class='card' ng-show='getEnvironmentIds().length > 0'>
+        <div class='card-header'>
           Metrics
         </div>
-        <div class='panel-body'>
+        <div class='card-body'>
           <div class='metric-selected' ng-repeat='metric in selectedMetrics'>
             <small>{{metric.label}}</small>
-            <a class='pull-right label label-default' ng-click='removeMetric(metric)'><strong>×</strong></a>
+			<a class='pull-right' ng-click='removeMetric(metric)'><span class='badge badge-secondary'><strong>×</strong></span></a>
           </div>
 
           Add metric:

--- a/squad/frontend/templates/squad/project-nav.html
+++ b/squad/frontend/templates/squad/project-nav.html
@@ -1,27 +1,33 @@
 {% load squad %}
-<h2 class="page-header well">
-  <a class="h2 text-primitive" href="{% group_url project.group %}">{{project.group.name}}</a>
-  » <a class="h2 text-primary" href="{% project_url project %}">{{project.name}}</a>
-  {{pagetitle}}
-</h1>
-<ul class="page-header nav nav-pills">
-  {% with url_name=request.resolver_match.url_name %}
-  <li role="presentation" {% if url_name == 'project' %}class="active"{% endif %}>
-    <a href="{% project_url project %}">
-      Project Summary
-    </a>
-  </li>
-  <li role="presentation" {% if url_name == 'build' or url_name == 'builds' or url_name == 'testrun' %}class="active"{% endif %}>
-    <a href="{% project_section_url project 'builds' %}">
-      Builds
-    </a>
-  </li>
+<div class="card bg-light mb-3">
+  <div class="card-header">
+    <h2>
+      <a class="text-dark" href="{% group_url project.group %}">{{project.group.name}}</a>
+      » <a class="text-primary" href="{% project_url project %}">{{project.name}}</a>
+      {{pagetitle}}
+    </h2>
+  </div>
+  <div class="card-body">
+    <ul class="nav nav-pills">
+      {% with url_name=request.resolver_match.url_name %}
+      <li class="nav-item">
+        <a class="nav-link {% if url_name == 'project' %}active{% endif %}" href="{% project_url project %}">
+          Project Summary
+        </a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link {% if url_name == 'build' or url_name == 'builds' or url_name == 'testrun' %}active{% endif %}" href="{% project_section_url project 'builds' %}">
+          Builds
+        </a>
+      </li>
 
-  <li role="presentation" {% if url_name == 'metrics' %}class="active"{% endif %}>
-    <a href="{% project_section_url project 'metrics' %}">
-      Metrics
-    </a>
-  </li>
+      <li class="nav-item">
+        <a class="nav-link {% if url_name == 'metrics' %}active{% endif %}" href="{% project_section_url project 'metrics' %}">
+          Metrics
+        </a>
+      </li>
 
-  {% endwith %}
-</ul>
+      {% endwith %}
+    </ul>
+  </div>
+</div>

--- a/squad/frontend/templates/squad/project.html
+++ b/squad/frontend/templates/squad/project.html
@@ -12,8 +12,8 @@
 {% if last_build %}
 <div>
 <h2>Last build - {% include "squad/_unfinished_build.html" with build=last_build %}
-  <span><i class="fa fa-exclamation-triangle text-danger popover-regressions {% if not last_build.status.get_regressions %}hidden{% endif %}"></i>
-  <button title="Regressions" class="hidden">
+  <span><i class="fa fa-exclamation-triangle text-danger popover-regressions" {% if not last_build.status.get_regressions %}hidden{% endif %}></i>
+  <button title="Regressions" hidden>
       {% for regression_key, regression_value in last_build.status.get_regressions.items %}
       <div>
           <h3>{{ regression_key }}</h3>
@@ -27,8 +27,8 @@
   </button>
 </span>
 <span>
-  <i class="fa fa-check-circle text-success popover-fixes {% if not last_build.status.get_fixes %}hidden{% endif %}"></i>
-  <button title="Fixes" class="hidden">
+  <i class="fa fa-check-circle text-success popover-fixes" {% if not last_build.status.get_fixes %}hidden{% endif %}></i>
+  <button title="Fixes" hidden>
       {% for fix_key, fix_value in status.get_fixes.items %}
       <div>
           <h3>{{ fix_key }}</h3>

--- a/squad/frontend/templates/squad/test_history.html
+++ b/squad/frontend/templates/squad/test_history.html
@@ -4,16 +4,20 @@
 
 {% block content %}
 
-  <h2 class="page-header well">
-    {{history.test}}
-    {% if request.GET.top %}
-    up to {{history.top.version}}
-    {% else %}
-      {% if history.top %}
-      <small>(<a href="?top={{history.top.version}}">permalink</a>)</small>
+<div class="card bg-light mb-3">
+  <div class="card-header">
+    <h2>
+      {{history.test}}
+      {% if request.GET.top %}
+      up to {{history.top.version}}
+      {% else %}
+        {% if history.top %}
+        <small>(<a href="?top={{history.top.version}}">permalink</a>)</small>
+        {% endif %}
       {% endif %}
-    {% endif %}
-  </h2>
+    </h2>
+  </div>
+</div>
 
   {% include "squad/_pagination.html" with items=history %}
 

--- a/squad/frontend/templates/squad/test_run.html
+++ b/squad/frontend/templates/squad/test_run.html
@@ -4,23 +4,27 @@
 {% block content %}
 
 {% load squad %}
-<h2 class="page-header well">
-    <a class="h2 text-primitive" href="{% group_url project.group %}">{{project.group.name}}</a>
-    » <a class="h2 text-primitive" href="{% project_url project %}">{{project.name}}</a>
-    » <a class="h2 text-prmitive" href="{% build_url build %}">{{build.version}}</a>
-    » <a class="h2 text-primary" href="{% project_url test_run %}">{{test_run.job_id}} </a>
-    <br>
-      <i class='fa fa-microchip'></i>
-      Test environment: <strong>{{test_run.environment}}</strong>
-      {% if test_run.environment.description %}
-      <a href='#' onclick="$('#environment-description').toggle(); return false" class='btn btn-xs btn-info'><span class='fa fa-info'></span></a>
+<div class="card bg-light mb-3">
+  <div class="card-header">
+    <h2>
+      <a class="h2 text-dark" href="{% group_url project.group %}">{{project.group.name}}</a>
+      » <a class="h2 text-dark" href="{% project_url project %}">{{project.name}}</a>
+      » <a class="h2 text-dark" href="{% build_url build %}">{{build.version}}</a>
+      » <a class="h2 text-dark" href="{% project_url test_run %}">{{test_run.job_id}} </a>
+      <br>
+        <i class='fa fa-microchip'></i>
+        Test environment: <strong>{{test_run.environment}}</strong>
+        {% if test_run.environment.description %}
+        <a href='#' onclick="$('#environment-description').toggle(); return false" class='btn btn-xs btn-info'><span class='fa fa-info'></span></a>
+        {% endif %}
+        {% if test_run.environment.description %}
+        <div class='alert alert-info' id='environment-description' style='display: none'>
+      {{test_run.environment.description|markdown}}
+        </div>
       {% endif %}
-      {% if test_run.environment.description %}
-      <div class='alert alert-info' id='environment-description' style='display: none'>
-	{{test_run.environment.description|markdown}}
-      </div>
-    {% endif %}
-</h2>
+    </h2>
+  </div>
+</div>
 
 <h2>Test run metadata</h2>
 {% include "squad/_metadata.html" %}

--- a/squad/frontend/templates/squad/test_run_suite_metrics.html
+++ b/squad/frontend/templates/squad/test_run_suite_metrics.html
@@ -2,13 +2,17 @@
 {% load squad %}
 {% block content %}
 
-<h2 class="page-header well">
-    <a class="h2 text-primitive" href="{% group_url project.group %}">{{project.group.name}}</a>
-    » <a class="h2 text-primitive" href="{% project_url project %}">{{project.name}}</a>
-    » <a class="h2 text-primitive" href="{% build_url build %}">Build {{build.version}}</a>
-    » <a class="h2 text-primitive" href="{% project_url test_run %}">Test run {{test_run.job_id}}</a>
-    » Test results for {{Suite}}
-</h2>
+<div class="card bg-light mb-3">
+  <div class="card-header">
+	<h2>
+		<a class="h2 text-dark" href="{% group_url project.group %}">{{project.group.name}}</a>
+		» <a class="h2 text-dark" href="{% project_url project %}">{{project.name}}</a>
+		» <a class="h2 text-dark" href="{% build_url build %}">Build {{build.version}}</a>
+		» <a class="h2 text-dark" href="{% project_url test_run %}">Test run {{test_run.job_id}}</a>
+		» Test results for {{suite}}
+	</h2>
+  </div>
+</div>
 
 <h2>
     Test environment: {{test_run.environment}}

--- a/squad/frontend/templates/squad/test_run_suite_tests.html
+++ b/squad/frontend/templates/squad/test_run_suite_tests.html
@@ -2,43 +2,47 @@
 {% load squad %}
 {% block content %}
 
-<h2 class="page-header well">
-    <a class="h2 text-primitive" href="{% group_url project.group %}">{{project.group.name}}</a>
-    » <a class="h2 text-primitive" href="{% project_url project %}">{{project.name}}</a>
-    » <a class="h2 text-primitive" href="{% build_url build %}"> {{build.version}}</a>
-    » <a class="h2 text-primitive" href="{% project_url test_run %}">{{test_run.job_id}}</a>
-    » <a class="h2 text-primary" href="{% project_url test_run %}">{{suite}}</a>
-    <br>
+<div class="card bg-light mb-3">
+  <div class="card-header">
+    <h2>
+        <a class="h2 text-dark" href="{% group_url project.group %}">{{project.group.name}}</a>
+        » <a class="h2 text-dark" href="{% project_url project %}">{{project.name}}</a>
+        » <a class="h2 text-dark" href="{% build_url build %}"> {{build.version}}</a>
+        » <a class="h2 text-dark" href="{% project_url test_run %}">{{test_run.job_id}}</a>
+        » <a class="h2 text-primary" href="{% project_url test_run %}">{{suite}}</a>
+        <br>
 
-    <small>
-      <i class='fa fa-microchip'></i>
-      Test environment: <strong> {{test_run.environment}} </strong>
-      {% if test_run.environment.description %}
-      <a href='#' onclick="$('#environment-description').toggle(); return false" class='btn btn-xs btn-info'><span class='fa fa-info'></span></a>
-      {% endif %}
-      {% if test_run.environment.description %}
-      <div class='alert alert-info' id='environment-description' style='display: none'>
-	{{test_run.environment.description|markdown}}
-      </div>
-      {% endif %}
-      <br>
-      <i class='fa fa-list'></i>
-      Suite: <strong> {{suite}} </strong>
-      {% if status.suite_version %}
-      {{status.suite_version.version}}
-      {% endif %}
-      {% if suite.metadata.description %}
-      <a href='#' onclick="$('#tests-{{suite.slug}}-description').toggle(); return false" class='btn btn-xs btn-info'><span class='fa fa-info'></span></a>
-      {% endif %}
-      
-      {% if suite.metadata.description %}
-      <div class='alert alert-info' id='tests-{{suite.slug}}-description' style='display: none'>
-	{{suite.metadata.description|markdown}}
-      </div>
-      {% endif %}
-    </small> 
-      <a name="tests"></a>
-</h2>
+        <small>
+          <i class='fa fa-microchip'></i>
+          Test environment: <strong> {{test_run.environment}} </strong>
+          {% if test_run.environment.description %}
+          <a href='#' onclick="$('#environment-description').toggle(); return false" class='btn btn-xs btn-info'><span class='fa fa-info'></span></a>
+          {% endif %}
+          {% if test_run.environment.description %}
+          <div class='alert alert-info' id='environment-description' style='display: none'>
+        {{test_run.environment.description|markdown}}
+          </div>
+          {% endif %}
+          <br>
+          <i class='fa fa-list'></i>
+          Suite: <strong> {{suite}} </strong>
+          {% if status.suite_version %}
+          {{status.suite_version.version}}
+          {% endif %}
+          {% if suite.metadata.description %}
+          <a href='#' onclick="$('#tests-{{suite.slug}}-description').toggle(); return false" class='btn btn-xs btn-info'><span class='fa fa-info'></span></a>
+          {% endif %}
+          
+          {% if suite.metadata.description %}
+          <div class='alert alert-info' id='tests-{{suite.slug}}-description' style='display: none'>
+        {{suite.metadata.description|markdown}}
+          </div>
+          {% endif %}
+        </small> 
+          <a name="tests"></a>
+    </h2>
+  </div>
+</div>
 
 <h2>
     Test results

--- a/squad/frontend/templates/squad/testjobs.html
+++ b/squad/frontend/templates/squad/testjobs.html
@@ -36,10 +36,10 @@
                 <a href="{{ testjob.parent_job.url }}">Resubmitted from #{{testjob.parent_job.job_id}}</a>
             {% endif %}
             {% if testjob.failure %}
-            <button class="btn btn-default btn-sm" type="button" data-toggle="collapse" data-target="#collapse-failure-{{testjob.pk}}" aria-expanded="false" aria-controls="collapse-failure-{{testjob.pk}}"><span class="glyphicon glyphicon-alert" aria-hidden="true"></span></button>
+            <button class="btn btn-default btn-sm" type="button" data-toggle="collapse" data-target="#collapse-failure-{{testjob.pk}}" aria-expanded="false" aria-controls="collapse-failure-{{testjob.pk}}"><span class="fa fa-exclamation-triangle" aria-hidden="true"></span></button>
             {% endif %}
             {% if testjob.definition %}
-            <button class="btn btn-default btn-sm" type="button" data-toggle="collapse" data-target="#collapse-definition-{{testjob.pk}}" aria-expanded="false" aria-controls="collapse-definition-{{testjob.pk}}"><span class="glyphicon glyphicon-list-alt" aria-hidden="true"></span></button>
+            <button class="btn btn-default btn-sm" type="button" data-toggle="collapse" data-target="#collapse-definition-{{testjob.pk}}" aria-expanded="false" aria-controls="collapse-definition-{{testjob.pk}}"><span class="fa fa-list-alt" aria-hidden="true"></span></button>
             {% endif %}
             {% if user.is_staff or user.is_superuser %}
             <div class='pull-right' ng-controller='ResubmitController'>

--- a/squad/settings.py
+++ b/squad/settings.py
@@ -272,6 +272,10 @@ REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'rest_framework.authentication.SessionAuthentication',
         'rest_framework.authentication.TokenAuthentication',
+    ),
+    'DEFAULT_RENDERER_CLASSES': (
+        'rest_framework.renderers.JSONRenderer',
+        'squad.api.renderers.BrowsableAPIRendererWithoutForms',
     )
 }
 


### PR DESCRIPTION
All templates were migrated to bootstrap 4. This caused conflicts with DRF templates which use bootstrap 2. Our version overwrites DRF version. For this reason we have to carry additional templates for pagination as the default ones are not compatible with bootstrap 4. Also POST/PUT forms were dropped from web API. I don't think they're very useful for ordinary users anyway. Alternative is to leave Web API on it's own bootstrap and try to theme it to be in line with the rest of the page. Other changes are pretty self explanatory. 