### PR TITLE
frontend: fix floatThead

### DIFF
--- a/.ackrc
+++ b/.ackrc
@@ -4,7 +4,7 @@
 --ignore-dir=squad/frontend/static/lodash.js
 --ignore-dir=squad/frontend/static/chartjs
 --ignore-dir=squad/frontend/static/jquery.js
---ignore-dir=squad/frontend/static/floatThread
+--ignore-dir=squad/frontend/static/floatThead
 --ignore-dir=squad/frontend/static/select2.js/
 --ignore-dir=squad/frontend/static/download.status
 --ignore-dir=static

--- a/.ctags
+++ b/.ctags
@@ -4,7 +4,7 @@
 --exclude=squad/frontend/static/lodash.js
 --exclude=squad/frontend/static/chartjs
 --exclude=squad/frontend/static/jquery.js
---exclude=squad/frontend/static/floatThread
+--exclude=squad/frontend/static/floatThead
 --exclude=squad/frontend/static/select2.js/
 --exclude=squad/frontend/static/download.status
 --exclude=static

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@
 /squad/frontend/static/lodash.js
 /squad/frontend/static/chartjs
 /squad/frontend/static/jquery.js
-/squad/frontend/static/floatThread
+/squad/frontend/static/floatThead
 /squad/frontend/static/select2.js/
 /squad/frontend/static/download.status
 /squad/local_settings.py

--- a/squad/frontend/static/download.conf
+++ b/squad/frontend/static/download.conf
@@ -1,3 +1,4 @@
+# NOTE: please re-run `./download` script in order to update cached files
 # DESTINATION             SOURCE                                                                                SHA1SUM
 angularjs                 http://code.angularjs.org/1.6.6/angular-1.6.6.zip                                     5731a2c2bdbba7077812bb76300b625a07be353e
 bootstrap                 https://github.com/twbs/bootstrap/releases/download/v3.3.7/bootstrap-3.3.7-dist.zip   e6b1000b94e835ffd37f4c6dcbdad43f4b48a02a
@@ -5,7 +6,7 @@ chartjs/Chart.bundle.js   https://github.com/chartjs/Chart.js/releases/download/
 font-awesome              http://deb.debian.org/debian/pool/main/f/fonts-font-awesome/fonts-font-awesome_4.7.0~dfsg.orig.tar.gz a59bc27ace9906ae09cc8a49aac3b70899e0ae70
 lodash.js                 https://raw.githubusercontent.com/lodash/lodash/4.17.4/dist/lodash.js                 d8e7e155b43e7edcabc46682a809836a68444b01
 jquery.js                 https://code.jquery.com/jquery-3.2.1.js                                               fd81582bf1b15e6747472df880ca822c362a97d1
-floatThread               https://github.com/mkoryak/floatThead/archive/2.0.3.zip                               d7112698ed5bf14f953fdef6252fdd9950af90bf
+floatThead                https://github.com/mkoryak/floatThead/archive/2.0.3.zip                               d7112698ed5bf14f953fdef6252fdd9950af90bf
 select2.js/select2.min.js https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.5/js/select2.min.js                42fe805a338908436c5c326dbf7e9aec0c8484c7
 select2.js/select2.css    https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.5/css/select2.css                  03f47309050b0691af394398f394065e8dd38503
 chartjs/chartjs-plugin-annotation.min.js https://cdnjs.cloudflare.com/ajax/libs/chartjs-plugin-annotation/0.5.7/chartjs-plugin-annotation.min.js 27026bf430b2301317e0beaa65701151b7515e87

--- a/squad/frontend/templates/squad/_test_results_table.jinja2
+++ b/squad/frontend/templates/squad/_test_results_table.jinja2
@@ -1,22 +1,24 @@
 {% if comparison %}
 <table class='test-results'>
-  <tr>
-    <td rowspan='2'></td>
-    {% for build, environments in comparison.environments.items() %}
-    <th colspan={{environments|length}}>
-      <a href="{{project_url(build)}}">{{ _('%s, build %s') % (build.project, build.version) }}</a>
-    </th>
-    {% endfor %}
-  </tr>
-  <tr>
-    {% for build, environments in comparison.environments.items() %}
-      {% for environment in environments %}
-      <th>
-        {{environment}}
+  <thead>
+    <tr>
+      <td rowspan='2'></td>
+      {% for build, environments in comparison.environments.items() %}
+      <th colspan={{environments|length}}>
+        <a href="{{project_url(build)}}">{{ _('%s, build %s') % (build.project, build.version) }}</a>
       </th>
       {% endfor %}
-    {% endfor %}
-  </tr>
+    </tr>
+    <tr>
+      {% for build, environments in comparison.environments.items() %}
+        {% for environment in environments %}
+        <th>
+          {{environment}}
+        </th>
+        {% endfor %}
+      {% endfor %}
+    </tr>
+  </thead>
   {% for test, results in comparison.results %}
     <tr>
       <th>{{test}}</th>

--- a/squad/frontend/templates/squad/base.jinja2
+++ b/squad/frontend/templates/squad/base.jinja2
@@ -71,7 +71,7 @@
     <script type="text/javascript" src="{{static("bootstrap/js/bootstrap.js")}}"></script>
     <script type="text/javascript" src="{{static("angularjs/angular.js")}}"></script>
     <script type="text/javascript" src="{{static("lodash.js")}}"></script>
-    <script type="text/javascript" src="{{static("floatThread/dist/jquery.floatThead.js")}}"></script>
+    <script type="text/javascript" src="{{static("floatThead/dist/jquery.floatThead.js")}}"></script>
     <script type="text/javascript" src="{{static("squad/common.js")}}"></script>
     <script type="text/javascript">
         csrf_token = '{{ csrf_token }}'

--- a/squad/frontend/templates/squad/build.jinja2
+++ b/squad/frontend/templates/squad/build.jinja2
@@ -21,12 +21,14 @@
 <div class="row" id="test-results">
     <div class='col-md-12 col-sm-12'>
         <table class='test-results'>
-            <tr>
-                <th style='width: 150px'>{{ _('Suite') }}</th>
-                {% for environment in test_results.environments  %}
-                <th>{{environment}}</th>
-                {% endfor %}
-            </tr>
+            <thead>
+                <tr>
+                    <th style='width: 150px'>{{ _('Suite') }}</th>
+                    {% for environment in test_results.environments  %}
+                    <th>{{environment}}</th>
+                    {% endfor %}
+                </tr>
+            </thead>
             {% for suite, results in test_results.data.items() %}
 	    <tr id='tests-{{suite.id}}' ng-show='match("tests-{{suite.id}}") || match("details-{{suite.id}}")'>
                 <td ng-click='toggle_details("details-{{suite.id}}")'>
@@ -186,4 +188,5 @@
 
 {% block javascript %}
 <script type="module" src='{{static("squad/build.js")}}'></script>
+<script type="module" src='{{static("squad/table.js")}}'></script>
 {% endblock %}


### PR DESCRIPTION
I noticed that the plugin `floatThead` as in *float table head*, was named wrong in download scripts as `floatThread`. This PR renames floatThread to floatThead and add `thead` where needed.

Hopefully it won't conflict with https://github.com/Linaro/squad/pull/543, but if it does, I'll update this PR.