### PR TITLE
frontend: support groups and project with empty name

### DIFF
--- a/squad/core/models.py
+++ b/squad/core/models.py
@@ -40,7 +40,14 @@ class GroupManager(models.Manager):
         return self.filter(id__in=group_ids).annotate(project_count=Count('projects', filter=Q(id__in=project_ids)))
 
 
-class Group(models.Model):
+class DisplayName(object):
+
+    @property
+    def display_name(self):
+        return self.name or self.slug
+
+
+class Group(models.Model, DisplayName):
     objects = GroupManager()
 
     slug = models.CharField(max_length=100, unique=True, validators=[slug_validator], db_index=True)
@@ -84,7 +91,7 @@ class EmailTemplate(models.Model):
         return self.name
 
 
-class Project(models.Model):
+class Project(models.Model, DisplayName):
     objects = ProjectManager()
 
     group = models.ForeignKey(Group, related_name='projects')

--- a/squad/frontend/templates/squad/_project_list.jinja2
+++ b/squad/frontend/templates/squad/_project_list.jinja2
@@ -5,7 +5,7 @@
     <a href="{{project_url(project)}}">
     <div class="col-md-4 col-sm-4">
         <strong>
-            {% if not hide_group %}{{project.group.name}}/{% endif %}{{project.name}}
+            {% if not hide_group %}{{project.group.display_name}}/{% endif %}{{project.display_name}}
         </strong>
         {% if project.description%}
         <div class='description-{{project.id}}'>

--- a/squad/frontend/templates/squad/build-nav.jinja2
+++ b/squad/frontend/templates/squad/build-nav.jinja2
@@ -1,6 +1,6 @@
 <h2 class="page-header well">
-    <a class="h2 text-primitive" href="{{group_url(project.group)}}">{{project.group.name}}</a>
-    » <a class="h2 text-primitive" href="{{project_url(project)}}">{{project.name}}</a>
+    <a class="h2 text-primitive" href="{{group_url(project.group)}}">{{project.group.display_name}}</a>
+    » <a class="h2 text-primitive" href="{{project_url(project)}}">{{project.display_name}}</a>
     » {% include "squad/_unfinished_build.jinja2" %} <a class="h2 text-primary" href="{{build_url(build)}}">Build {{build.version}}</a>
 </h2>
 

--- a/squad/frontend/templates/squad/group.jinja2
+++ b/squad/frontend/templates/squad/group.jinja2
@@ -1,7 +1,7 @@
 {% extends "squad/base.jinja2" %}
 
 {% block content %}
-<h2 class="page-header well">{{group.name}}</h2>
+<h2 class="page-header well">{{group.display_name}}</h2>
 
 <p>
 {{group.description|default("")}}

--- a/squad/frontend/templates/squad/index.jinja2
+++ b/squad/frontend/templates/squad/index.jinja2
@@ -9,7 +9,7 @@
     <a href="{{group_url(group)}}">
     <div class="col-md-3 col-sm-3">
         <strong>
-            {{group.name}}
+            {{group.display_name}}
         </strong>
     </div>
     <div class="col-md-6 col-sm-6">

--- a/squad/frontend/templates/squad/project-nav.jinja2
+++ b/squad/frontend/templates/squad/project-nav.jinja2
@@ -1,6 +1,6 @@
 <h2 class="page-header well">
-  <a class="h2 text-primitive" href="{{group_url(project.group) }}">{{project.group.name}}</a>
-  » <a class="h2 text-primary" href="{{project_url(project)}}">{{project.name}}</a>
+  <a class="h2 text-primitive" href="{{group_url(project.group) }}">{{project.group.display_name}}</a>
+  » <a class="h2 text-primary" href="{{project_url(project)}}">{{project.display_name}}</a>
   {{pagetitle|default("")}}
 </h1>
 <ul class="page-header nav nav-pills">

--- a/squad/frontend/templates/squad/test_history.jinja2
+++ b/squad/frontend/templates/squad/test_history.jinja2
@@ -3,8 +3,8 @@
 {% block content %}
 
   <h2 class="page-header well">
-    <a class="h2 text-primitive" href="{{group_url(project.group)}}">{{project.group.name}}</a>
-    » <a class="h2 text-primitive" href="{{project_url(project)}}">{{project.name}}</a>
+    <a class="h2 text-primitive" href="{{group_url(project.group)}}">{{project.group.display_name}}</a>
+    » <a class="h2 text-primitive" href="{{project_url(project)}}">{{project.display_name}}</a>
     »
     {{history.test}}
     {% if request.GET.top %}

--- a/squad/frontend/templates/squad/test_run.jinja2
+++ b/squad/frontend/templates/squad/test_run.jinja2
@@ -3,8 +3,8 @@
 {% block content %}
 
 <h2 class="page-header well">
-    <a class="h2 text-primitive" href="{{group_url(project.group)}}">{{project.group.name}}</a>
-    » <a class="h2 text-primitive" href="{{project_url(project)}}">{{project.name}}</a>
+    <a class="h2 text-primitive" href="{{group_url(project.group)}}">{{project.group.display_name}}</a>
+    » <a class="h2 text-primitive" href="{{project_url(project)}}">{{project.display_name}}</a>
     » <a class="h2 text-prmitive" href="{{build_url(build)}}">{{build.version}}</a>
     » <a class="h2 text-primary" href="{{project_url(test_run)}}">{{test_run.job_id}} </a>
     <br>

--- a/squad/frontend/templates/squad/test_run_suite_metrics.jinja2
+++ b/squad/frontend/templates/squad/test_run_suite_metrics.jinja2
@@ -2,8 +2,8 @@
 {% block content %}
 
 <h2 class="page-header well">
-    <a class="h2 text-primitive" href="{{group_url(project.group)}}">{{project.group.name}}</a>
-    » <a class="h2 text-primitive" href="{{project_url(project)}}">{{project.name}}</a>
+    <a class="h2 text-primitive" href="{{group_url(project.group)}}">{{project.group.display_name}}</a>
+    » <a class="h2 text-primitive" href="{{project_url(project)}}">{{project.display_name}}</a>
     » <a class="h2 text-primitive" href="{{build_url(build)}}">Build {{build.version}}</a>
     » <a class="h2 text-primitive" href="{{project_url(test_run)}}">Test run {{test_run.job_id}}</a>
     » Test results for {{suite.slug}}

--- a/squad/frontend/templates/squad/test_run_suite_tests.jinja2
+++ b/squad/frontend/templates/squad/test_run_suite_tests.jinja2
@@ -2,8 +2,8 @@
 {% block content %}
 
 <h2 class="page-header well">
-    <a class="h2 text-primitive" href="{{group_url(project.group)}}">{{project.group.name}}</a>
-    » <a class="h2 text-primitive" href="{{project_url(project)}}">{{project.name}}</a>
+    <a class="h2 text-primitive" href="{{group_url(project.group)}}">{{project.group.display_name}}</a>
+    » <a class="h2 text-primitive" href="{{project_url(project)}}">{{project.display_name}}</a>
     » <a class="h2 text-primitive" href="{{build_url(build)}}"> {{build.version}}</a>
     » <a class="h2 text-primitive" href="{{project_url(test_run)}}">{{test_run.job_id}}</a>
     » <a class="h2 text-primary" href="{{project_url(test_run)}}">{{suite}}</a>

--- a/squad/frontend/templates/squad/user_settings/subscriptions.jinja2
+++ b/squad/frontend/templates/squad/user_settings/subscriptions.jinja2
@@ -14,9 +14,9 @@
     <div class="col-md-10">
       <select id="project_subscriptions" name="subscription" style="width: 100%;">
         {% for group in groups %}
-        <optgroup label="{{ group.name }}">
+        <optgroup label="{{ group.display_name }}">
           {% for project in group.projects.all() %}
-          <option value="{{ project.id }}">{{ project.name }}</option>
+          <option value="{{ project.id }}">{{ project.display_name }}</option>
         {% endfor %}
         </optgroup>
         {% endfor %}
@@ -40,7 +40,7 @@
 <p style="margin-top: 10px;">Your current subscriptions:</p>
 {% if subscriptions %}
 {% for sub in subscriptions %}
-<pre>{{ sub.project.group.name }}/{{ sub.project.name }} ({{ sub.notification_strategy }})
+<pre>{{ sub.project.group.display_name }}/{{ sub.project.display_name }} ({{ sub.notification_strategy }})
   <a href="{{url('settings-subscription-remove', args=[sub.id])}}" class="btn btn-xs btn-danger btn-group-vertical pull-right" title="Remove subscription">
     <span class="glyphicon glyphicon-trash"></span>
   </a>


### PR DESCRIPTION
The field name is optional for both group and project created through
the API or via the command line. But groups and projects with empty
names are displayed as `None` throughout the UI.

This patches changes all instances of `group.name` and `project.name` to
use a new `display_name` property, which will fallback to the slug in
case the name is empty.