### PR TITLE
api: fix DelayedReport baseline to point to proper object

### DIFF
--- a/squad/api/rest.py
+++ b/squad/api/rest.py
@@ -481,7 +481,10 @@ class PatchSourceViewSet(viewsets.ModelViewSet):
 
 class DelayedReportSerializer(serializers.HyperlinkedModelSerializer):
     id = serializers.IntegerField(read_only=True)
-    baseline = serializers.HyperlinkedIdentityField(view_name='build-status')
+    baseline = serializers.HyperlinkedRelatedField(
+        view_name='build-status',
+        read_only=True,
+        many=False)
 
     class Meta:
         model = DelayedReport


### PR DESCRIPTION
By using HyperlinkedRelatedField instead of HyperlinkedIdentityField
baseline field points to the proper ProjectStatus object.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>