### PR TITLE
reduce RAM usage when processing new test results

### DIFF
--- a/squad/core/comparison.py
+++ b/squad/core/comparison.py
@@ -77,6 +77,7 @@ class TestComparison(object):
             self.all_environments.add(str(environment))
             self.environments[build].add(str(environment))
             self.__extract_test_results__(test_run)
+        self.results = OrderedDict(sorted(self.results.items()))
         for build in self.builds:
             self.environments[build] = sorted(self.environments[build])
 
@@ -90,7 +91,6 @@ class TestComparison(object):
                 if issue.intermittent:
                     env = str(test_run.environment)
                     self.__intermittent__[(test.full_name, env)] = True
-        self.results = OrderedDict(sorted(self.results.items()))
 
     __diff__ = None
 

--- a/squad/core/comparison.py
+++ b/squad/core/comparison.py
@@ -46,7 +46,6 @@ class TestComparison(object):
         self.results = OrderedDict()
         self.__intermittent__ = {}
 
-        models.Build.prefetch_related(self.builds)
         self.__extract_results__()
 
     @classmethod

--- a/squad/core/models.py
+++ b/squad/core/models.py
@@ -229,18 +229,6 @@ class Build(models.Model):
     def __str__(self):
         return '%s (%s)' % (self.version, self.datetime)
 
-    @staticmethod
-    def prefetch_related(builds):
-        prefetch_related_objects(
-            builds,
-            'project',
-            'project__group',
-            'test_runs',
-            'test_runs__environment',
-            'test_runs__tests',
-            'test_runs__tests__suite',
-        )
-
     def prefetch(self, *related):
         prefetch_related_objects([self], *related)
 

--- a/test/performance.py
+++ b/test/performance.py
@@ -18,11 +18,20 @@ def count_queries(k):
         reset_queries()
         yield
         q = len(connection.queries)
+        log_queries(k, connection.queries)
     finally:
         settings.DEBUG = debug
     count.setdefault(k, 0)
     count[k] += q
     return q
+
+
+def log_queries(k, queries):
+    os.makedirs('tmp/queries', exist_ok=True)
+    with open('tmp/queries/%s.log' % re.sub('/', '_', k), 'w') as log:
+        for query in connection.queries:
+            log.write(repr(query))
+            log.write("\n")
 
 
 def export(f):

--- a/test/performance.py
+++ b/test/performance.py
@@ -41,8 +41,9 @@ def export(f):
     rc = 0
     if os.path.exists(f):
         rc = diff(f)
-    with open(f, 'w') as output:
-        output.write(json.dumps(count))
+    if rc == 0:
+        with open(f, 'w') as output:
+            output.write(json.dumps(count))
     return rc
 
 


### PR DESCRIPTION
These commits reduce a lot the RAM consumption when receiving new test results.
The main culprit is the TestComparison class, which used to load every single
test object to RAM at once. That just does not work with hundreds of thousands
of tests.