### PR TITLE
frontend: results_table: show "mean (stddev)" details only for metric comparison

### DIFF
--- a/squad/frontend/templates/squad/_results_table.jinja2
+++ b/squad/frontend/templates/squad/_results_table.jinja2
@@ -20,8 +20,10 @@
         {% for environment in environments %}
         <th>
           {{environment}}
-          <br />
-          {{ _('mean (stdev)') }}
+          {% if comparison_type == 'metric' %}
+            <br />
+            {{ _('mean (stdev)') }}
+          {% endif %}
         </th>
         {% endfor %}
       {% endfor %}


### PR DESCRIPTION
Forgot to restrict the "mean stddev" details only to be displayed for metric comparison.