### PR TITLE
frontend: regressions and fixes need to be in copy-pastable

### DIFF
--- a/squad/frontend/static/main.css
+++ b/squad/frontend/static/main.css
@@ -314,3 +314,11 @@ table.test-results-details {
     border-color: #466086;
     -moz-border-radius: 0; -webkit-border-radius: 0; border-radius: 0;
 }
+
+.popover-regressions-fixes {
+    background:none!important;
+    float:none!important;
+    border:none;
+    padding:0!important;
+    cursor:pointer;
+}

--- a/squad/frontend/static/squad/common.js
+++ b/squad/frontend/static/squad/common.js
@@ -1,10 +1,24 @@
-// enable popovers that need to trigger on mouse hovers
+// enable popovers that need to trigger on mouse click
 $(document).ready(function(){
-    $('.popover-hover').popover({
-            trigger: 'hover',
-            container: 'body',
-            html: true,
-            title: function() { return $(this).parent().find('.hidden').attr('title') },
-            content: function() { return $(this).parent().find('.hidden').html() }
+    $('.popover-regressions-fixes').popover({
+        trigger: 'click',
+        container: 'body',
+        html: true,
+        title: function() { return $(this).parent().find('.hidden').attr('title') + '<button type="button" class="close close-popover">&times;</button>' },
+        content: function() { return $(this).parent().find('.hidden').html() }
+    }).click(function(event) {
+        // Prevent parent events triggering.
+        event.preventDefault();
+    }).on('show.bs.popover', function () {
+        // Hide all other popovers.
+        $(".popover-regressions-fixes").not(this).popover('hide');
     });
+
+    // Find and simulate click on the button because manully closing popover
+    // does not work properly.
+    $('body').on("click", ".close-popover", function(event) {
+        $('[aria-describedby="' + $(this).parent().parent().attr("id") + '"]').click();
+    });
+
+    $('[data-toggle="tooltip"]').tooltip({"trigger": "hover"});
 });

--- a/squad/frontend/templates/squad/_regressions_and_fixes.jinja2
+++ b/squad/frontend/templates/squad/_regressions_and_fixes.jinja2
@@ -1,7 +1,7 @@
 {% with regressions=build.status.get_regressions() %}
 {% if regressions %}
-<span>
-    <i class="fa fa-exclamation-triangle text-danger popover-hover popover-regressions"></i>
+<span data-toggle="tooltip" title="Click to display regressions">
+    <button class="fa fa-exclamation-triangle text-danger popover-regressions-fixes"></button>
     <span title="Regressions" class="hidden">
         {% for regression_key, regression_value in regressions.items() %}
         <p>Regressions found on <strong>{{ regression_key }}</strong>:</p>
@@ -18,8 +18,8 @@
 
 {% with fixes=build.status.get_fixes() %}
 {% if fixes %}
-<span>
-    <i class="fa fa-check-circle text-success popover-hover popover-fixes"></i>
+<span data-toggle="tooltip" title="Click to display fixes">
+    <button class="fa fa-check-circle text-success popover-regressions-fixes"></button>
     <div title="Fixes" class="hidden">
         {% for fix_key, fix_value in fixes.items() %}
         <p>Fixes found on <strong>{{ fix_key }}</strong>:</p>


### PR DESCRIPTION
Leave popover hanging so user can select and copy-paste the
text within. The popover will close on next click on the
regression/fixes button.