### PR TITLE
frontend: fix pagination iterator variable

### DIFF
--- a/squad/frontend/templates/squad/test_run_suite_metrics.html
+++ b/squad/frontend/templates/squad/test_run_suite_metrics.html
@@ -49,6 +49,6 @@
     {% include "squad/_test_run_metric.html" %}
 {% endfor %}
 
-{% include "squad/_pagination.html" with items=tests %}
+{% include "squad/_pagination.html" with items=metrics %}
 
 {% endblock %}


### PR DESCRIPTION
I noticed the upper pagination passed 'metrics' to the include
while the lower pagination passed 'tests', which was probably
ctrl+v'ed from test_run_suite_tests.html