### PR TITLE
core: GroupManager.accessible_to: restore and fix project count

### DIFF
--- a/squad/core/models.py
+++ b/squad/core/models.py
@@ -6,7 +6,7 @@ from hashlib import sha1
 
 from django.db import models
 from django.db import transaction
-from django.db.models import Q
+from django.db.models import Q, Count, Sum, Case, When
 from django.db.models.query import prefetch_related_objects
 from django.contrib.auth.models import Group as UserGroup
 from django.contrib.auth.models import User
@@ -35,10 +35,21 @@ class GroupManager(models.Manager):
 
     def accessible_to(self, user):
         if user.is_superuser:
-            return self.all()
-        public_project_groups = Q(projects__is_public=True)
-        user_groups = Q(user_groups__in=user.groups.all())
-        return self.filter(public_project_groups | user_groups)
+            return self.all().annotate(project_count=Count('projects'))
+        projects = Project.objects.accessible_to(user)
+        project_ids = [p.id for p in projects]
+        group_ids = set([p.group_id for p in projects])
+        return self.filter(
+            Q(id__in=group_ids) | Q(user_groups__in=user.groups.all())
+        ).annotate(
+            project_count=Sum(
+                Case(
+                    When(projects__id__in=project_ids, then=1),
+                    default=0,
+                    output_field=models.IntegerField(),
+                )
+            )
+        )
 
 
 class DisplayName(object):

--- a/squad/frontend/templates/squad/base.jinja2
+++ b/squad/frontend/templates/squad/base.jinja2
@@ -64,7 +64,7 @@
         SQUAD is free software,
         developed by <a href="https://www.linaro.org/">Linaro</a>.
         It is distributed under the terms of the
-        <a href="https://www.gnu.org/licenses/agpl-3.0.html">GNU Affero General Public License, version 3</a> or (at your option) any later version</a>.
+        <a href="https://www.gnu.org/licenses/agpl-3.0.html">GNU Affero General Public License, version 3</a> or (at your option) any later version.
         <a href="https://github.com/Linaro/squad">Source code</a> and
         <a href="https://github.com/Linaro/squad/issues">Issue tracker</a>
         are available at Github.

--- a/test/core/test_group.py
+++ b/test/core/test_group.py
@@ -42,3 +42,16 @@ class GroupTest(TestCase):
             [self.group],
             list(Group.objects.accessible_to(self.admin))
         )
+
+    def test_count_accessible_projects(self):
+        self.group.projects.create(slug='foo')
+        self.group.projects.create(slug='bar', is_public=False)
+
+        admin_groups = list(Group.objects.accessible_to(self.admin))
+        self.assertEqual(admin_groups[0].project_count, 2)
+
+        member_groups = list(Group.objects.accessible_to(self.user1))
+        self.assertEqual(member_groups[0].project_count, 2)
+
+        anonymous_user_groups = list(Group.objects.accessible_to(AnonymousUser()))
+        self.assertEqual(anonymous_user_groups[0].project_count, 1)

--- a/test/frontend/test_basics.py
+++ b/test/frontend/test_basics.py
@@ -1,3 +1,4 @@
+import re
 from django.test import TestCase
 from django.test import Client
 from django.contrib.auth.models import User
@@ -14,6 +15,7 @@ class FrontendTest(TestCase):
     def setUp(self):
         self.group = models.Group.objects.create(slug='mygroup')
         self.project = self.group.projects.create(slug='myproject')
+        self.other_project = self.group.projects.create(slug='yourproject')
         self.user = User.objects.create(username='theuser')
 
         self.client = Client()
@@ -38,7 +40,9 @@ class FrontendTest(TestCase):
         return response
 
     def test_home(self):
-        self.hit('/')
+        response = self.hit('/')
+        self.assertContains(response, '<strong>mygroup</strong>', html=True, count=1)
+        self.assertIsNotNone(re.search(r'2</span>\s*projects', response.content.decode()))
 
     def test_compare(self):
         self.hit('/_/compare/')


### PR DESCRIPTION
We need to go through the accessible projects to be able to count how
many projects in each group are accessible to each user. i.e. if a group
has one public and one private project, an anonymous user should see it
as having only one project.