### PR TITLE
Dockerfile: cache installed dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,8 @@
 FROM debian:buster-slim
 
-WORKDIR /app
-COPY . ./
-
 RUN apt-get update -q=2 && \
-    apt-get install -q=2 --no-install-recommends auto-apt-proxy && \
+    apt-get install -q=2 --no-install-recommends iproute2 auto-apt-proxy && \
     apt-get install -q=2 --no-install-recommends \
-        iproute2 \
         python3 \
         python3-celery \
         python3-coreapi  \
@@ -30,9 +26,12 @@ RUN apt-get update -q=2 && \
         python3-svgwrite \
         python3-whitenoise \
         wget \
-        unzip \
-    && \
-    ln -sfT container_settings.py /app/squad/local_settings.py && \
+        unzip
+
+WORKDIR /app
+COPY . ./
+
+RUN ln -sfT container_settings.py /app/squad/local_settings.py && \
     python3 -m squad.frontend && \
     ./manage.py collectstatic --noinput --verbosity 0 && \
     python3 setup.py develop && \


### PR DESCRIPTION
Having the installation of packages after WORKDIR and COPY forces a
reinstallation of the dependencies every time there is any change to the source
tree. By installing the dependencies directly on top of the base image, that
layer will be used from the cache and only needs to be rebuilt if the list of
deopendencies change.

The resulting image has a couple of extra layers, but is the same size as
before:

squad/after   latest   3e6bc1fd3f33  6 seconds ago   280MB
squad/before  latest   e09e3b1ead22  2 minutes ago   280MB

(Also, install iproute2 together with auto-apt-proxy so that the later works properly)