### PR TITLE
settings: optionally load squad/local_settings.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 /squad/frontend/static/floatThread
 /squad/frontend/static/select2.js/
 /squad/frontend/static/download.status
+/squad/local_settings.py
 /static
 /.tests
 /__pycache__

--- a/squad/settings.py
+++ b/squad/settings.py
@@ -279,4 +279,9 @@ REST_FRAMEWORK = {
 CORS_ORIGIN_ALLOW_ALL = True
 CORS_ALLOW_METHODS = ['GET', 'HEAD']
 
+try:
+    from squad.local_settings import *  # noqa: F403
+except ImportError:
+    pass
+
 exec(open(os.getenv('SQUAD_EXTRA_SETTINGS', '/dev/null')).read())

--- a/test/test_architecture.py
+++ b/test/test_architecture.py
@@ -26,6 +26,7 @@ ALLOWED_MODULE_DEPENDENCIES = (
     ('squad.plugins', 'squad.core'),
     ('squad.plugins', 'squad.frontend'),
     ('squad.settings', 'squad.core'),
+    ('squad.settings', 'squad.local_settings'),
 )
 
 


### PR DESCRIPTION
This makes it easy to have local settings without having to export environment variables, or changing files that are tracked by git.