### PR TITLE
api: add schema for REST API clients

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -287,6 +287,23 @@ patchsources (/api/patchsources/)
 
 Provides access to PatchSource object.
 
+REST API Schema (for CLI)
+-------------------------
+
+SQUAD's API supports API clients. Example is coreapi. In order for client
+to understand the API SQUAD generates schema file. Schema is dynamically
+built and it's available at /api/schema URL. Example usage with coreapi-cli:
+
+::
+
+  coreapi get https://<host_tld>/api/schema
+  coreapi action projects list
+
+More details about coreapi can be found on coreapi website and DRF website:
+
+ * http://www.coreapi.org/
+ * https://www.django-rest-framework.org/topics/api-clients/
+
 Badges
 ------
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 celery
+coreapi
 Django>=1.11,<1.12
 django-cors-headers
 django-simple-history

--- a/squad/api/rest.py
+++ b/squad/api/rest.py
@@ -139,6 +139,9 @@ class API(routers.APIRootView):
       the project in question.
 
     * All URLs displayed in this API browser are clickable.
+
+    * Client interaction is enabled with <a href="/api/schema/">/api/schema</a>
+    URL.
     """
 
     def get_view_name(self):

--- a/squad/api/urls.py
+++ b/squad/api/urls.py
@@ -1,6 +1,6 @@
 from django.conf.urls import include, url
 from django.shortcuts import redirect
-
+from rest_framework.schemas import get_schema_view
 
 from . import views
 from . import data
@@ -11,8 +11,11 @@ from . import rest
 from squad.core.models import slug_pattern
 
 
+schema_view = get_schema_view(title="SQUAD API")
+
 urlpatterns = [
     url(r'^', include(rest.router.urls)),
+    url(r'^schema/', schema_view),
     url(r'^auth/', include('rest_framework.urls', namespace='rest_framework')),
     url(r'^createbuild/(%s)/(%s)/(%s)' % ((slug_pattern,) * 3), views.create_build),
     url(r'^submit/(%s)/(%s)/(%s)/(%s)' % ((slug_pattern,) * 4), views.add_test_run),


### PR DESCRIPTION
In order to support standard clients SQUAD offers an API schema that is
used to describe the interface endpoints.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>