### PR TITLE
test: fix detection of test failures in custom test runner

### DIFF
--- a/squad/core/tasks/__init__.py
+++ b/squad/core/tasks/__init__.py
@@ -73,7 +73,7 @@ class ValidateTestRun(object):
         if "job_id" not in metadata.keys():
             raise exceptions.InvalidMetadata("job_id is mandatory in metadata")
         elif '/' in metadata['job_id']:
-                raise exceptions.InvalidMetadata('job_id cannot contain the "/" character')
+            raise exceptions.InvalidMetadata('job_id cannot contain the "/" character')
 
     def __validate_metrics(self, metrics_file):
         try:

--- a/squad/jinja2.py
+++ b/squad/jinja2.py
@@ -99,5 +99,5 @@ def _load_django_default_filters():
         for tupl in all_funcs:
             name, func = tupl
 
-            if name[0] is not '_' and func.__module__ == mod.__name__:
+            if name[0] != '_' and func.__module__ == mod.__name__:
                 register_filter(func)

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -38,4 +38,4 @@ class Runner(DiscoverRunner):
 
     def suite_result(self, suite, result, **kwargs):
         write_results(result)
-        super(Runner, self).suite_result(suite, result, **kwargs)
+        return super(Runner, self).suite_result(suite, result, **kwargs)


### PR DESCRIPTION
That missing `return` was causing the test process to return 0 even when
some tests failed.