### PR TITLE
frontend: css: fix word-wrap

### DIFF
--- a/squad/frontend/static/main.css
+++ b/squad/frontend/static/main.css
@@ -182,6 +182,10 @@ table.test-results-details {
   margin-top: 1em;
 }
 
+.metric-selected small, .popover-content li {
+	word-break: break-all;
+}
+
 .settings-nav a {
   display: block;
 }


### PR DESCRIPTION
Fix word-wrap for long metric names and for long test names
when displaying regressions/fixes

From this

![Screenshot from 2019-07-29 08-40-27](https://user-images.githubusercontent.com/2254825/62048541-88a94d00-b1e3-11e9-8f5c-dce64386a613.png)
![Screenshot from 2019-07-29 09-22-58](https://user-images.githubusercontent.com/2254825/62048583-9fe83a80-b1e3-11e9-88f3-a08254fb9bcd.png)


To this

![Screenshot from 2019-07-29 09-22-26](https://user-images.githubusercontent.com/2254825/62048617-b5f5fb00-b1e3-11e9-8de3-9d90155869e4.png)
![Screenshot from 2019-07-29 09-24-12](https://user-images.githubusercontent.com/2254825/62048621-bb534580-b1e3-11e9-86bf-87318def1468.png)
