### PR TITLE
compare_projects.jinja2: add pagination to test results

### DIFF
--- a/squad/frontend/comparison.py
+++ b/squad/frontend/comparison.py
@@ -1,4 +1,5 @@
 from django.shortcuts import render
+from django.core.paginator import Paginator
 
 from squad.core.models import Project
 from squad.core.comparison import TestComparison
@@ -11,6 +12,13 @@ def compare_projects(request):
 
     if len(selected) > 1:
         comparison = TestComparison.compare_projects(*selected)
+
+        try:
+            page = int(request.GET.get('page', '1'))
+        except ValueError:
+            page = 1
+        paginator = Paginator(tuple(comparison.results.items()), 50)
+        comparison.results = paginator.page(page)
     else:
         comparison = None
 

--- a/squad/frontend/templates/squad/_pagination.jinja2
+++ b/squad/frontend/templates/squad/_pagination.jinja2
@@ -4,7 +4,7 @@
         {% with page_list=items|get_page_list %}
         {% if page_list.link_first %}
         <li>
-            <a href="?page=1" aria-label="page 1">
+            <a href="{{get_page_url(1)}}" aria-label="page 1">
                 <span aria-hidden="true">1</span>
             </a>
         </li>
@@ -18,7 +18,7 @@
 
         {% for page in page_list.pages %}
         <li {% if items.number == page %}class="active"{% endif %}>
-            <a href="?page={{page}}" aria-label="page {{page}}">{{page}}</a>
+            <a href="{{get_page_url(page)}}" aria-label="page {{page}}">{{page}}</a>
         </li>
         {% endfor %}
 
@@ -30,7 +30,7 @@
 
         {% if page_list.link_last %}
         <li>
-            <a href="?page={{ items.paginator.num_pages }}" aria-label="page {{items.paginator.num_pages}}">
+            <a href="{{get_page_url(items.paginator.num_pages)}}" aria-label="page {{items.paginator.num_pages}}">
                 <span aria-hidden="true">{{items.paginator.num_pages}}</span>
             </a>
         </li>

--- a/squad/frontend/templates/squad/_test_results_table.jinja2
+++ b/squad/frontend/templates/squad/_test_results_table.jinja2
@@ -17,7 +17,7 @@
       {% endfor %}
     {% endfor %}
   </tr>
-  {% for test, results in comparison.results.items() %}
+  {% for test, results in comparison.results %}
     <tr>
       <th>{{test}}</th>
       {% for build, environments in comparison.environments.items() %}

--- a/squad/frontend/templates/squad/compare_projects.jinja2
+++ b/squad/frontend/templates/squad/compare_projects.jinja2
@@ -3,7 +3,17 @@
 {% block content %}
 <h1>{{ _('Compare project') }}s</h1>
 
-{% include "squad/_test_results_table.jinja2" %}
+{% if comparison %}
+  {% with items=comparison.results %}
+    {% include "squad/_pagination.jinja2" %}
+  {% endwith %}
+
+  {% include "squad/_test_results_table.jinja2" %}
+
+  {% with items=comparison.results %}
+    {% include "squad/_pagination.jinja2" %}
+  {% endwith %}
+{% endif %}
 
 <h2>{{ _('Select projects to compare') }}</h2>
 <form>

--- a/squad/frontend/templatetags/squad.py
+++ b/squad/frontend/templatetags/squad.py
@@ -159,6 +159,13 @@ def get_page_list(items):
     }
 
 
+@register_global_function(takes_context=True)
+def get_page_url(context, page):
+    query_string = context['request'].GET.copy()
+    query_string.update({'page': page})
+    return '?' + query_string.urlencode()
+
+
 @register_filter
 def add_class(field, class_name):
     return field.as_widget(attrs={"class": class_name})

--- a/test/frontend/test_template_tags.py
+++ b/test/frontend/test_template_tags.py
@@ -1,0 +1,41 @@
+import urllib.parse
+from jinja2 import Template
+
+
+from django.test import TestCase
+
+
+from squad.frontend.templatetags.squad import get_page_url
+
+
+class FakeRequest():
+    pass
+
+
+class FakeGet():
+
+    def __init__(self, params=None):
+        self.params = params or {}
+
+    def update(self, params):
+        self.params.update(**params)
+
+    def copy(self):
+        return self
+
+    def urlencode(self):
+        return urllib.parse.urlencode(self.params)
+
+
+class TemplateTagsTest(TestCase):
+
+    def test_get_page_url(self):
+        fake_request = FakeRequest()
+        fake_request.GET = FakeGet({'page': 2, 'existing_arg': 'val'})
+        context = {'request': fake_request, 'get_page_url': get_page_url}
+
+        template_to_render = Template('{{get_page_url(42)}}')
+        rendered_template = template_to_render.render(context)
+        self.assertNotIn('page=2', rendered_template)
+        self.assertIn('page=42', rendered_template)
+        self.assertIn('existing_arg=val', rendered_template)


### PR DESCRIPTION
While that didn't reduce time consumed in generating the comparison, now it feels way faster just because of much fewer html rendering.