### PR TITLE
mail: add bulk mail headers to outgoing mail

### DIFF
--- a/squad/ci/tasks.py
+++ b/squad/ci/tasks.py
@@ -2,7 +2,7 @@ from squad.celery import app as celery
 from squad.ci.models import Backend, TestJob
 from squad.ci.exceptions import SubmissionIssue, FetchIssue
 from celery.utils.log import get_task_logger
-from django.core.mail import EmailMultiAlternatives
+from squad.mail import Message
 from django.conf import settings
 from django.template.loader import render_to_string
 
@@ -82,7 +82,7 @@ def send_testjob_resubmit_admin_email(job_id, resubmitted_job_id):
         context=context,
     )
 
-    message = EmailMultiAlternatives(subject, text_message, sender, emails)
+    message = Message(subject, text_message, sender, emails)
     if test_job.target.html_mail:
         message.attach_alternative(html_message, "text/html")
     message.send()

--- a/squad/core/models.py
+++ b/squad/core/models.py
@@ -11,7 +11,7 @@ from django.db.models.query import prefetch_related_objects
 from django.contrib.auth.models import Group as UserGroup
 from django.contrib.auth.models import User
 from django.conf import settings
-from django.core.mail import EmailMultiAlternatives
+from squad.mail import Message
 from django.core.exceptions import ValidationError
 from django.core.validators import EmailValidator
 from django.core.validators import RegexValidator, MaxValueValidator, MinValueValidator
@@ -409,7 +409,7 @@ class DelayedReport(models.Model):
         sender = "%s <%s>" % (settings.SITE_NAME, settings.EMAIL_FROM)
         subject = "Custom report %s" % self.pk
 
-        message = EmailMultiAlternatives(subject, self.output_text, sender, recipients)
+        message = Message(subject, self.output_text, sender, recipients)
         if self.output_html:
             message.attach_alternative(self.output_html, "text/html")
         message.send()

--- a/squad/core/notification.py
+++ b/squad/core/notification.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from django.core.mail import EmailMultiAlternatives
+from squad.mail import Message
 from django.conf import settings
 import django.template
 from django.template.loader import render_to_string
@@ -162,7 +162,7 @@ class Notification(object):
         if NotificationDelivery.exists(self.status, subject, txt, html):
             return
 
-        message = EmailMultiAlternatives(subject, txt, sender, recipients)
+        message = Message(subject, txt, sender, recipients)
         if self.project.html_mail:
             message.attach_alternative(html, "text/html")
         message.send()
@@ -241,7 +241,7 @@ def send_admin_notification(status, project):
     recipients = [r.email for r in project.admin_subscriptions.all()]
     txt = render_to_string('squad/notification/failed_test_jobs.txt.jinja2', data)
 
-    message = EmailMultiAlternatives(subject, txt, sender, recipients)
+    message = Message(subject, txt, sender, recipients)
     html = ''
     if project.html_mail:
         html = render_to_string('squad/notification/failed_test_jobs.html.jinja2', data)

--- a/squad/mail.py
+++ b/squad/mail.py
@@ -1,0 +1,10 @@
+from django.core.mail import EmailMultiAlternatives
+
+
+class Message(EmailMultiAlternatives):
+
+    def __init__(self, subject, body, sender, recipients):
+        super().__init__(subject, body, sender, recipients)
+        self.extra_headers['Precedence'] = 'bulk'
+        self.extra_headers['Auto-Submitted'] = 'auto-generated'
+        self.extra_headers['X-Auto-Response-Suppress'] = 'All'

--- a/test/test_mail.py
+++ b/test/test_mail.py
@@ -1,0 +1,17 @@
+from django.test import TestCase
+from squad.mail import Message
+
+
+class TestMessage(TestCase):
+
+    def setUp(self):
+        self.msg = Message('mail subject', 'mail body', 'sender@example.com', ['recipient@example.com'])
+
+    def test_precedence(self):
+        self.assertEqual('bulk', self.msg.extra_headers["Precedence"])
+
+    def test_auto_submitted(self):
+        self.assertEqual('auto-generated', self.msg.extra_headers['Auto-Submitted'])
+
+    def test_x_auto_response_supress(self):
+        self.assertEqual('All', self.msg.extra_headers['X-Auto-Response-Suppress'])


### PR DESCRIPTION
This is to avoid people's vacation autoresponders replying to squad
mail.

References:

- https://tools.ietf.org/search/rfc3834
- http://www.redmine.org/projects/redmine/repository/revisions/2655/
- https://blog.returnpath.com/precedence/
- X-Auto-Response-Suppress is used by github