### PR TITLE
frontend: hide dropdowns in comparetest page

### DIFF
--- a/squad/frontend/static/squad/compare.js
+++ b/squad/frontend/static/squad/compare.js
@@ -44,6 +44,10 @@ function CompareController($scope, $http, $location) {
         return _.map($scope.selectedProjects, function(pr) {return pr.id})
     }
 
+    $scope.hideDropdown = function(dropdown_id) {
+        $(dropdown_id).collapse('hide');
+    }
+
     $scope.projectSearchUpdate = function(project_list) {
         if ($scope.projectSearchResponses > 0) {
             for (var i = 0; i < project_list.length; i++) {

--- a/squad/frontend/templates/squad/compare.html
+++ b/squad/frontend/templates/squad/compare.html
@@ -23,7 +23,7 @@
           </div>
 
           <div class="input-group">
-            <input class="form-control" ng-model="project" ng-change="doProjectSearch()"></input>
+            <input class="form-control" ng-model="project" ng-change="doProjectSearch()" ng-blur="hideDropdown('#projects-dropdown')"></input>
             <span class="input-group-addon"><i class="glyphicon glyphicon-search"></i></span>
 
             <div id="projects-dropdown" class="col-md-12 dropdown-menu">
@@ -47,7 +47,7 @@
           </div>
 
           <div class="input-group">
-            <input class="form-control" ng-model="suite" ng-change="doSuiteSearch()"></input>
+            <input class="form-control" ng-model="suite" ng-change="doSuiteSearch()" ng-blur="hideDropdown('#suites-dropdown')"></input>
             <span class="input-group-addon"><i class="glyphicon glyphicon-search"></i></span>
             <div id="suites-dropdown" class="col-md-12 dropdown-menu">
               <div class="search-dropdown-display" ng-repeat="suite in suites" ng-click="addSuite(suite)" ng-model="suite">
@@ -71,7 +71,7 @@
           </div>
 
           <div class="input-group">
-            <input class="form-control" ng-model="test" ng-change="doTestSearch()"></input>
+            <input class="form-control" ng-model="test" ng-change="doTestSearch()" ng-blur="hideDropdown('#tests-dropdown')"></input>
             <span class="input-group-addon"><i class="glyphicon glyphicon-search"></i></span>
             <div id="tests-dropdown" class="col-md-12 dropdown-menu">
               <div class="search-dropdown-display" ng-repeat="test in tests" ng-click="addTest(test)" ng-model="test">


### PR DESCRIPTION
The dropdowns for each of the search fields are now removed on lost
focus in the input field.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>