### PR TITLE
api: fix reverse for baseline in DelayedReport object

### DIFF
--- a/squad/api/rest.py
+++ b/squad/api/rest.py
@@ -481,6 +481,7 @@ class PatchSourceViewSet(viewsets.ModelViewSet):
 
 class DelayedReportSerializer(serializers.HyperlinkedModelSerializer):
     id = serializers.IntegerField(read_only=True)
+    baseline = serializers.HyperlinkedIdentityField(view_name='build-status')
 
     class Meta:
         model = DelayedReport

--- a/test/api/test_rest.py
+++ b/test/api/test_rest.py
@@ -215,6 +215,7 @@ class RestApiTest(TestCase):
         self.assertIsNone(report_object.status_code)
         self.assertEqual(report_object.baseline, self.build.status)
         prepare_report_mock.assert_called()
+        self.hit(response.json()['url'])  # should not crash
 
     @patch('squad.core.tasks.prepare_report.delay')
     def test_build_report_retry(self, prepare_report_mock):


### PR DESCRIPTION
Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>