### PR TITLE
Improve project compare

### DIFF
--- a/squad/api/rest.py
+++ b/squad/api/rest.py
@@ -251,6 +251,7 @@ class GroupViewSet(viewsets.ModelViewSet):
     serializer_class = GroupSerializer
     filter_fields = ('slug', 'name')
     filter_class = GroupFilter
+    filter_backends = (ComplexFilterBackend, )
     search_fields = ('slug', 'name')
     ordering_fields = ('slug', 'name')
 

--- a/squad/frontend/comparison.py
+++ b/squad/frontend/comparison.py
@@ -1,7 +1,10 @@
+from functools import reduce
+
 from django.shortcuts import render, get_object_or_404
 from django.core.paginator import Paginator
+from django.db.models import Q, Prefetch
 
-from squad.core.models import Project, Group
+from squad.core.models import Project, Group, Build
 from squad.core.comparison import TestComparison, MetricComparison
 from squad.frontend.utils import alphanum_sort
 
@@ -17,20 +20,28 @@ def compare_projects(request):
     comparison = None
     group = None
     projects = None
-    selected = None
 
     comparison_type = request.GET.get('comparison_type', 'test')
     group_slug = request.GET.get('group')
 
     if group_slug:
         group = get_object_or_404(Group, slug=group_slug)
-        user = request.user
-        projects = alphanum_sort(group.projects.accessible_to(user), 'slug')
-        selected = [p for p in projects if p.slug in request.GET.getlist('project')]
+        qs = group.projects.accessible_to(request.user).prefetch_related(
+            Prefetch('builds', queryset=Build.objects.order_by('-datetime'))
+        )
+        projects = alphanum_sort(qs, 'slug')
 
-        if len(selected) > 1:
+        filters = []
+        for key, value in request.GET.items():
+            if 'project_' in key and len(key.split('_')) == 2:
+                project_id = key.split('_')[1]
+                filters.append(Q(project_id=project_id) & Q(version=value))
+
+        if len(filters) > 1:
+            build_filters = reduce(lambda x, y: x | y, filters)
+            builds = Build.objects.filter(build_filters)
             comparison_class = __get_comparison_class(comparison_type)
-            comparison = comparison_class.compare_projects(*selected)
+            comparison = comparison_class.compare_builds(*builds)
 
             try:
                 page = int(request.GET.get('page', '1'))
@@ -42,7 +53,6 @@ def compare_projects(request):
     context = {
         'group': group,
         'projects': projects,
-        'selected': selected,
         'comparison': comparison,
         'comparison_type': comparison_type,
     }

--- a/squad/frontend/comparison.py
+++ b/squad/frontend/comparison.py
@@ -3,6 +3,7 @@ from django.core.paginator import Paginator
 
 from squad.core.models import Project, Group
 from squad.core.comparison import TestComparison, MetricComparison
+from squad.frontend.utils import alphanum_sort
 
 
 def __get_comparison_class(comparison_type):
@@ -24,7 +25,7 @@ def compare_projects(request):
     if group_slug:
         group = get_object_or_404(Group, slug=group_slug)
         user = request.user
-        projects = group.projects.accessible_to(user)
+        projects = alphanum_sort(group.projects.accessible_to(user), 'slug')
         selected = [p for p in projects if p.slug in request.GET.getlist('project')]
 
         if len(selected) > 1:

--- a/squad/frontend/static/compare.css
+++ b/squad/frontend/static/compare.css
@@ -1,0 +1,16 @@
+form#compare-projects-form div.checkbox {
+    height: 2.2em;
+}
+
+form#compare-projects-form div.checkbox select{
+    width: 20em;
+    padding-top: 0px;
+}
+
+form#compare-projects-form div.checkbox label{
+    padding-top: 5px;
+}
+
+form#compare-projects-form div.checkbox .select-build{
+    display: inline;
+}

--- a/squad/frontend/static/squad/controllers/project_compare.js
+++ b/squad/frontend/static/squad/controllers/project_compare.js
@@ -7,4 +7,26 @@ export function ProjectCompareController($scope, attach_select2) {
             })
         }
     }
+
+    // projects is in the form of [project_id] => true/false
+    // where true == checked, and false == not checked
+    $scope.projects = {}
+
+    $scope.attachSelect2 = function(elemId, project_id) {
+        var elem = $('#' + elemId)
+        attach_select2('/api/builds/', elem, 'version', function(term){
+            return {'project__id': project_id, 'version__startswith': term}
+        })
+    }
+
+    $scope.submit = function() {
+        var selected_builds = {}
+        for(var project_id in $scope.projects) {
+            if($scope.projects[project_id]) {
+                let key = 'project_' + project_id
+                selected_builds[key] = $('select[name=' + key + ']').val()
+            }
+        }
+        console.log($.param(selected_builds))
+    }
 }

--- a/squad/frontend/static/squad/controllers/project_compare.js
+++ b/squad/frontend/static/squad/controllers/project_compare.js
@@ -1,0 +1,10 @@
+export function ProjectCompareController($scope, attach_select2) {
+    $scope.init = function() {
+        if($('#group-select').length) {
+            attach_select2('/api/groups/', $('#group-select'), 'slug', function(term){
+                return {'filters': '%28name__icontains%253D' + term +
+                       '%29%20%7C%20%28slug__icontains%253D' + term + '%29'}
+            })
+        }
+    }
+}

--- a/squad/frontend/static/squad/project_compare.js
+++ b/squad/frontend/static/squad/project_compare.js
@@ -1,0 +1,19 @@
+import {ProjectCompareController} from './controllers/project_compare.js'
+import {attach_select2} from './attach_select2.js'
+import {Config as appConfig} from './config.js'
+
+var app = angular.module('ProjectCompare', []);
+
+appConfig(app, ['httpProvider']);
+
+app.factory('attach_select2', ['$http', attach_select2]);
+
+app.controller(
+    'ProjectCompareController',
+    [
+        '$scope',
+        'attach_select2',
+        ProjectCompareController
+    ]
+);
+

--- a/squad/frontend/templates/squad/compare_projects.jinja2
+++ b/squad/frontend/templates/squad/compare_projects.jinja2
@@ -14,34 +14,62 @@
     {% include "squad/_pagination.jinja2" %}
   {% endwith %}
 {% endif %}
-
-<h2>{{ _('Select projects to compare') }}</h2>
-<form>
-  {% for project in projects %}
-  <div class="checkbox">
-    <label>
-      <input type='checkbox' name='project' value='{{project}}'
-       {% if project in selected %}
-       checked
-       {% endif %}
-       />
-      {{project}}
-    </label>
+<div class="row">
+  <div class="col-md-6 col-sm-6" ng-app="ProjectCompare" ng-controller="ProjectCompareController" ng-init="init()">
+    <form>
+      <div class="form-group">
+        <h2>{{ _('Group') }}</h2>
+        <select
+          name="group"
+          id="group-select"
+          placeholder="{{ _('Enter group name') }}"
+          onchange="this.form.submit()"
+          class="form-control"
+        >
+          {% if group %}
+            <option id="{{group.slug}}">{{ group.slug }}</option>
+          {% endif %}
+        </select>
+      </div>
+      {% if group %}
+        <h2>{{ _('Select projects to compare') }}</h2>
+        {% for project in projects %}
+        <div class="checkbox form-group">
+          <label>
+            <input
+              type='checkbox'
+              name='project'
+              value='{{project.slug}}'
+              {% if project in selected %}checked{% endif %}
+            />
+            {{project.slug}}
+          </label>
+        </div>
+        {% endfor %}
+        <div class="form-group">
+          <label>{{ _('Comparison type') }}</label>
+          <div>
+            <input id="test-comparison" name="comparison_type" type="radio" value="test" checked="checked"/>
+            <label for="test-comparison">{{ _('compare by tests') }}</label>
+            <br />
+            <input id="metric-comparison" name="comparison_type" type="radio" value="metric" />
+            <label for="metric-comparison">{{ _('compare by metrics') }}</label>
+          </div>
+        </div>
+        <div class="form-group">
+          <input onclick="this.form.submit()" value="{{ _('Compare') }}" type="button" class="btn btn-default" />
+        </div>
+      {% endif %}
+    </form>
   </div>
-  {% endfor %}
-  <div class="form-group">
-    <label>{{ _('Comparison type') }}</label>
-    <div>
-      <input id="test-comparison" name="comparison_type" type="radio" value="test" checked="checked"/>
-      <label for="test-comparison">{{ _('compare by tests') }}</label>
-      <br />
-	  <input id="metric-comparison" name="comparison_type" type="radio" value="metric" />
-      <label for="metric-comparison">{{ _('compare by metrics') }}</label>
-    </div>
-  </div>
-  <input type='submit' value='{{ _('Compare') }}' class='btn btn-default'/>
-</form>
+</div>
 {% endblock %}
 {% block javascript %}
 <script type="text/javascript" src='{{static("squad/table.js")}}'></script>
+<script type="text/javascript" src='{{static("select2.js/select2.min.js")}}'></script>
+<script type="module" src='{{static("squad/project_compare.js")}}'></script>
+{% endblock %}
+
+{% block styles %}
+<link href='{{static("select2.js/select2.css")}}' rel="stylesheet" />
 {% endblock %}

--- a/squad/frontend/templates/squad/compare_projects.jinja2
+++ b/squad/frontend/templates/squad/compare_projects.jinja2
@@ -16,14 +16,14 @@
 {% endif %}
 <div class="row">
   <div class="col-md-6 col-sm-6" ng-app="ProjectCompare" ng-controller="ProjectCompareController" ng-init="init()">
-    <form>
+    <form id="compare-projects-form">
       <div class="form-group">
         <h2>{{ _('Group') }}</h2>
         <select
           name="group"
           id="group-select"
           placeholder="{{ _('Enter group name') }}"
-          onchange="this.form.submit()"
+          onchange="window.location='{{request.path}}?group=' + this.value"
           class="form-control"
         >
           {% if group %}
@@ -34,16 +34,29 @@
       {% if group %}
         <h2>{{ _('Select projects to compare') }}</h2>
         {% for project in projects %}
+        {% set project_key = 'project_%d' % project.id %}
+        {% set version = request.GET.get(project_key, project.builds.first().version) %}
         <div class="checkbox form-group">
           <label>
             <input
               type='checkbox'
-              name='project'
-              value='{{project.slug}}'
-              {% if project in selected %}checked{% endif %}
+              ng-model="projects[{{project.id}}]"
+              ng-init="projects[{{project.id}}] = {{ string(project_key in request.GET)|lower }}"
             />
             {{project.slug}}
           </label>
+          <div class="select-build" ng-show="projects[{{project.id}}]">
+            <select
+              id="{{project_key}}"
+              name="{{project_key}}"
+              placeholder="{{ _('Enter build version') }}"
+              ng-init="attachSelect2('{{project_key}}', {{project.id}})"
+            >
+              {% if version %}
+              <option id="{{ version }}">{{ version }}</option>
+              {% endif %}
+            </select>
+          </div>
         </div>
         {% endfor %}
         <div class="form-group">
@@ -72,4 +85,5 @@
 
 {% block styles %}
 <link href='{{static("select2.js/select2.css")}}' rel="stylesheet" />
+<link href='{{static("compare.css")}}' rel="stylesheet" />
 {% endblock %}

--- a/squad/frontend/templatetags/squad.py
+++ b/squad/frontend/templatetags/squad.py
@@ -37,6 +37,11 @@ def url(path, *args, **kwargs):
 
 
 @register_global_function
+def string(value):
+    return str(value)
+
+
+@register_global_function
 def group_url(group):
     return reverse('group', args=[group.slug])
 

--- a/test/frontend/test_comparison.py
+++ b/test/frontend/test_comparison.py
@@ -57,7 +57,8 @@ class ProjectComparisonTest(TestCase):
         self.build2 = self.project2.builds.last()
 
     def test_comparison_project_sanity_check(self):
-        response = self.client.get('/_/compare/?group=mygroup&project=project1&project=project2')
+        url = '/_/compare/?group=mygroup&project_%d=1&project_%d=1' % (self.project1.id, self.project2.id)
+        response = self.client.get(url)
         self.assertEqual(200, response.status_code)
         self.assertIn('d/e', str(response.content))
         self.assertIn('myenv', str(response.content))

--- a/test/frontend/test_comparison.py
+++ b/test/frontend/test_comparison.py
@@ -57,7 +57,7 @@ class ProjectComparisonTest(TestCase):
         self.build2 = self.project2.builds.last()
 
     def test_comparison_project_sanity_check(self):
-        response = self.client.get('/_/compare/?project=mygroup/project1&project=mygroup/project2')
+        response = self.client.get('/_/compare/?group=mygroup&project=project1&project=project2')
         self.assertEqual(200, response.status_code)
         self.assertIn('d/e', str(response.content))
         self.assertIn('myenv', str(response.content))


### PR DESCRIPTION
Closes https://github.com/Linaro/squad/issues/186

This PR includes the following improvements:
 - restrict project comparison to projects from the same group only
   - change group by typing its name or slug under "Group" header
 - by selecting a project, a dropdown box appears next to it for build selection
   - by default, the latest build is selected
   - change build by typing its version string

![Screenshot from 2019-07-17 19-37-59](https://user-images.githubusercontent.com/2254825/61419194-85ed5480-a8d3-11e9-9bfa-f5f66ef6aa95.png)
