### PR TITLE
fix pep8 E402 module level import not at top of file

### DIFF
--- a/squad/container_settings.py
+++ b/squad/container_settings.py
@@ -9,6 +9,8 @@
 
 import subprocess
 
+from squad.settings import EMAIL_HOST
+
 
 __implicit_email_host__ = """
 ########################################################################
@@ -22,7 +24,6 @@ __implicit_email_host__ = """
 # environment variable.
 ########################################################################
 """
-from squad.settings import EMAIL_HOST
 if EMAIL_HOST == 'localhost':
     EMAIL_HOST = subprocess.check_output(
         ['ip', 'route', 'show', '0.0.0.0/0']


### PR DESCRIPTION
After running tests locally, I got a pep8 error:

    squad/container_settings.py:25:1: E402 module level import not at top of file

Weirdly, this is not being flagged by travis. Running flake8:
3.2.1 (pycodestyle: 2.2.0, mccabe: 0.5.3, pyflakes: 1.3.0) CPython 3.5.3 on Linux