### PR TITLE
frontend: extract "test results summary" into a shared template

### DIFF
--- a/squad/frontend/templates/squad/_builds_table.jinja2
+++ b/squad/frontend/templates/squad/_builds_table.jinja2
@@ -26,19 +26,7 @@
         {% if status.has_tests %}
         <div title='Test results'>
             <i class='fa fa-check-square-o'></i>
-            <span class="badge" data-toggle="tooltip" data-placement="top" title="Total">{{status.tests_total}} tests</span>
-            {% if status.tests_pass > 0 %}
-            <span class="badge alert-success" data-toggle="tooltip" data-placement="top" title="Pass">{{status.tests_pass}} pass</span>
-            {% endif %}
-            {% if status.tests_skip > 0 %}
-            <span class="badge alert-warning" data-toggle="tooltip" data-placement="top" title="Skip">{{status.tests_skip}} skip</span>
-            {% endif %}
-            {% if status.tests_fail > 0 %}
-            <span class="badge alert-danger" data-toggle="tooltip" data-placement="top" title="Fail">{{status.tests_fail}} fail</span>
-            {% endif %}
-            {% if status.tests_xfail > 0 %}
-            <span class="badge alert-info" data-toggle="tooltip" data-placement="top" title="Fail">{{status.tests_xfail}} xfail</span>
-            {% endif %}
+            {% include "squad/_test_results_summary.jinja2" %}
         </div>
         {% endif %}
 

--- a/squad/frontend/templates/squad/_project_list.jinja2
+++ b/squad/frontend/templates/squad/_project_list.jinja2
@@ -38,16 +38,7 @@
         {% if status.has_tests %}
         <div title='Test results'>
             <i class='fa fa-check-square-o'></i>
-            <span class="badge" data-toggle="tooltip" data-placement="top" title="Total">{{status.tests_total}} total</span>
-            {% if status.tests_pass > 0 %}
-            <span class="badge alert-success" data-toggle="tooltip" data-placement="top" title="Pass">{{status.tests_pass}} pass</span>
-            {% endif %}
-            {% if status.tests_skip > 0 %}
-            <span class="badge alert-warning" data-toggle="tooltip" data-placement="top" title="Skip">{{status.tests_skip}} skip</span>
-            {% endif %}
-            {% if status.tests_fail > 0 %}
-            <span class="badge alert-danger" data-toggle="tooltip" data-placement="top" title="Fail">{{status.tests_fail}} fail</span>
-            {% endif %}
+            {% include "squad/_test_results_summary.jinja2" %}
         </div>
         {% endif %}
 

--- a/squad/frontend/templates/squad/_test_results_summary.jinja2
+++ b/squad/frontend/templates/squad/_test_results_summary.jinja2
@@ -1,0 +1,13 @@
+<span class="badge" data-toggle="tooltip" data-placement="top" title="Total">{{status.tests_total}} tests</span>
+{% if status.tests_pass > 0 %}
+<span class="badge alert-success" data-toggle="tooltip" data-placement="top" title="Pass">{{status.tests_pass}} pass</span>
+{% endif %}
+{% if status.tests_skip > 0 %}
+<span class="badge alert-warning" data-toggle="tooltip" data-placement="top" title="Skip">{{status.tests_skip}} skip</span>
+{% endif %}
+{% if status.tests_fail > 0 %}
+<span class="badge alert-danger" data-toggle="tooltip" data-placement="top" title="Fail">{{status.tests_fail}} fail</span>
+{% endif %}
+{% if status.tests_xfail > 0 %}
+<span class="badge alert-info" data-toggle="tooltip" data-placement="top" title="Fail">{{status.tests_xfail}} xfail</span>
+{% endif %}

--- a/squad/frontend/templates/squad/build.jinja2
+++ b/squad/frontend/templates/squad/build.jinja2
@@ -73,7 +73,7 @@
                             </tr>
                         {% for entry in entries %}
                             {% for status in entry.statuses %}
-			    <tr id='details-row-{{status.id}}' ng-show='details_visible["details-{{suite.id}}"]''>
+			    <tr id='details-row-{{status.id}}' ng-show='details_visible["details-{{suite.id}}"]'>
                                     <td>
 					<a href="{{url("testrun", args=[project.group.slug, project.slug, build.version, status.test_run.job_id])}}">
                                             {{status.test_run.job_id}}

--- a/squad/frontend/templates/squad/build.jinja2
+++ b/squad/frontend/templates/squad/build.jinja2
@@ -86,19 +86,7 @@
                                     </td>
                                     <td>
 					<a href="{{testrun_suite_tests_url(project.group, project, build, status)}}">
-                                                <span class="badge" data-toggle="tooltip" data-placement="top" title="Total">{{status.tests_total}} tests</span>
-                                                {% if status.tests_pass > 0 %}
-                                                <span class="badge alert-success" data-toggle="tooltip" data-placement="top" title="Pass">{{status.tests_pass}} pass</span>
-                                                {% endif %}
-                                                {% if status.tests_skip > 0 %}
-                                                <span class="badge alert-warning" data-toggle="tooltip" data-placement="top" title="Skip">{{status.tests_skip}} skip</span>
-                                                {% endif %}
-                                                {% if status.tests_fail > 0 %}
-                                                <span class="badge alert-danger" data-toggle="tooltip" data-placement="top" title="Fail">{{status.tests_fail}} fail</span>
-                                                {% endif %}
-                                                {% if status.tests_xfail > 0 %}
-                                                <span class="badge alert-info" data-toggle="tooltip" data-placement="top" title="Fail">{{status.tests_xfail}} xfail</span>
-                                                {% endif %}
+                                        {% include "squad/_test_results_summary.jinja2" %}
                                         </a>
                                     </td>
                                 </tr>

--- a/squad/frontend/templates/squad/test_run.jinja2
+++ b/squad/frontend/templates/squad/test_run.jinja2
@@ -84,16 +84,7 @@
 
     <div class='col-md-4 col-sm-4' title='Test results'>
         <i class='fa fa-check-square-o'></i>
-        <span class="badge" data-toggle="tooltip" data-placement="top" title="Total">{{status.tests_total}} tests</span>
-        {% if status.tests_pass > 0 %}
-        <span class="badge alert-success" data-toggle="tooltip" data-placement="top" title="Pass">{{status.tests_pass}} pass</span>
-        {% endif %}
-        {% if status.tests_skip > 0 %}
-        <span class="badge alert-warning" data-toggle="tooltip" data-placement="top" title="Skip">{{status.tests_skip}} skip</span>
-        {% endif %}
-        {% if status.tests_fail > 0 %}
-        <span class="badge alert-danger" data-toggle="tooltip" data-placement="top" title="Fail">{{status.tests_fail}} fail</span>
-        {% endif %}
+        {% include "squad/_test_results_summary.jinja2" %}
     </div>
 
     <div class='col-md-2 col-sm-2' title='Test run'>


### PR DESCRIPTION
This fixes the absence of xfail in a couple of pages, and will make it
easier to translate those bits of UI.