### PR TITLE
Clean up is_pipeline checks.

### DIFF
--- a/doc/ci.rst
+++ b/doc/ci.rst
@@ -119,6 +119,9 @@ Out of the box SQUAD supports following backends:
 LAVA
 ~~~~
 
+SQUAD supports only LAVA v2. Old version of LAVA was made obsolete with 2017.11
+LAVA release.
+
 LAVA backend supports the following settings:
  - CI_LAVA_INFRA_ERROR_MESSAGES
    a list of strings that cause automated job resubmission when matched

--- a/squad/ci/backend/lava.py
+++ b/squad/ci/backend/lava.py
@@ -274,9 +274,6 @@ class Backend(BaseBackend):
         lava_infra_error_messages = []
         if self.settings is not None:
             lava_infra_error_messages = self.settings.get('CI_LAVA_INFRA_ERROR_MESSAGES', [])
-        if data['is_pipeline'] is False:
-            # in case of v1 job, return empty data
-            return (data['status'], {}, {}, {})
         definition = yaml.load(data['definition'])
         if data['multinode_definition']:
             definition = yaml.load(data['multinode_definition'])
@@ -381,8 +378,6 @@ class Backend(BaseBackend):
         if job.name is None:
             # fetch job name once
             data = self.__get_job_details__(lava_id)
-            if data['is_pipeline'] is False:
-                return
             definition = yaml.load(data['definition'])
             if data['multinode_definition']:
                 definition = yaml.load(data['multinode_definition'])

--- a/test/ci/backend/test_lava.py
+++ b/test/ci/backend/test_lava.py
@@ -144,7 +144,6 @@ JOB_DEFINITION_NO_METADATA = {
 }
 
 JOB_DETAILS = {
-    'is_pipeline': True,
     'status': 'Complete',
     'id': 1234,
     'definition': yaml.dump(JOB_DEFINITION),
@@ -152,7 +151,6 @@ JOB_DETAILS = {
 }
 
 JOB_DETAILS_RUNNING = {
-    'is_pipeline': True,
     'status': 'Running',
     'id': 1234,
     'definition': yaml.dump(JOB_DEFINITION),
@@ -160,7 +158,6 @@ JOB_DETAILS_RUNNING = {
 }
 
 JOB_DETAILS_CANCELED = {
-    'is_pipeline': True,
     'status': 'Canceled',
     'id': 1234,
     'definition': yaml.dump(JOB_DEFINITION),
@@ -168,7 +165,6 @@ JOB_DETAILS_CANCELED = {
 }
 
 JOB_DETAILS_NO_METADATA = {
-    'is_pipeline': True,
     'status': 'Complete',
     'id': 1234,
     'definition': yaml.dump(JOB_DEFINITION_NO_METADATA),
@@ -176,7 +172,6 @@ JOB_DETAILS_NO_METADATA = {
 }
 
 JOB_DETAILS_WITH_SUITE_VERSIONS = {
-    'is_pipeline': True,
     'status': 'Complete',
     'id': 1234,
     'definition': yaml.dump({


### PR DESCRIPTION
is_pipeline field is long removed from TestJob object.
Remove obsolete checks in the code.