### PR TITLE
docs: add step-by-step on how to set up SQUAD with LAVA

### DIFF
--- a/doc/ci.rst
+++ b/doc/ci.rst
@@ -7,7 +7,7 @@ CI: continous integration support
 CI module in SQUAD
 ------------------
 
-Thissubsystem has the following features:
+This subsystem has the following features:
 
 * receiving test job requests
 * submitting test job requests to test execution backends
@@ -35,7 +35,7 @@ So for example you can have multiple backends of the same type (e.g. different
 2 LAVA servers).
 
 For the CI loop integration to work, you need to run a few extra
-processes beyond the web interface. See :ref:`install_python` for details.
+processes beyond the web interface. See :ref:`production_install_ref_label` for details.
 
 .. _ci_job_ref_label:
 
@@ -44,9 +44,9 @@ Submitting test job requests
 
 The API is the following
 
-**POST** /api/submitjob/:team/:project/:build/:environment
+**POST** /api/submitjob/:group/:project/:build/:environment
 
-* ``team``, ``project``, ``build`` and ``environment`` are used to
+* ``group``, ``project``, ``build`` and ``environment`` are used to
   identify which project/build/environment will be used to record the
   results of the test job.
 * The following data must be submitted as POST parameters:
@@ -64,7 +64,7 @@ Example (with test job definition as POST parameter)::
         --header "Auth-Token: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" \
         --form backend=lava \
         --form definition="$DEFINITION" \
-        https://squad.example.com/api/submitjob/my-team/my-project/x.y.z/my-ci-env
+        https://squad.example.com/api/submitjob/my-group/my-project/x.y.z/my-ci-env
 
 Example (with test job definition as file upload)::
 
@@ -72,7 +72,7 @@ Example (with test job definition as file upload)::
         --header "Auth-Token: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" \
         --form backend=lava \
         --form definition=@/path/to/definition.txt \
-        https://squad.example.com/api/submitjob/my-team/my-project/x.y.z/my-ci-env
+        https://squad.example.com/api/submitjob/my-group/my-project/x.y.z/my-ci-env
 
 .. _ci_watch_ref_label:
 
@@ -84,9 +84,9 @@ that some other service submitted the test job for execution and SQUAD is
 requested to track the progress. After test job is finished SQUAD will retrieve
 the results and do post processing. The API is following:
 
-**POST** /api/submitjob/:team/:project/:build/:environment
+**POST** /api/submitjob/:group/:project/:build/:environment
 
-* ``team``, ``project``, ``build`` and ``environment`` are used to
+* ``group``, ``project``, ``build`` and ``environment`` are used to
   identify which project/build/environment will be used to record the
   results of the test job.
 * The following data must be submitted as POST parameters:
@@ -102,7 +102,9 @@ Example (with test job definition as POST parameter)::
         --header "Auth-Token: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" \
         --form backend=lava \
         --form testjob_id=123456 \
-        https://squad.example.com/api/watchjob/my-team/my-project/x.y.z/my-ci-env
+        https://squad.example.com/api/watchjob/my-group/my-project/x.y.z/my-ci-env
+
+.. _`backend_settings_ref_label`:
 
 Backend settings
 ----------------

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -50,7 +50,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'SQUAD'
-copyright = '2016-2017, Linaro Limited'
+copyright = '2016-2019, Linaro Limited'
 author = 'Linaro'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -17,6 +17,7 @@ SQUAD — Software Quality Dashboard
    install
    ci
    api
+   lava_usecase
 
 Indices and tables
 ==================

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -1,16 +1,17 @@
+.. _production_install_ref_label:
+
 =====================================================
 Installation Instructions for production environments
 =====================================================
-
-.. _install_python:
 
 Installation using the Python package manager pip
 -------------------------------------------------
 
 Make sure you have the ``pip`` Python package manager installed on your Python 3
-environment. On Debian/Ubuntu, the easiest way to do that is::
+environment, and the C library for YAML development. On Debian/Ubuntu,
+the easiest way to do that is::
 
-    apt-get install python3-pip
+    apt-get install python3-pip libyaml-dev
 
 Install squad::
 
@@ -25,7 +26,7 @@ need to install an AMQP server. We recommend RabbitMQ::
     apt-get install rabbitmq-server
 
 By default SQUAD will look for an AMQP server running on localhost, listening
-to the standard port,, so for a single-server deployment you don't need to do
+to the standard port, so for a single-server deployment you don't need to do
 anything else.
 
 If you have a multi-server setup, then each server needs to be configured with
@@ -47,6 +48,8 @@ application as ``root``!)::
 
     squad
 
+* Note: if that doesn't work, ``~/.local/bin`` is probably missing in the ``$PATH`` environment variable.
+
 This will make the web UI available at http://localhost:8000/. To serve the UI
 to external users, you will need to setup a public-facing web server such as
 Apache or nginx and reverse proxy to localhost on port 8000. You can change the
@@ -65,9 +68,9 @@ an admin user for yourself, use::
 
 These are the command lines to run the other processes:
 
-+-----------+----------------------------
-| Process   | Command                   |
 +-----------+---------------------------+
+| Process   | Command                   |
++===========+===========================+
 | worker    | celery -A squad worker    |
 +-----------+---------------------------+
 | scheduler | celery -A squad beat      |

--- a/doc/intro.rst
+++ b/doc/intro.rst
@@ -19,7 +19,7 @@ Core data model
               |ProjectStatus|-+       |Environment|
               +-------------+         +-----------+
 
-SQUAD is multi-team and multi-project. Each team can have multiple
+SQUAD is multi-group and multi-project. Each group can have multiple
 projects. For each project, you can have multiple builds, and for each
 build, multiple test runs. Each test run can include multiple test
 results, which can be either pass/fail results, or metrics, containing
@@ -47,9 +47,9 @@ Submitting results
 
 The API is the following
 
-**POST** /api/submit/:team/:project/:build/:environment
+**POST** /api/submit/:group/:project/:build/:environment
 
--  ``:team`` is the team identifier. It must exist previously.
+-  ``:group`` is the group identifier. It must exist previously.
 -  ``:project`` is the project identifier. It must exist previously.
 -  ``:build`` is the build identifier. It can be a git commit hash, a
    Android manifest hash, or anything really. Extra information on the
@@ -58,7 +58,7 @@ The API is the following
 -  ``:environment`` is the environmenr identitifer. It will be created
    automatically if does not exist before.
 
-All of the above identifiers (``:team``, ``:project``, ``:build``, and
+All of the above identifiers (``:group``, ``:project``, ``:build``, and
 ``:environment``) must match the regular expression
 ``[a-zA-Z0-9][a-zA-Z0-9_.-]*``.
 
@@ -84,7 +84,7 @@ Example with test data as file uploads::
         --form log=@/path/to/log.txt \
         --form attachment=@/path/to/screenshot.png \
         --form attachment=@/path/to/extra-info.txt \
-        https://squad.example.com/api/submit/my-team/my-project/x.y.z/my-ci-env
+        https://squad.example.com/api/submit/my-group/my-project/x.y.z/my-ci-env
 
 Example with test data as regular ``POST`` parameters::
 
@@ -96,7 +96,7 @@ Example with test data as regular ``POST`` parameters::
         --form log='log text ...' \
         --form attachment=@/path/to/screenshot.png \
         --form attachment=@/path/to/extra-info.txt \
-        https://squad.example.com/api/submit/my-team/my-project/x.y.z/my-ci-env
+        https://squad.example.com/api/submit/my-group/my-project/x.y.z/my-ci-env
 
 Since test results should always come from automation systems, the API
 is the only way to submit results into the system. Even manual testing

--- a/doc/lava_usecase.rst
+++ b/doc/lava_usecase.rst
@@ -1,0 +1,92 @@
+===============================
+Use case: setup SQUAD with LAVA
+===============================
+
+Introduction
+------------
+
+Once SQUAD installation is complete, a typical use case would be integrating
+it with a LAVA instance. The purpose of this use case is to describe a
+step-by-step set up of SQUAD with LAVA to submit and fetch jobs. If you haven't
+yet set up SQUAD, take a step back and follow :ref:`production_install_ref_label`
+
+
+Setting up a LAVA instance
+--------------------------
+
+LAVA has its own extensive documentation on how to get a server up and running.
+If you don't have it already, please refer to `LAVA installation`_ to configure
+yourself one. From this point it's taken that you have enough access to a
+running LAVA v2 instance that jobs can be submitted to and fetched from.
+
+
+:Note:
+ Make sure that your LAVA instance has ``event notifications`` enabled,
+ as it is disabled by default. See `LAVA event notifications`_ for details.
+
+
+.. _`LAVA installation`: https://validation.linaro.org/static/docs/v2/installing_on_debian.html#debian-installation
+.. _`LAVA authentication tokens`: https://validation.linaro.org/static/docs/v2/first_steps.html?highlight=token#authentication-tokens
+.. _`LAVA event notifications`: https://validation.linaro.org/static/docs/v2/data-export.html#event-notifications
+
+
+Creating a Backend for a LAVA instance
+--------------------------------------
+
+Log in into SQUAD admin view (``/admin``) and access ``ci > backends > add backend``
+for inclusion form. Fill up accordingly:
+
+- name: name of the backend. Example: validation.linaro.org
+- url: LAVA RPC2 endpoint, it's how SQUAD will communicate with LAVA. Example: https://validation.linaro.org/RPC2
+- username: a LAVA user with enough access to submit jobs
+- token: a generated token for the user above, used to securely connect to the LAVA instance. See `LAVA authentication tokens`_ for details
+- implementation type: leave it as ``lava``
+- backend settings: used to spare specific settings for LAVA instances. For details see :ref:`backend_settings_ref_label` 
+- poll interval: number of minutes to wait before fetching a job from LAVA
+- max fetch attempts: max number of times SQUAD will attempt to fetch a job from LAVA
+- poll enabled: if this is disabled SQUAD will not try to poll jobs from LAVA 
+
+
+Creating a Project in SQUAD
+---------------------------
+
+SQUAD needs minimal data to start working with LAVA: Group and Project.
+By logging in the admin view, go to ``core > groups > add`` to add a new
+group and ``core > projects > add`` to add a new project. These are trivial
+to create, but please feel free to contact us if any help is needed.
+
+
+Submitting and fetching test jobs
+---------------------------------
+
+Given that all steps above are working correctly, you are ready to submit your
+first job through SQUAD. You can learn from LAVA documentation how to write
+new test definitions or use existing ones. For the sake of simplicity,
+we'll stick to `LAVA's example of first job`_ and use it to call SQUAD
+api for submitting a new test job::
+
+    wget https://validation.linaro.org/static/docs/v2/examples/test-jobs/qemu-pipeline-first-job.yaml
+    curl localhost:8000/api/submitjob/<group-slug>/<project-slug>/<build-version>/<env> \
+         --header "Auth-Token: <squad-token>" \
+         --form "backend: <backend-name>" \
+         --form "definition=@qemu-pipeline-first-job.yaml"
+
+Where ``group-slug`` and ``project-slug`` are the ones created in steps above, whereas
+``build-version`` and ``env`` do not need to exist before submitting a job. For clarification ``buid-version``
+is usually a git-commit hash and ``env`` is commonly the board target that a job is running.
+Although it's not covered in this tutorial, creating a ``squad-token`` is straightforward, do so
+by logging into admin view and go to ``auth token > tokens > add`` to add an auth token for a user.
+Lastly, ``backend-name`` is the one created in the sections above.
+
+
+.. _`LAVA's example of first job`: https://validation.linaro.org/static/docs/v2/first-job.html
+
+Extra use cases
+---------------
+
+The example above showed a simplistic SQUAD instance working along with a LAVA
+one. More can be done by using SQUAD's backend API to transform it into a proxy
+between a CI system (e.g. Jenkins) and a LAVA server. An instance of SQUAD is
+currently running at https://qa-reports.linaro.org and its set up is fully
+automated through ansible scripts at https://github.com/Linaro/qa-reports.linaro.org.
+

--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -5,9 +5,14 @@ Quick start: Running SQUAD locally
 SQUAD is a Django application and works just like any other Django
 application. If you are new to Django and want to setup a development
 environment, you can follow the instructions below. If you want to
-install SQUAD for production usage, see [INSTALL](INSTALL.rst) instead.
+install SQUAD for production usage, see :ref:`production_install_ref_label` instead.
 
 Note that SQUAD is Python3-only, so it won't work with Python 2.
+
+Before moving on, there's a system dependency needed for Python to load yaml content
+with the C library, install it with::
+
+    apt-get install libyaml-dev
 
 To install the dependencies::
 


### PR DESCRIPTION
It closes #441 and also:
- fixes small typos
- changes `team` for `group`
- fixes processes table
- adds documentation to install libyaml-dev before installing SQUAD dependencies