### PR TITLE
api: add 'force' parameter to /build/<ID>/report

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -209,6 +209,7 @@ following additional routes:
   - template - ID of the EmailTemplate to be used
   - baseline - ID of the Build object to be used as comparison baseline. The default
     is "previous finished" build in the same project.
+  - force - if set to true invalidates cached object. Default is false
 
 - report (/api/build/<id>/report/)
 
@@ -243,6 +244,7 @@ following additional routes:
     call. It is recommended to send this option usig POST request to avoid password
     leakage.
   - keep - number of days to keep the cached reports in the database
+  - force - if set to true invalidates cached object. Default is false
 
 With enough privileges Builds can also be created, modified and deleted
 using REST API with POST, PUT and DELETE HTTP requests respectively. This is

--- a/squad/api/rest.py
+++ b/squad/api/rest.py
@@ -635,8 +635,9 @@ class BuildViewSet(ModelViewSet):
 
     @detail_route(methods=['get', 'post'], suffix='report', permission_classes=[AllowAny])
     def report(self, request, pk=None):
+        force = request.query_params.get("force", False)
         delayed_report, created = self.__return_delayed_report(request)
-        if created:
+        if created or force:
             prepare_report.delay(delayed_report.pk)
         data = {"message": "OK", "url": rest_reverse('delayedreport-detail', args=[delayed_report.pk], request=request)}
         return Response(data, status=status.HTTP_202_ACCEPTED)


### PR DESCRIPTION
This patch adds 'force' option to 'report' API. Force has the same
effect as in case of 'email' api - it invalidates the cached object and
forces re-calculation.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>