### PR TITLE
api: fix pagination in TestRun detail routes

### DIFF
--- a/squad/api/rest.py
+++ b/squad/api/rest.py
@@ -12,7 +12,7 @@ from rest_framework import routers, serializers, views, viewsets, status
 from rest_framework.decorators import detail_route
 from rest_framework.exceptions import NotFound
 from rest_framework.response import Response
-from rest_framework.pagination import CursorPagination
+from rest_framework.pagination import CursorPagination, PageNumberPagination
 
 import rest_framework_filters as filters
 from jinja2 import TemplateSyntaxError
@@ -622,18 +622,20 @@ class TestRunViewSet(ModelViewSet):
     @detail_route(methods=['get'], suffix='tests')
     def tests(self, request, pk=None):
         testrun = self.get_object()
-        tests = testrun.tests.prefetch_related('suite')
-        page = self.paginate_queryset(tests)
+        tests = testrun.tests.prefetch_related('suite').order_by('id')
+        paginator = PageNumberPagination()
+        page = paginator.paginate_queryset(tests, request)
         serializer = TestSerializer(page, many=True, context={'request': request})
-        return self.get_paginated_response(serializer.data)
+        return paginator.get_paginated_response(serializer.data)
 
     @detail_route(methods=['get'], suffix='metrics')
     def metrics(self, request, pk=None):
         testrun = self.get_object()
-        metrics = testrun.metrics.prefetch_related('suite')
-        page = self.paginate_queryset(metrics)
+        metrics = testrun.metrics.prefetch_related('suite').order_by('id')
+        paginator = PageNumberPagination()
+        page = paginator.paginate_queryset(metrics, request)
         serializer = MetricSerializer(page, many=True, context={'request': request})
-        return self.get_paginated_response(serializer.data)
+        return paginator.get_paginated_response(serializer.data)
 
 
 class BackendSerializer(serializers.ModelSerializer):

--- a/test/api/test_rest.py
+++ b/test/api/test_rest.py
@@ -150,6 +150,18 @@ class RestApiTest(TestCase):
         data = self.hit('/api/testjobs/%d/' % self.testjob.id)
         self.assertEqual('myenv', data['environment'])
 
+    def test_testruns(self):
+        data = self.hit('/api/testruns/%d/' % self.testrun.id)
+        self.assertEqual(self.testrun.id, data['id'])
+
+    def test_testruns_tests(self):
+        data = self.hit('/api/testruns/%d/tests/' % self.testrun.id)
+        self.assertEqual(list, type(data['results']))
+
+    def test_testruns_metrics(self):
+        data = self.hit('/api/testruns/%d/metrics/' % self.testrun.id)
+        self.assertEqual(list, type(data['results']))
+
     def test_testjob_definition(self):
         data = self.hit('/api/testjobs/%d/definition/' % self.testjob.id)
         self.assertEqual('foo: bar', data)


### PR DESCRIPTION
It was using the pagination settings, including field names etc from
TestRun to paginate Test's and Metric's.