### PR TITLE
frontend: Fix test_run's job_id on build page

### DIFF
--- a/squad/frontend/templates/squad/build.html
+++ b/squad/frontend/templates/squad/build.html
@@ -148,7 +148,7 @@
 
 		<div class='col-md-2 col-sm-2' title='Test runs'>
 		    <i class='fa fa-cog'></i>
-		    {{test_run.job_id}}
+		    {{status.test_run.job_id}}
 		</div>
 	    </div>
 	</a>


### PR DESCRIPTION
There was a reference to {{ test_run.job_id }} in a block that
didn't have `test_run` declared. Django just render it as blank.
The correct way here would be {{ status.test_run.job_id }}