### PR TITLE
test-docker: fail on locally-installed Python packages

### DIFF
--- a/scripts/test-docker
+++ b/scripts/test-docker
@@ -4,3 +4,12 @@ set -exu
 
 docker build -t squad .
 docker run squad python3 manage.py test -v 3
+
+rc=0
+for lib in $(docker run squad sh -c 'find /usr/local/lib/python3.* -name "*.egg"'); do
+    set +x
+    echo "E: library installed from outside of Debian: $lib"
+    rc=1
+    set -x
+done
+exit "$rc"


### PR DESCRIPTION
We want the docker image to use packages from Debian. requirements.txt
should not require anything that is not available in the target Debian
release.