### PR TITLE
squad/controllers/charts.js: display tooltip on line hover

### DIFF
--- a/squad/frontend/static/squad/controllers/charts.js
+++ b/squad/frontend/static/squad/controllers/charts.js
@@ -283,7 +283,9 @@ function ChartPanel($http, DATA) {
                                 var build_id = dataset.data[tooltip.index]
                                 return "Build #" + data_point.build_id
                             }
-                        }
+                        },
+                        intersect: false,
+                        mode: 'index'
                     },
                     animation: {
                         duration: 0,


### PR DESCRIPTION
In current chart is quite tricky to get a tooltip to show up.
You need to hover on the specific point to get it displayed, and
that's just a few pixels wide.

With this configuration set up, a tooltip will be displayed
pointing to the nearest point that the mouse is hovering on.

Also, if two points overlap each other, the tooltip will
include both of their data.

![Screenshot from 2019-05-15 16-14-06](https://user-images.githubusercontent.com/2254825/57802518-8713d100-772c-11e9-9ef7-a5fefd0dcad2.png)
