### PR TITLE
Standardize "settings" tab to be similar to Group and Project 

### DIFF
--- a/squad/frontend/templates/squad/build-nav.jinja2
+++ b/squad/frontend/templates/squad/build-nav.jinja2
@@ -55,7 +55,7 @@
     {% if project.writable_by(user) %}
     <li role="presentation" {% if url_name == 'build_settings' %}class="active"{% endif %}>
         <a href="{{build_section_url(build, 'build_settings')}}">
-            Settings
+            Build settings
         </a>
     </li>
     {% endif %}


### PR DESCRIPTION
@terceiro right after I merged your build-settings branch, I realized that Group and Project settings tab are named "Group settings" and "Project settings", respectively. So this is just a minor tweak to the build settings tab name.