### PR TITLE
frontend: allow empty searches in test comparison page

### DIFF
--- a/squad/frontend/static/squad/controllers/compare.js
+++ b/squad/frontend/static/squad/controllers/compare.js
@@ -200,7 +200,7 @@ function CompareController($scope, $http, $location) {
                 };
             },
         },
-        minimumInputLength: 1
+        minimumInputLength: 0
     });
 
     var projectSelect = $(".project-select");
@@ -238,7 +238,7 @@ function CompareController($scope, $http, $location) {
                 };
             },
         },
-        minimumInputLength: 1
+        minimumInputLength: 0
     });
     var suiteSelect = $(".suite-select");
     suiteSelect.on('select2:unselect', function(e){
@@ -277,7 +277,7 @@ function CompareController($scope, $http, $location) {
                 };
             },
         },
-        minimumInputLength: 1
+        minimumInputLength: 0
     });
     var testSelect = $(".test-select");
     testSelect.on('select2:unselect', function(e){


### PR DESCRIPTION
So far the minimum input required in search boxes in test comparison
page was 1 character. This led to situation where it was hard to use the
form without knowning at least 1st character of the suite or test name.
This patch removes the 1 character limitation and allows for empty
searches.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>