### PR TITLE
core/notification.py: turn off escaping for text emails

### DIFF
--- a/squad/core/notification.py
+++ b/squad/core/notification.py
@@ -107,6 +107,7 @@ class Notification(object):
             template = custom_email_template.subject
         else:
             template = '{{project}}: {{tests_total}} tests, {{tests_fail}} failed, {{tests_pass}} passed (build {{build}})'
+
         return jinja2.from_string(template).render(subject_data)
 
     def message(self, do_html=True, custom_email_template=None):

--- a/squad/core/templatetags/squad_notification.py
+++ b/squad/core/templatetags/squad_notification.py
@@ -1,4 +1,3 @@
-from squad.core.utils import format_metadata
 from squad.jinja2 import register_global_function, register_filter
 
 
@@ -37,7 +36,5 @@ def tabulate_test_comparison(comparison, test_results=None):
 
 @register_filter
 def metadata_txt(v, key=None):
-    separator = " "
-    if key:
-        separator = "\n" + " " * (len(key) + 2)
-    return format_metadata(v, separator)
+    separator = ("\n" + " " * (len(key) + 2)) if key else " "
+    return separator.join(v) if type(v) is list else v

--- a/squad/jinja2.py
+++ b/squad/jinja2.py
@@ -1,5 +1,5 @@
 from importlib import import_module
-from jinja2 import Environment
+from jinja2 import Environment, select_autoescape
 from django.contrib.staticfiles.storage import staticfiles_storage
 from django.utils import translation
 
@@ -38,6 +38,10 @@ def environment(**options):
     env.filters.update(_local_env['filters'])
     env.tests.update(_local_env['tests'])
     env.install_gettext_translations(translation)
+    env.autoescape = select_autoescape(
+        disabled_extensions=('txt.jinja2',),
+        default_for_string=False,
+        default=True)
     return env
 
 


### PR DESCRIPTION
By default Django/Jinja2 escapes some caracters, e.g. ' and & to html
entities. That troubles subject content and text emails with escaped characters.

Now the behavior works as follows:
1. if template comes from string: do not escape
2. if template comes from a file and filename endswith ```.txt.jinja2```: do not escape
3. else: escape