### PR TITLE
frontend/templatetags: fix pagination get_page_url

### DIFF
--- a/squad/frontend/templatetags/squad.py
+++ b/squad/frontend/templatetags/squad.py
@@ -162,7 +162,7 @@ def get_page_list(items):
 @register_global_function(takes_context=True)
 def get_page_url(context, page):
     query_string = context['request'].GET.copy()
-    query_string.update({'page': page})
+    query_string['page'] = page
     return '?' + query_string.urlencode()
 
 

--- a/test/frontend/test_template_tags.py
+++ b/test/frontend/test_template_tags.py
@@ -17,8 +17,11 @@ class FakeGet():
     def __init__(self, params=None):
         self.params = params or {}
 
-    def update(self, params):
-        self.params.update(**params)
+    def __setitem__(self, key, value):
+        self.params[key] = value
+
+    def __getitem__(self, key):
+        return self.params[key]
 
     def copy(self):
         return self


### PR DESCRIPTION
Fix a bug where every page change, the variable `page` is appended
to the querystring, instead of being updated.

For some reason, `query_string.update` was appending `page` key in every iteraction.