### PR TITLE
Fix api/data call date arguments.

### DIFF
--- a/squad/api/data.py
+++ b/squad/api/data.py
@@ -1,4 +1,7 @@
 import json
+
+from datetime import datetime
+
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404
 from django.http import HttpResponseBadRequest
@@ -28,6 +31,19 @@ def get(request, group_slug, project_slug):
     metrics = request.GET.getlist('metric')
     date_start = request.GET.get('date_start', None)
     date_end = request.GET.get('date_end', None)
+
+    if date_start:
+        try:
+            date_start = datetime.strptime(date_start, "%m-%d-%Y")
+        except ValueError:
+            return HttpResponseBadRequest("Invalid date_start format: %s. Try using %s notation." % (date_start, "%m-%d-%Y"))
+    if date_end:
+        try:
+            date_end = datetime.strptime(date_end, "%m-%d-%Y")
+        except ValueError:
+            return HttpResponseBadRequest(
+                "Invalid date_end format: %s. Try using %s notation." % (date_end, "%m-%d-%Y"))
+
     # If the metrics parameter is not present, return data for all metrics.
     if not metrics:
         metric_set = models.Metric.objects.filter(

--- a/squad/core/queries.py
+++ b/squad/core/queries.py
@@ -7,6 +7,8 @@ from django.utils import timezone
 
 def get_metric_data(project, metrics, environments, date_start=None,
                     date_end=None):
+    # Note that date_start and date_end **must** be datetime objects and not
+    # strings, if used.
 
     date_start = timezone.make_aware(
         date_start or datetime.datetime.fromtimestamp(0))


### PR DESCRIPTION
Previously we passed date_start and date_end as strings to
get_metric_data which was incorrect because make_aware expects
datetime objects and not strings. This patch fixes that.