### PR TITLE
fix yaml.load default Loader warning

### DIFF
--- a/squad/api/rest.py
+++ b/squad/api/rest.py
@@ -407,9 +407,9 @@ class ProjectStatusSerializer(serializers.HyperlinkedModelSerializer):
     def to_representation(self, instance):
         ret = super().to_representation(instance)
         if instance.regressions is not None:
-            ret['regressions'] = json.dumps(yaml.load(ret['regressions']))
+            ret['regressions'] = json.dumps(instance.get_regressions())
         if instance.fixes is not None:
-            ret['fixes'] = json.dumps(yaml.load(ret['fixes']))
+            ret['fixes'] = json.dumps(instance.get_fixes())
         return ret
 
     class Meta:
@@ -633,7 +633,7 @@ class BuildViewSet(ModelViewSet):
         if created or force:
             delayed_report = prepare_report(delayed_report.pk)
         if delayed_report.status_code != status.HTTP_200_OK:
-            return Response(yaml.load(delayed_report.error_message or ''), delayed_report.status_code)
+            return Response(yaml.safe_load(delayed_report.error_message or ''), delayed_report.status_code)
         if delayed_report.output_format == "text/html" and delayed_report.output_html:
             return HttpResponse(delayed_report.output_html, content_type=delayed_report.output_format)
         return HttpResponse(delayed_report.output_text, content_type=delayed_report.output_format)

--- a/squad/ci/backend/lava.py
+++ b/squad/ci/backend/lava.py
@@ -174,7 +174,7 @@ class Backend(BaseBackend):
         return None
 
     def __lava_job_name(self, definition):
-        yaml_definition = yaml.load(definition)
+        yaml_definition = yaml.safe_load(definition)
         if 'job_name' in yaml_definition.keys():
             # only return first 255 characters
             return yaml_definition['job_name'][:255]
@@ -243,7 +243,7 @@ class Backend(BaseBackend):
     def __get_testjob_results_yaml__(self, job_id):
         logger.debug("Retrieving result summary for job: %s" % job_id)
         suites = self.proxy.results.get_testjob_suites_list_yaml(job_id)
-        y = yaml.load(suites)
+        y = yaml.safe_load(suites)
         lava_job_results = []
         for suite in y:
             limit = 500
@@ -273,14 +273,14 @@ class Backend(BaseBackend):
     def __parse_results__(self, data, test_job):
         handle_lava_suite = self.settings.get('CI_LAVA_HANDLE_SUITE', False)
         if hasattr(test_job, 'target') and test_job.target.project_settings is not None:
-            project_settings = yaml.load(test_job.target.project_settings) or {}
+            project_settings = yaml.safe_load(test_job.target.project_settings) or {}
             tmp_handle_lava = project_settings.get('CI_LAVA_HANDLE_SUITE')
             if tmp_handle_lava is not None:
                 handle_lava_suite = tmp_handle_lava
 
-        definition = yaml.load(data['definition'])
+        definition = yaml.safe_load(data['definition'])
         if data['multinode_definition']:
-            definition = yaml.load(data['multinode_definition'])
+            definition = yaml.safe_load(data['multinode_definition'])
         test_job.name = definition['job_name'][:255]
         job_metadata = definition.get('metadata', {})
 
@@ -387,9 +387,9 @@ class Backend(BaseBackend):
         if job.name is None:
             # fetch job name once
             data = self.__get_job_details__(lava_id)
-            definition = yaml.load(data['definition'])
+            definition = yaml.safe_load(data['definition'])
             if data['multinode_definition']:
-                definition = yaml.load(data['multinode_definition'])
+                definition = yaml.safe_load(data['multinode_definition'])
             job.name = definition['job_name'][:255]
         job.save()
         if job.job_status in self.complete_statuses:

--- a/squad/ci/backend/null.py
+++ b/squad/ci/backend/null.py
@@ -21,7 +21,7 @@ class Backend(object):
         if self.data is not None and \
                 self.data.backend_settings is not None and \
                 len(self.data.backend_settings) > 0:
-            self.settings = yaml.load(self.data.backend_settings)
+            self.settings = yaml.safe_load(self.data.backend_settings)
 
     def submit(self, test_job):
         """

--- a/squad/ci/models.py
+++ b/squad/ci/models.py
@@ -186,7 +186,7 @@ class TestJob(models.Model):
     def show_definition(self):
         try:
             # we'll loose comments in web UI
-            yaml_def = yaml.load(self.definition)
+            yaml_def = yaml.safe_load(self.definition)
         except yaml.parser.ParserError:
             # in case yaml is not valid, return original string
             return self.definition

--- a/squad/core/models.py
+++ b/squad/core/models.py
@@ -991,7 +991,7 @@ class ProjectStatus(models.Model, TestSummaryBase):
 
     def __get_yaml_field__(self, field_value):
         if field_value is not None:
-            return yaml.load(field_value)
+            return yaml.load(field_value, Loader=yaml.Loader)
         return {}
 
     def get_regressions(self):

--- a/test/api/test_rest.py
+++ b/test/api/test_rest.py
@@ -172,7 +172,14 @@ class RestApiTest(APITestCase):
         self.assertEqual(3, len(data['results']))
 
     def test_builds_status(self):
-        self.hit('/api/builds/%d/status/' % self.build.id)
+        self.build2.test_jobs.all().delete()
+        self.build3.test_jobs.all().delete()
+        UpdateProjectStatus()(self.testrun2)
+        UpdateProjectStatus()(self.testrun3)
+
+        data = self.hit('/api/builds/%d/status/' % self.build3.id)
+        self.assertIn('foo/test2', data['regressions'])
+        self.assertIn('foo/test1', data['fixes'])
 
     def test_builds_email_missing_status(self):
         # this should not happen normally, but let's test it anyway

--- a/test/ci/test_models.py
+++ b/test/ci/test_models.py
@@ -483,7 +483,7 @@ class TestJobTest(TestCase):
         testjob = models.TestJob(
             definition=definition
         )
-        display = yaml.load(testjob.show_definition)
+        display = yaml.safe_load(testjob.show_definition)
         self.assertNotEqual('qux', display['secrets']['baz'])
 
     def test_show_definition_non_dict(self):
@@ -491,5 +491,5 @@ class TestJobTest(TestCase):
         testjob = models.TestJob(
             definition=definition
         )
-        display = yaml.load(testjob.show_definition)
+        display = yaml.safe_load(testjob.show_definition)
         self.assertEqual(definition, display)

--- a/test/core/test_project_status.py
+++ b/test/core/test_project_status.py
@@ -1,5 +1,3 @@
-import yaml
-
 from django.utils import timezone
 from django.test import TestCase
 from dateutil.relativedelta import relativedelta
@@ -282,7 +280,7 @@ class ProjectStatusTest(TestCase):
         self.assertEqual(thresholds[0][1].result, 3)
 
     def test_last_build_comparison(self):
-        # Test that the build that we compare agains is truly the last one
+        # Test that the build that we compare against is truly the last one
         # time wise.
         build1 = self.create_build('1', datetime=h(10))
         test_run1 = build1.test_runs.first()
@@ -302,6 +300,6 @@ class ProjectStatusTest(TestCase):
         test_run3.tests.create(name='bar', suite=self.suite, result=True)
         status3 = ProjectStatus.create_or_update(build3)
 
-        fixes3 = yaml.load(status3.fixes)
+        fixes3 = status3.get_fixes()
         self.assertEqual(len(fixes3['theenvironment']), 1)
         self.assertEqual(fixes3['theenvironment'][0], 'foo')

--- a/test/core/test_tasks.py
+++ b/test/core/test_tasks.py
@@ -800,7 +800,7 @@ class PrepareDelayedReport(TestCase):
             "message": LONG_ERROR_MESSAGE
         }
         update_delayed_report(prepared_report, data, 400)
-        self.assertEqual(yaml.load(prepared_report.error_message)['message'], LONG_ERROR_MESSAGE)
+        self.assertEqual(yaml.safe_load(prepared_report.error_message)['message'], LONG_ERROR_MESSAGE)
 
     @patch('squad.core.tasks.notification.notify_delayed_report_email.delay')
     def test_email_notification(self, email_notification_mock):


### PR DESCRIPTION
PyYAML has deprecated the default `yaml.load`. It recommends explicitly specify
the loader or calling a shortcut function, which is done in this commit.

Source: https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation