### PR TITLE
Collect and record number of database queries during tests

### DIFF
--- a/scripts/get-metrics
+++ b/scripts/get-metrics
@@ -21,8 +21,13 @@ else
   tests_per_sec=0
 fi
 
+(
+if [ -f tmp/queries.json ]; then
+  cat tmp/queries.json | jq '' | sed -e 's/}/,/; s#/#_#g; s#:_#/_#; s#^\(\s\+"\)#\1queries/#;'
+else
+  echo "{"
+fi
 echo "
-{
   \"python/lines\": $python_lines,
   \"python/comments\": $python_comments,
   \"python/tests\": $python_tests,
@@ -37,4 +42,5 @@ echo "
 
   \"git/commits\": $git_commits,
   \"git/authors\": $git_authors
-}" | jq ''
+}"
+) | jq ''

--- a/scripts/get-metrics
+++ b/scripts/get-metrics
@@ -2,12 +2,12 @@
 
 set -eu
 
-python_lines=$(find -name '*.py' | xargs grep '\S' | wc -l)
-python_comments=$(find -name '*.py' | xargs grep '^\s*#' | wc -l)
+python_lines=$(find * -name '*.py' | xargs grep '\S' | wc -l)
+python_comments=$(find * -name '*.py' | xargs grep '^\s*#' | wc -l)
 python_tests=$(grep --binary-files=without-match -r 'def\s*test' test/ | wc -l)
 python_runtime_dependencies=$(grep ^[^-#] requirements.txt | wc -l)
 python_development_dependencies=$(grep ^[^-#] requirements-dev.txt | wc -l)
-python_files=$(find -name '*.py' | wc -l)
+python_files=$(find * -name '*.py' | wc -l)
 
 git_commits=$(git log --oneline | wc -l)
 git_authors=$(git log --format=%aN | sort -u | wc -l)

--- a/squad/manage.py
+++ b/squad/manage.py
@@ -3,12 +3,19 @@ import sys
 
 
 def main():
+    testing = False
     if len(sys.argv) > 1 and sys.argv[1] == 'test':
         os.environ.setdefault("DJANGO_SETTINGS_MODULE", "test.settings")
+        testing = True
     else:
         os.environ.setdefault("DJANGO_SETTINGS_MODULE", "squad.settings")
     from django.core.management import execute_from_command_line
-    execute_from_command_line(sys.argv)
+    try:
+        execute_from_command_line(sys.argv)
+    finally:
+        if testing:
+            import test.performance
+            test.performance.export('tmp/queries.json')
 
 
 if __name__ == "__main__":

--- a/test/api/test_rest.py
+++ b/test/api/test_rest.py
@@ -6,6 +6,7 @@ from django.utils import timezone
 from squad.core import models
 from squad.core.tasks import UpdateProjectStatus
 from squad.ci import models as ci_models
+from test.performance import count_queries
 
 
 class RestApiTest(TestCase):
@@ -113,7 +114,8 @@ class RestApiTest(TestCase):
         )
 
     def hit(self, url):
-        response = self.client.get(url)
+        with count_queries('url:' + url):
+            response = self.client.get(url)
         self.assertEqual(200, response.status_code)
         text = response.content.decode('utf-8')
         if response['Content-Type'] == 'application/json':

--- a/test/frontend/test_basics.py
+++ b/test/frontend/test_basics.py
@@ -5,6 +5,7 @@ from django.contrib.auth.models import User
 
 from squad.core import models
 from squad.core.tasks import ReceiveTestRun
+from test.performance import count_queries
 
 
 class FrontendTest(TestCase):
@@ -30,7 +31,8 @@ class FrontendTest(TestCase):
         self.test_run.attachments.create(filename="foo", data=attachment_data, length=len(attachment_data))
 
     def hit(self, url, expected_status=200):
-        response = self.client.get(url)
+        with count_queries('url:' + url):
+            response = self.client.get(url)
         self.assertEqual(expected_status, response.status_code)
         return response
 

--- a/test/performance.py
+++ b/test/performance.py
@@ -1,0 +1,66 @@
+from contextlib import contextmanager
+import json
+import os
+import re
+import sys
+from django.conf import settings
+from django.db import connection, reset_queries
+
+
+count = {}
+
+
+@contextmanager
+def count_queries(k):
+    q = 0
+    debug = settings.DEBUG
+    try:
+        settings.DEBUG = True
+        reset_queries()
+        yield
+        q = len(connection.queries)
+    finally:
+        settings.DEBUG = debug
+    count.setdefault(k, 0)
+    count[k] += q
+    return q
+
+
+def export(f):
+    d = os.path.dirname(f)
+    if not os.path.exists(d):
+        os.makedirs(d)
+    if os.path.exists(f):
+        diff(f)
+    with open(f, 'w') as output:
+        output.write(json.dumps(count))
+
+
+def diff(previous_file):
+    previous = json.loads(open(previous_file).read())
+    improvements = []
+    regressions = []
+    for k, v in count.items():
+        if k in previous:
+            v0 = previous[k]
+            if v > v0:
+                regressions.append((k, v0, v))
+            elif v < v0:
+                improvements.append((k, v0, v))
+    if improvements:
+        list_changes(improvements, 'DATABASE PERFORMANCE IMPROVEMENTS')
+    if regressions:
+        list_changes(regressions, 'DATABASE PERFORMANCE REGRESSIONS')
+        print('')
+        print('If there are good reasons for the increase(s) above (e.g. new features), just remove `%s` and carry on. You will not be bothered again.' % previous_file)
+        sys.exit(1)
+
+
+def list_changes(data, title):
+    print('')
+    print(title)
+    print(re.sub('.', '-', title))
+    print('Unit: number of database queries')
+    print('')
+    for k, v0, v in data:
+        print("%s: %d -> %d" % (k, v0, v))

--- a/test/test_architecture.py
+++ b/test/test_architecture.py
@@ -21,6 +21,7 @@ ALLOWED_MODULE_DEPENDENCIES = (
     ('squad.frontend', 'squad.http'),
     ('squad.frontend', 'squad.ci'),
     ('squad.http', 'squad.core'),
+    ('squad.manage', 'test.performance'),
     ('squad.run', 'squad.manage'),
     ('squad.run', 'squad.version'),
     ('squad.plugins', 'squad.core'),


### PR DESCRIPTION
This pull request adds the infrastructure for recording the number of database
queries when executing a set of operations.

Initially queries are counted for frontend tests in
test/frontend/test_basics.py, and for the REST API test in
test/api/test_rest.py. This, however, does not need to be restricted to tests
involving web requests; in the future we can also record query counts for core
operations in isolation.

When executing tests via `./manage.py test`, the query counts are recorded in
JSON format into `tmp/queries.json`, and subsequent runs will check for
improvements and regressions. `tmp/queries.json` is also now read when
collecting metrics to be submitted to qa-reports.linaro.org, so we will de able
to track query counts over time.

The last commit fixes a performce regression in squad/core/comparison.py, and
was verified as an improvement using the infrastructure added in the previous
commits.