### PR TITLE
core: add 'xfail' to default test statuses

### DIFF
--- a/squad/core/models.py
+++ b/squad/core/models.py
@@ -329,7 +329,7 @@ class Build(models.Model):
                 if t.suite in result[tr.environment].keys():
                     result[tr.environment][t.suite][t.status] += 1
                 else:
-                    result[tr.environment].setdefault(t.suite, {'fail': 0, 'pass': 0, 'skip': 0})
+                    result[tr.environment].setdefault(t.suite, {'fail': 0, 'pass': 0, 'skip': 0, 'xfail': 0})
                     result[tr.environment][t.suite][t.status] += 1
         for env in result.keys():
             # there should only be one key in the most nested dict

--- a/test/core/test_build.py
+++ b/test/core/test_build.py
@@ -4,7 +4,7 @@ from django.utils import timezone
 from unittest.mock import patch
 
 
-from squad.core.models import Group, Project, Build
+from squad.core.models import Group, Project, Build, KnownIssue
 from squad.ci.models import TestJob, Backend
 
 
@@ -204,8 +204,14 @@ class BuildTest(TestCase):
         testrun1 = build.test_runs.create(environment=env1)
         testrun2 = build.test_runs.create(environment=env2)
         testrun1.tests.create(suite=foo, name='test1', result=True)
+        testrun1.tests.create(suite=foo, name='pla', result=True)
         testrun1.tests.create(suite=bar, name='test1', result=False)
         testrun2.tests.create(suite=foo, name='test1', result=True)
+
+        # make sure 'xfail' is covered by test
+        issue = KnownIssue.objects.create(title='pla is broken', test_name='qux')
+        xfail_test = testrun2.tests.create(suite=foo, name='pla', result=False)
+        xfail_test.known_issues.add(issue)
 
         test_suites = build.test_suites_by_environment
 


### PR DESCRIPTION
When collecting all test results by environment and KnownIssue is active
for one of the tests 'xfail' status appears in the dictionary. This
patch makes sure there is no missing key in that dict.

Fixes #341

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>