### PR TITLE
frontend: js: update lodash to 4.17.14

### DIFF
--- a/squad/frontend/static/download.conf
+++ b/squad/frontend/static/download.conf
@@ -4,7 +4,7 @@ angularjs                 http://code.angularjs.org/1.6.6/angular-1.6.6.zip     
 bootstrap                 https://github.com/twbs/bootstrap/releases/download/v3.3.7/bootstrap-3.3.7-dist.zip   e6b1000b94e835ffd37f4c6dcbdad43f4b48a02a
 chartjs/Chart.bundle.js   https://github.com/chartjs/Chart.js/releases/download/v2.7.0/Chart.bundle.js          345ebf1ec2b69db24cfbda8e7ad61516086c3848
 font-awesome              http://deb.debian.org/debian/pool/main/f/fonts-font-awesome/fonts-font-awesome_4.7.0~dfsg.orig.tar.gz a59bc27ace9906ae09cc8a49aac3b70899e0ae70
-lodash.js                 https://raw.githubusercontent.com/lodash/lodash/4.17.4/dist/lodash.js                 d8e7e155b43e7edcabc46682a809836a68444b01
+lodash.js                 https://raw.githubusercontent.com/lodash/lodash/4.17.14/dist/lodash.js                f5d17a118da63d17eeade07e4ebb455f7c7d7237
 jquery.js                 https://code.jquery.com/jquery-3.2.1.js                                               fd81582bf1b15e6747472df880ca822c362a97d1
 floatThead                https://github.com/mkoryak/floatThead/archive/2.0.3.zip                               d7112698ed5bf14f953fdef6252fdd9950af90bf
 select2.js/select2.min.js https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.5/js/select2.min.js                42fe805a338908436c5c326dbf7e9aec0c8484c7


### PR DESCRIPTION
CVE-2019-10744 reported a vulnerability in lodash < 4.17.13
that was fixed in that version

See https://github.com/lodash/lodash/pull/4336 for context.