### PR TITLE
ci: allow cloning LAVA results with measurements

### DIFF
--- a/doc/ci.rst
+++ b/doc/ci.rst
@@ -135,6 +135,10 @@ LAVA backend supports the following settings:
    boolean flag that parses results from LAVA test suite when
    set to ``True``. Please note that this option can be overwritten by
    having the same option with different value in Project `project_settings`
+ - CI_LAVA_CLONE_MEASUREMENTS
+   boolean flag that allows to sate LAVA result as both Test and Measurement
+   when set to ``True``. Default is ``False``. Can be overwritten for each
+   project separately (similar to CI_LAVA_HANDLE_SUITE).
 
 Example LAVA backend settings:
 

--- a/test/ci/backend/test_lava.py
+++ b/test/ci/backend/test_lava.py
@@ -460,6 +460,29 @@ class LavaTest(TestCase):
 
     @patch("squad.ci.backend.lava.Backend.__get_job_logs__", return_value="abc")
     @patch("squad.ci.backend.lava.Backend.__get_job_details__", return_value=JOB_DETAILS)
+    @patch("squad.ci.backend.lava.Backend.__get_testjob_results_yaml__", return_value=TEST_RESULTS)
+    def test_parse_results_clone_measurements(self, get_results, get_details, get_logs):
+        self.backend.backend_settings = 'CI_LAVA_CLONE_MEASUREMENTS: true'
+
+        # Project settings has higher priority than backend settings
+        self.project.project_settings = 'CI_LAVA_CLONE_MEASUREMENTS: true'
+
+        lava = LAVABackend(self.backend)
+        testjob = TestJob(
+            job_id='1235',
+            backend=self.backend,
+            target=self.project,
+            target_build=self.build,
+            environment="foo_env")
+        status, completed, metadata, results, metrics, logs = lava.fetch(testjob)
+
+        self.assertEqual(len(results), 3)
+        self.assertEqual(len(metrics), 2)
+        self.assertEqual(10, metrics['DefinitionFoo/case_foo'])
+        self.assertEqual('job_foo', testjob.name)
+
+    @patch("squad.ci.backend.lava.Backend.__get_job_logs__", return_value="abc")
+    @patch("squad.ci.backend.lava.Backend.__get_job_details__", return_value=JOB_DETAILS)
     @patch("squad.ci.backend.lava.Backend.__get_testjob_results_yaml__", return_value=TEST_RESULTS_INFRA_FAILURE)
     def test_completed(self, get_results, get_details, get_logs):
         lava = LAVABackend(None)


### PR DESCRIPTION
LAVA results always carry 'pass/fail' information. So far this was
discarded in case there was measurement associated with the result. This
patch allows to save LAVA result as both Test and Measurement.

Fixes: #536

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>