### PR TITLE
api: fix authentication in resubmit API

### DIFF
--- a/squad/api/ci.py
+++ b/squad/api/ci.py
@@ -3,7 +3,7 @@ from django.shortcuts import get_object_or_404
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_http_methods
 
-from squad.http import auth_submit, read_file_upload
+from squad.http import auth_submit, read_file_upload, auth_user_from_request
 from squad.ci.tasks import submit
 from squad.ci.models import Backend, TestJob
 
@@ -99,9 +99,9 @@ def watch_job(request, group_slug, project_slug, version, environment_slug):
 @csrf_exempt
 def resubmit_job(request, test_job_id, method='resubmit'):
     testjob = get_object_or_404(TestJob.objects, pk=test_job_id)
-
+    user = auth_user_from_request(request, request.user)
     project = testjob.target
-    if not project.can_submit(request.user):
+    if not project.can_submit(user):
         return HttpResponse(status=401)
 
     call = getattr(testjob, method)


### PR DESCRIPTION
This patch adds support for token authentication in /api/resubmit/<id>.
This API will now work with external requests and Auth-Token header.
Header value should be set to the token used with REST API.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>