### PR TITLE
frontend: Make order of tests important in notifications

### DIFF
--- a/squad/core/models.py
+++ b/squad/core/models.py
@@ -854,7 +854,7 @@ class TestSummary(TestSummaryBase):
         self.tests_skip = 0
         self.failures = OrderedDict()
 
-        tests = {}
+        tests = OrderedDict()
         test_runs = build.test_runs.prefetch_related(
             'environment',
             'tests',


### PR DESCRIPTION
In notification emails tests are now stored in OrderedDict rather than a
dict. This makes sure they're reported in the same order as they were
collected.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>