### PR TITLE
ci: add support for LAVA multinode jobs

### DIFF
--- a/doc/ci.rst
+++ b/doc/ci.rst
@@ -154,4 +154,24 @@ Example LAVA backend settings:
     CI_LAVA_SEND_ADMIN_EMAIL: False
     CI_LAVA_HANDLE_SUITE: True
 
+Multinode
++++++++++
+
+SQUAD supports fetching results from LAVA multinode jobs. There are however
+a few limitations with this setup:
+ - All results from multinode will share environment name
+   Since test jobs are submitted via SQUAD using the environment from submit
+   URL there is no way for SQUAD to distinguish between different environmens
+   on different parts of multinode job.
+ - Resubmit will repeat the whole set
+   In SQUAD all parts of multinode job will share the multinode definition.
+   For this reason re-submitting any part of the multinode job will result
+   in new multinode job that includes all parts.
+ - Each part of the multinode job will be retrieved separately
+   This means that each part will create a TestRun in SQUAD. This should not
+   be a major issue as all results will still be available. Users need to make
+   sure that the test names don't overlap as SQUAD will not have any means of
+   distinguishing between identically named tests from different parts of
+   multinode job.
+
 .. vim: ts=4 sw=4 et=1

--- a/squad/ci/backend/fake.py
+++ b/squad/ci/backend/fake.py
@@ -16,7 +16,7 @@ class Backend(object):
         self.data = data
 
     def submit(self, test_job):
-        return str(test_job.id)
+        return [str(test_job.id)]
 
     def resubmit(self, test_job):
         count = test_job.resubmitted_count + 1

--- a/squad/ci/backend/null.py
+++ b/squad/ci/backend/null.py
@@ -27,7 +27,7 @@ class Backend(object):
         """
         Submits a given test job to the backend service.
 
-        The return value must be the job id as provided by the backend.
+        The return value must be list of job ids as provided by the backend.
 
         On errors, implementations can raise two classes of exceptions:
             * squad.ci.exceptions.SubmissionIssue, when there is an

--- a/squad/ci/backend/null.py
+++ b/squad/ci/backend/null.py
@@ -37,7 +37,7 @@ class Backend(object):
               that could be gone in the future (e.g. a server-side issue or a
               maintainance window).
         """
-        pass
+        raise NotImplementedError
 
     def resubmit(self, test_job):
         """
@@ -54,7 +54,7 @@ class Backend(object):
               that could be gone in the future (e.g. a server-side issue or a
               maintainance window).
         """
-        pass
+        raise NotImplementedError
 
     def fetch(self, test_job):
         """
@@ -75,20 +75,20 @@ class Backend(object):
               is temporary so the test job can be fetched again in the future
               (e.g. a server-side issue or a maintainance window).
         """
-        pass
+        raise NotImplementedError
 
     def listen(self):
         """
         Listens the backend service for realtime test results. What to do with
         the received data is up to each specific backend implementation.
         """
-        pass
+        raise NotImplementedError
 
     def job_url(selt, test_job):
         """
         Returns the URL of the test job in the backend
         """
-        pass
+        raise NotImplementedError
 
     def format_message(self, msg):
         return self.data.name + ': ' + msg

--- a/test/api/test_ci.py
+++ b/test/api/test_ci.py
@@ -30,7 +30,7 @@ class CiApiTest(TestCase):
         Token.objects.create(user=self.project_member_user, key='memberkey')
         Token.objects.create(user=self.project_admin_user, key='adminkey')
 
-        self.backend = models.Backend.objects.create(name='lava')
+        self.backend = models.Backend.objects.create(name='lava', implementation_type='fake')
         self.client = APIClient('thekey')
         self.memberclient = APIClient('memberkey')
         self.adminclient = APIClient('adminkey')

--- a/test/ci/backend/test_fake.py
+++ b/test/ci/backend/test_fake.py
@@ -28,7 +28,7 @@ class FakeBackendTest(TestCase):
         job = TestJob.objects.create(backend=self.backend, target=self.project)
         impl = FakeBackend(self.backend)
         jid = impl.submit(job)
-        self.assertEqual(str(job.id), jid)
+        self.assertEqual([str(job.id)], jid)
 
     def test_resubmit(self):
         job = TestJob.objects.create(backend=self.backend, target=self.project, job_id='22')

--- a/test/ci/backend/test_lava.py
+++ b/test/ci/backend/test_lava.py
@@ -273,7 +273,18 @@ class LavaTest(TestCase):
         testjob = TestJob(
             definition=test_definition,
             backend=self.backend)
-        self.assertEqual('1234', lava.submit(testjob))
+        self.assertEqual(['1234'], lava.submit(testjob))
+        self.assertEqual('bar', testjob.name)
+        __submit__.assert_called_with(test_definition)
+
+    @patch("squad.ci.backend.lava.Backend.__submit__", return_value=['1234.0', '1234.1'])
+    def test_submit_multinode(self, __submit__):
+        lava = LAVABackend(None)
+        test_definition = "foo: 1\njob_name: bar"
+        testjob = TestJob(
+            definition=test_definition,
+            backend=self.backend)
+        self.assertEqual(['1234.0', '1234.1'], lava.submit(testjob))
         self.assertEqual('bar', testjob.name)
         __submit__.assert_called_with(test_definition)
 

--- a/test/ci/test_models.py
+++ b/test/ci/test_models.py
@@ -433,7 +433,7 @@ class BackendSubmitTest(BackendTestBase):
     def test_submit(self, get_implementation):
         test_job = self.create_test_job()
         impl = MagicMock()
-        impl.submit = MagicMock(return_value='999')
+        impl.submit = MagicMock(return_value=['999'])
         get_implementation.return_value = impl
 
         self.backend.submit(test_job)

--- a/test/ci/test_models.py
+++ b/test/ci/test_models.py
@@ -391,9 +391,10 @@ class BackendFetchTest(BackendTestBase):
             completed=False,
         )
 
+    @patch('squad.ci.backend.null.Backend.job_url', return_value="http://example.com/123")
     @patch('squad.ci.backend.null.Backend.fetch')
     @patch('squad.ci.models.ReceiveTestRun.__call__')
-    def test_really_fetch_sets_fetched_at(self, receive, backend_fetch):
+    def test_really_fetch_sets_fetched_at(self, receive, backend_fetch, backend_job_url):
         backend_fetch.return_value = ('Completed', True, {}, {}, {}, None)
 
         env = self.project.environments.create(slug='foo')
@@ -409,9 +410,10 @@ class BackendFetchTest(BackendTestBase):
         self.assertIsNotNone(test_job.fetched_at)
 
     @patch.object(models.Backend, '__postprocess_testjob__')
+    @patch('squad.ci.backend.null.Backend.job_url', return_value="http://example.com/123")
     @patch('squad.ci.backend.null.Backend.fetch')
     @patch('squad.ci.models.ReceiveTestRun.__call__')
-    def test_really_fetch_postprocessing(self, receive, backend_fetch, postprocess):
+    def test_really_fetch_postprocessing(self, receive, backend_fetch, backend_job_url, postprocess):
         backend_fetch.return_value = ('Completed', True, {}, {}, {}, None)
 
         env = self.project.environments.create(slug='foo')
@@ -466,7 +468,8 @@ class TestJobTest(TestCase):
         )
         self.assertIsNone(testjob.job_id)
 
-    def test_records_resubmitted_count(self):
+    @patch('squad.ci.backend.null.Backend.resubmit', return_value="1")
+    def test_records_resubmitted_count(self, backend_resubmit):
         testjob = models.TestJob.objects.create(
             target=self.project,
             target_build=self.build,

--- a/test/core/test_build.py
+++ b/test/core/test_build.py
@@ -139,8 +139,9 @@ class BuildTest(TestCase):
         finished, _ = build.finished
         self.assertFalse(finished)
 
+    @patch('squad.ci.backend.null.Backend.job_url', return_value="http://example.com/123")
     @patch('squad.ci.backend.null.Backend.fetch')
-    def test_not_finished_with_pending_ci_jobs(self, fetch):
+    def test_not_finished_with_pending_ci_jobs(self, fetch, job_url):
         build = self.project.builds.create(version='1')
         env1 = self.project.environments.create(slug='env1', expected_test_runs=1)
         backend = Backend.objects.create(name='foobar', implementation_type='null')
@@ -176,8 +177,9 @@ class BuildTest(TestCase):
         finished, _ = build.finished
         self.assertTrue(finished)
 
+    @patch('squad.ci.backend.null.Backend.job_url', return_value="http://example.com/123")
     @patch('squad.ci.backend.null.Backend.fetch')
-    def test_not_finished_no_pending_testjobs_but_not_enough_of_them(self, fetch):
+    def test_not_finished_no_pending_testjobs_but_not_enough_of_them(self, fetch, job_url):
         build = self.project.builds.create(version='1')
         env1 = self.project.environments.create(slug='env1', expected_test_runs=2)
         backend = Backend.objects.create(name='foobar', implementation_type='null')

--- a/test/frontend/test_test_job.py
+++ b/test/frontend/test_test_job.py
@@ -27,7 +27,8 @@ class TestJobViewTest(TestCase):
         )
         self.assertIsNone(testjob.job_id)
 
-    def test_testjob_page(self):
+    @patch('squad.ci.backend.null.Backend.job_url', return_value=None)
+    def test_testjob_page(self, backend_job_url):
         job_id = 1234
         testjob = models.TestJob.objects.create(
             target=self.project,

--- a/test/integration/test_build_notification_from_ci.py
+++ b/test/integration/test_build_notification_from_ci.py
@@ -17,8 +17,9 @@ logs = "hello world\nfinished\n"
 class BuildNotificationFromCI(TestCase):
 
     @patch('squad.core.tasks.maybe_notify_project_status')
+    @patch('squad.ci.backend.null.Backend.job_url', return_value="http://example.com/123")
     @patch('squad.ci.backend.null.Backend.fetch')
-    def test_fetch_triggers_notification(self, fetch, notify):
+    def test_fetch_triggers_notification(self, fetch, job_url, notify):
         fetch.return_value = (job_status, completed, metadata, tests, metrics, logs)
 
         group = Group.objects.create(slug='mygroup')


### PR DESCRIPTION
This patch adds support for multinode jobs. In case of multnode LAVA API
calls return list in the following form: [job_id.0, job_id.1, ...].
SQUAD will use each of the IDs in the list to create new TestJob object.
This way we ensure that results from all test jobs are assigned to
proper build and fetched.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>