### PR TITLE
celery: set maximum number of producer connection attempts

### DIFF
--- a/squad/settings.py
+++ b/squad/settings.py
@@ -258,6 +258,9 @@ SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
 # Celery settings
 CELERY_BROKER_URL = os.getenv('SQUAD_CELERY_BROKER_URL')
+CELERY_BROKER_TRANSPORT_OPTIONS = {
+    'max_retries': 5,
+}
 CELERY_ACCEPT_CONTENT = ['json', 'msgpack', 'yaml']
 CELERY_TASK_SERIALIZER = 'msgpack'
 CELERY_BEAT_SCHEDULE = {


### PR DESCRIPTION
This avoids waiting forever when a connection to RabbitMQ cannot be
established.

Fixes #478