### PR TITLE
frontend: fix page title in project settings

### DIFF
--- a/squad/frontend/templates/squad/project_settings/base.jinja2
+++ b/squad/frontend/templates/squad/project_settings/base.jinja2
@@ -2,7 +2,7 @@
 
 {% block content %}
 
-{% with pagetitle="» Project settings" %}
+{% with pagetitle="Project settings" %}
 {% include "squad/project-nav.jinja2" %}
 {% endwith %}
 


### PR DESCRIPTION
The template already puts a » in the correct place, so there is no need
to include one in the title itself.