### PR TITLE
Add build settings tab

### DIFF
--- a/squad/core/models.py
+++ b/squad/core/models.py
@@ -248,8 +248,15 @@ class Build(models.Model):
     def __str__(self):
         return '%s (%s)' % (self.version, self.datetime)
 
+    def __get_help_text(self, field):
+        return self._meta.get_field(field).help_text
+
     def prefetch(self, *related):
         prefetch_related_objects([self], *related)
+
+    @property
+    def keep_data_help_text(self):
+        return self.__get_help_text('keep_data')
 
     @property
     def test_summary(self):

--- a/squad/frontend/static/squad/build.js
+++ b/squad/frontend/static/squad/build.js
@@ -1,9 +1,12 @@
 import {AnnotationController} from './controllers/annotation.js'
+import {BuildSettingsController} from './controllers/buildSettings.js'
 import {FilterController} from './controllers/filter.js'
 import {ResubmitController} from './controllers/resubmit.js'
 import {Config as appConfig} from './config.js'
 
 var app = angular.module('Build', []);
+
+app.value('build', window.build);
 
 appConfig(app, ['httpProvider']);
 
@@ -14,6 +17,16 @@ app.controller(
         '$http',
         '$httpParamSerializerJQLike',
         AnnotationController
+    ]
+)
+
+app.controller(
+    'BuildSettingsController',
+    [
+        '$scope',
+        '$http',
+        'build',
+        BuildSettingsController
     ]
 )
 

--- a/squad/frontend/static/squad/controllers/buildSettings.js
+++ b/squad/frontend/static/squad/controllers/buildSettings.js
@@ -1,0 +1,47 @@
+export function BuildSettingsController($scope, $http, build) {
+    $scope.build = build
+
+    var alertBox = $('#build-settings-alert')
+
+    $scope.updateBuild = function() {
+        var method = 'patch'
+        var url = '/api/builds/' + $scope.build.id + '/'
+        var data = {
+            keep_data: $scope.keep_data,
+        }
+        $http({
+            method: method,
+            url: url,
+            data: data
+        }).then(function(response) {
+            $scope.form_changed = false
+            $scope.build = response.data // returns saved build
+
+            $scope.alert_type = 'success'
+            $scope.alert_message = 'Build settings saved successfully!'
+            alertBox.show()
+            setTimeout(function(){alertBox.fadeOut(500)}, 3000)
+        }, function(response) {
+            var errors = ''
+            response.data['keep_data'].forEach(function(el) {
+                errors += el.toLowerCase() + ' '
+            })
+
+            var error_msg = 'Keep data (' + errors + ')'
+            $scope.alert_type = 'danger'
+            $scope.alert_message = 'Could not save settings: ' + error_msg
+            alertBox.show()
+        })
+    }
+
+    $scope.init = function(){
+        $scope.keep_data = $scope.build.keep_data
+        alertBox.hide()
+    }
+
+    $scope.$watch('keep_data', function() {
+        $scope.form_changed = ($scope.keep_data != $scope.build.keep_data)
+    });
+
+    $scope.init()
+}

--- a/squad/frontend/templates/squad/build-nav.jinja2
+++ b/squad/frontend/templates/squad/build-nav.jinja2
@@ -52,6 +52,13 @@
         </a>
     </li>
     {% endif %}
+    {% if project.accessible_to(user) %}
+    <li role="presentation" {% if url_name == 'build_settings' %}class="active"{% endif %}>
+        <a href="{{build_section_url(build, 'build_settings')}}">
+            Settings
+        </a>
+    </li>
+    {% endif %}
 
     {% endwith %}
 </ul>

--- a/squad/frontend/templates/squad/build_settings.jinja2
+++ b/squad/frontend/templates/squad/build_settings.jinja2
@@ -1,0 +1,53 @@
+{% extends "squad/base.jinja2" %}
+
+{% block content %}
+<div ng-app='Build'>
+{% include "squad/build-nav.jinja2" %}
+
+  <h2>Build settings</h2>
+
+  <div ng-controller="BuildSettingsController">
+    <form id="build_settings_form" ng-submit="updateBuild('{{ build.id }}')">
+      {% set is_disabled = 'disabled' if not project.writable_by(user) else '' %}
+      <div class="form-group">
+        <div class="form-check form-check-inline">
+          <label class="form-check-label">
+            <input ng-model="keep_data" class="form-check-input" type="checkbox" {{ is_disabled }}> Keep data
+          </label>
+        </div>
+        <small id="keep_data_help" class="form-text text-muted">
+          {{ build.keep_data_help_text }}
+        </small>
+      </div>
+      {% if not is_disabled %}
+      {% raw %}
+      <div class="container">
+        <div class="row">
+          <div class="col-md-1" style="padding-left: 0px;">
+            <button type="submit" class="btn btn-primary" ng-disabled="!form_changed" title="{{ form_changed ? '' : 'Button becomes available on form change' }}">Save</button>
+          </div>
+          <div class="col-md-5">
+            <div id="build-settings-alert" class="alert alert-{{ alert_type }} alert-dismissible" role="alert" style="padding: 6px; padding-left: 10px; padding-right: 35px; margin: 0">
+              {{ alert_message }}
+            </div>
+          </div>
+        </div>
+      </div>
+      {% endraw %}
+      {% endif %}
+    </form>
+  </div>
+
+</div>
+{% endblock %}
+
+{% block javascript %}
+<script type="text/javascript">
+build = {
+    "id": {{ build.id }},
+    "keep_data": {{ 'true' if build.keep_data else 'false' }}
+}
+</script>
+<script type="module" src='{{static("squad/build.js")}}'></script>
+{% endblock %}
+

--- a/squad/frontend/urls.py
+++ b/squad/frontend/urls.py
@@ -28,6 +28,7 @@ urlpatterns = [
     url(r'^(%s)/(%s)/build/([^/]+)/tests/$' % ((slug_pattern,) * 2), tests.tests, name='tests'),
     url(r'^(%s)/(%s)/build/([^/]+)/testjobs/$' % ((slug_pattern,) * 2), ci.testjobs, name='testjobs'),
     url(r'^(%s)/(%s)/build/([^/]+)/metadata/$' % ((slug_pattern,) * 2), views.build_metadata, name='build_metadata'),
+    url(r'^(%s)/(%s)/build/([^/]+)/settings/$' % ((slug_pattern,) * 2), views.build_settings, name='build_settings'),
     url(r'^(%s)/(%s)/build/([^/]+)/testrun/([^/]+)/$' % ((slug_pattern,) * 2), views.test_run, name='testrun'),
     url(r'^(%s)/(%s)/build/([^/]+)/testrun/([^/]+)/suite/([^/]+)/tests/$' % ((slug_pattern,) * 2), views.test_run_suite_tests, name='testrun_suite_tests'),
     url(r'^(%s)/(%s)/build/([^/]+)/testrun/([^/]+)/suite/([^/]+)/metrics/$' % ((slug_pattern,) * 2), views.test_run_suite_metrics, name='testrun_suite_metrics'),

--- a/squad/frontend/views.py
+++ b/squad/frontend/views.py
@@ -287,6 +287,20 @@ def build_metadata(request, group_slug, project_slug, version):
 
 
 @auth
+def build_settings(request, group_slug, project_slug, version):
+    group = Group.objects.get(slug=group_slug)
+    project = group.projects.get(slug=project_slug)
+
+    build = get_build(project, version)
+
+    context = {
+        'project': project,
+        'build': build,
+    }
+    return render(request, 'squad/build_settings.jinja2', context)
+
+
+@auth
 def test_run(request, group_slug, project_slug, build_version, job_id):
     group = Group.objects.get(slug=group_slug)
     project = group.projects.get(slug=project_slug)

--- a/test/unit/test_buildSettings.js
+++ b/test/unit/test_buildSettings.js
@@ -1,0 +1,82 @@
+import {BuildSettingsController} from '../../squad/frontend/static/squad/controllers/buildSettings.js'
+
+var app = angular.module('buildSettingsApp', [])
+app.controller(
+    'BuildSettingsController',
+    [
+        '$scope',
+        '$http',
+        'build',
+        BuildSettingsController
+    ]
+)
+
+describe("BuildSettingsController", function () {
+
+    beforeEach(module("buildSettingsApp"))
+
+    var $controller, $rootScope, $compile
+
+    beforeEach(inject(function(_$controller_, _$rootScope_, _$compile_){
+        $controller = _$controller_
+        $rootScope = _$rootScope_
+        $compile = _$compile_
+    }));
+
+    describe("$scope.updateBuild", function () {
+
+        var $scope, $httpBackend, build, controller, alertBox
+
+        beforeEach(function() {
+            $scope = $rootScope.$new()
+            build = {
+                "id": 1,
+                "keep_data": true
+            }
+
+            controller = $controller('BuildSettingsController', {
+                $scope: $scope,
+                build: build
+            })
+        })
+
+        beforeEach(inject(function($injector) {
+            $httpBackend = $injector.get('$httpBackend')
+        }))
+
+        afterEach(function() {
+            $httpBackend.verifyNoOutstandingExpectation()
+            $httpBackend.verifyNoOutstandingRequest()
+        })
+
+        it('tests when updateBuild function succeeds', function () {
+            $httpBackend.whenPATCH("/api/builds/1/").respond(200, {
+                id: 1, keep_data: false
+            })
+
+            $scope.keep_data = false
+
+            $scope.updateBuild()
+            $httpBackend.flush()
+
+            expect($scope.alert_type).toBe('success')
+            expect($scope.keep_data).toBe(false)
+            expect($scope.build.keep_data).toBe(false)
+        })
+
+        it('tests when updateBuild fails', function () {
+            $httpBackend.whenPATCH("/api/builds/1/").respond(401, {
+                "keep_data": ["invalid value"]
+            })
+
+            $scope.keep_data = false
+
+            $scope.updateBuild()
+            $httpBackend.flush()
+
+            expect($scope.alert_type).toBe('danger')
+            expect($scope.alert_message.indexOf('invalid value')).not.toBe(-1)
+            expect($scope.build.keep_data).toBe(true)
+        })
+    })
+})


### PR DESCRIPTION
Add build settings as a new tab in `build-nav.jinja2`, thus
allowing end-user to mark whether or not that build should
keep its data in an event of Data Policy Rentention removal.

This will avoid the need of going in admin UI to do the same action,
also usefull for future build-specific settings.