### PR TITLE
Show "Projects" tab only if user had specific permission

### DIFF
--- a/squad/frontend/templates/squad/group-nav.jinja2
+++ b/squad/frontend/templates/squad/group-nav.jinja2
@@ -9,11 +9,11 @@
 </p>
 <ul class="page-header nav nav-pills">
     {% with url_name=request.resolver_match.url_name %}
+    {% if group.writable_by(user) %}
     <li role="presentation" {% if url_name == "group" %}class="active"{% endif %}>
         <a href="{{group_url(group)}}">{{ _('Projects') }}</a>
     </li>
 
-    {% if group.writable_by(user) %}
     <li role="presentation" {% if "group-settings" in url_name %}class="active"{% endif %}>
         <a href="{{url("group-settings", args=[group.slug])}}">{{ _('Group settings') }}</a>
     </li>


### PR DESCRIPTION
The "Projects" tab allows users to navigate from project settings and creating new projects. If the user does not have such privileges, there will be only one tab pointing to the current page, making no use
for it.