### PR TITLE
frontend: Fix missing changes in Jinja templates

### DIFF
--- a/squad/core/templates/squad/notification/diff.txt.jinja2
+++ b/squad/core/templates/squad/notification/diff.txt.jinja2
@@ -24,7 +24,7 @@ Failures
 {% if summary.failures %}
 {% for env, tests in summary.failures.items() %}{{env}}:
 {% for test in tests %}
-  * {{test.full_name}}{% for issue in known_issues %}{% if issue.test_name == test.full_name %}{% for issue_environment in issue.environment.all %}{% if env == issue_environment.slug %}
+  * {{test.full_name}}{% for issue in known_issues %}{% if issue.test_name == test.full_name %}{% for issue_environment in issue.environment.all() %}{% if env == issue_environment.slug %}
     * Known issue: {{issue.title}}{% if issue.url %} {{issue.url}}{% endif %}{% if issue.intermittent %} (intermittent){% endif %}{% endif %}{% endfor %}{% endif %}{% endfor %}{% endfor %}
 {% endfor %}
 {% else %}

--- a/squad/frontend/templates/squad/_regressions_and_fixes.jinja2
+++ b/squad/frontend/templates/squad/_regressions_and_fixes.jinja2
@@ -1,9 +1,9 @@
-{% with regressions=build.status.get_regressions %}
+{% with regressions=build.status.get_regressions() %}
 {% if regressions %}
 <span>
     <i class="fa fa-exclamation-triangle text-danger popover-hover popover-regressions"></i>
     <span title="Regressions" class="hidden">
-        {% for regression_key, regression_value in regressions.items %}
+        {% for regression_key, regression_value in regressions.items() %}
         <p>Regressions found on <strong>{{ regression_key }}</strong>:</p>
         <ul>
             {% for test in regression_value %}
@@ -16,12 +16,12 @@
 {% endif %}
 {% endwith %}
 
-{% with fixes=build.status.get_fixes %}
+{% with fixes=build.status.get_fixes() %}
 {% if fixes %}
 <span>
     <i class="fa fa-check-circle text-success popover-hover popover-fixes"></i>
     <div title="Fixes" class="hidden">
-        {% for fix_key, fix_value in fixes.items %}
+        {% for fix_key, fix_value in fixes.items() %}
         <p>Fixes found on <strong>{{ fix_key }}</strong>:</p>
         <ul>
             {% for test in fix_value %}

--- a/squad/frontend/templates/squad/_test_run_test.jinja2
+++ b/squad/frontend/templates/squad/_test_run_test.jinja2
@@ -5,7 +5,7 @@
             {{test.name}} — {{test.status|upper}}
         </a>
         {% if test.has_known_issues %}
-        {% for known_issue in test.known_issues.all %}
+        {% for known_issue in test.known_issues.all() %}
             Known issue:
             {% if known_issue.url %}
                 <a href="{{known_issue.url}}">{{known_issue.title}}</a>{% if known_issue.intermittent %} (intermittent){% endif %}.


### PR DESCRIPTION
On Oct 31st there was an error in squad/frontend/templates/squad/_test_run_test.jinja2
where line 8 was still using `test.known_issues.all` instead of `.all()`. Probably because
the tests didn't cover the case where `test.has_known_issues` on line 7 evaluates to true.

I went ahead and found other places with missing that kind of fix