### PR TITLE
doc/quickstart.rst: Add missing system dependency

### DIFF
--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -16,7 +16,7 @@ To install the dependencies::
 Alternatively to using pip, on Debian stretch or later you can install
 dependencies from the repository::
 
-    apt-get install python3-dateutil python3-django python3-celery \
+    apt-get install python3-dateutil python3-django python3-celery libyaml-dev \
       python3-django-celery python3-jinja2 python3-whitenoise python3-zmq
 
 To run the tests::


### PR DESCRIPTION
When running squad locally, i.e., installing all
dependencies with pip3 still misses out on yaml.CLoader[1]
(https://github.com/linaro/squad/blob/master/squad/ci/backend/lava.py#L209)

Just added the system dependency 'libyaml-dev' so that
when pip installs all requirements, CLoader will be available
for 'yaml' module.

[1] https://github.com/yaml/pyyaml/issues/108 