### PR TITLE
frontend: filter comparison by transitions

### DIFF
--- a/squad/frontend/static/compare.css
+++ b/squad/frontend/static/compare.css
@@ -14,3 +14,13 @@ form#compare-projects-form div.checkbox label{
 form#compare-projects-form div.checkbox .select-build{
     display: inline;
 }
+
+div#test-results-transition-filters table {
+   width: 60%;
+}
+div#test-results-transition-filters table th,
+div#test-results-transition-filters table td {
+    width: 10%;
+    text-align: center;
+    padding: 3px;
+}

--- a/squad/frontend/static/squad/controllers/project_compare.js
+++ b/squad/frontend/static/squad/controllers/project_compare.js
@@ -27,6 +27,6 @@ export function ProjectCompareController($scope, attach_select2) {
                 selected_builds[key] = $('select[name=' + key + ']').val()
             }
         }
-        console.log($.param(selected_builds))
+        window.location = window.location.search + '&' + $.param(selected_builds)
     }
 }

--- a/squad/frontend/templates/squad/_results_table.jinja2
+++ b/squad/frontend/templates/squad/_results_table.jinja2
@@ -1,4 +1,9 @@
 {% if comparison %}
+
+{% if comparison_type == 'test' %}
+  {% include "squad/_results_transitions_filter.jinja2" %}
+{% endif %}
+
 <table class='test-results'>
   <thead>
     <tr>
@@ -29,34 +34,40 @@
       {% endfor %}
     </tr>
   </thead>
-  {% for test, results in comparison.results %}
+  {% if not comparison.results %}
     <tr>
-      <th>{{test}}</th>
-      {% for build, environments in comparison.environments.items() %}
-        {% for environment in environments %}
-          {% with result=results.get((build, environment)) %}
-            {% if result %}
-              {% if comparison_type == 'test' %}
-                <td class='{{result|slugify}}'>
-                  <a href="{{url('test_history', args=[build.project.group.slug, build.project.slug, test])}}">
-                    <strong>{{result}}</strong>
-                  </a>
-                </td>
-              {% else %}
-                {% set mean = result.0|float %}
-                {% set stddev = result.1|float %}
-                {% set total = result.2|int %}
-                <td title="{{_('Number of measurements: %d' % total)}}">
-                  <strong>{{'%.2f' % mean}} ({{'%.2f' % stddev}})</strong>
-                </td>
-              {% endif %}
-            {% else %}
-              <td><i>{{ _('n/a') }}</i></td>
-            {% endif %}
-          {% endwith %}
-        {% endfor %}
-      {% endfor %}
+      <th>No tests to display</th>
     </tr>
-  {% endfor %}
+  {% else %}
+    {% for test, results in comparison.results %}
+      <tr>
+        <th>{{test}}</th>
+        {% for build, environments in comparison.environments.items() %}
+          {% for environment in environments %}
+            {% with result=results.get((build, environment)) %}
+              {% if result %}
+                {% if comparison_type == 'test' %}
+                  <td class='{{result|slugify}}'>
+                    <a href="{{url('test_history', args=[build.project.group.slug, build.project.slug, test])}}">
+                      <strong>{{result}}</strong>
+                    </a>
+                  </td>
+                {% else %}
+                  {% set mean = result.0|float %}
+                  {% set stddev = result.1|float %}
+                  {% set total = result.2|int %}
+                  <td title="{{_('Number of measurements: %d' % total)}}">
+                    <strong>{{'%.2f' % mean}} ({{'%.2f' % stddev}})</strong>
+                  </td>
+                {% endif %}
+              {% else %}
+                <td><i>{{ _('n/a') }}</i></td>
+              {% endif %}
+            {% endwith %}
+          {% endfor %}
+        {% endfor %}
+      </tr>
+    {% endfor %}
+  {% endif %}
 </table>
 {% endif %}

--- a/squad/frontend/templates/squad/_results_transitions_filter.jinja2
+++ b/squad/frontend/templates/squad/_results_transitions_filter.jinja2
@@ -1,0 +1,54 @@
+{% set states = ['pass', 'fail', 'xfail', 'skip', 'n/a'] %}
+{% set transition_filter_action = request.path + strip_get_parameters(['transitions', 'page']) %}
+{% set ignore = 'ignore' in request.GET.getlist('transitions', []) %}
+<div id="test_result_transition_filters" class="col-md-6 row">
+  <h3>Select transitions to display</h3>
+  <form id="transitions-form">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>{{ _('From / To') }}</th>
+          {% for state in states %}
+            <th>{{ state }}</th>
+          {% endfor %}
+        </tr>
+      </thead>
+      <tbody>
+        {% for _from in states %}
+          <tr>
+            <th>{{ _from }}</th>
+            {% for _to in states %}
+              <td>
+              {% if _from ==_to %}
+                -
+              {% else %}
+                <input
+                  name="transitions"
+                  value="{{ _from }}:{{ _to  }}"
+                  type="checkbox"
+                  onchange="window.location='{{ transition_filter_action }}&' + $(this.form).serialize()"
+                  {{ 'checked' if transitions.get((_from, _to)) else ''}}
+                  {{ 'disabled' if ignore else '' }}
+                />
+              {% endif %}
+              </td>
+            {% endfor %}
+          </tr>
+        {% endfor %}
+        <tr>
+          <th colspan="6">
+                {{ _('show all tests') }}&nbsp;
+                <input
+                  name="transitions"
+                  value="ignore"
+                  type="checkbox"
+                  onchange="window.location='{{ transition_filter_action }}&' + $(this.form).serialize()"
+                  {{ 'checked' if ignore else ''}}
+                />
+          </th>
+        </tr>
+      </tbody>
+    </table>
+  </form>
+</div>
+<div class="clearfix"></div>

--- a/squad/frontend/templates/squad/_results_transitions_filter.jinja2
+++ b/squad/frontend/templates/squad/_results_transitions_filter.jinja2
@@ -1,13 +1,13 @@
 {% set states = ['pass', 'fail', 'xfail', 'skip', 'n/a'] %}
 {% set transition_filter_action = request.path + strip_get_parameters(['transitions', 'page']) %}
 {% set ignore = 'ignore' in request.GET.getlist('transitions', []) %}
-<div id="test_result_transition_filters" class="col-md-6 row">
+<div id="test-results-transition-filters" class="col-md-6 row">
   <h3>Select transitions to display</h3>
   <form id="transitions-form">
     <table class="table table-striped">
       <thead>
         <tr>
-          <th>{{ _('From / To') }}</th>
+          <th>{{ _('From/To') }}</th>
           {% for state in states %}
             <th>{{ state }}</th>
           {% endfor %}
@@ -35,20 +35,18 @@
             {% endfor %}
           </tr>
         {% endfor %}
-        <tr>
-          <th colspan="6">
-                {{ _('show all tests') }}&nbsp;
-                <input
-                  name="transitions"
-                  value="ignore"
-                  type="checkbox"
-                  onchange="window.location='{{ transition_filter_action }}&' + $(this.form).serialize()"
-                  {{ 'checked' if ignore else ''}}
-                />
-          </th>
-        </tr>
       </tbody>
     </table>
+    <div>
+     {{ _('show all tests') }}&nbsp;
+     <input
+       name="transitions"
+       value="ignore"
+       type="checkbox"
+       onchange="window.location='{{ transition_filter_action }}&' + $(this.form).serialize()"
+       {{ 'checked' if ignore else ''}}
+     />
+    </div>
   </form>
 </div>
 <div class="clearfix"></div>

--- a/squad/frontend/templates/squad/compare_builds.jinja2
+++ b/squad/frontend/templates/squad/compare_builds.jinja2
@@ -80,4 +80,5 @@
 
 {% block styles %}
 <link href='{{static("select2.js/select2.css")}}' rel="stylesheet" />
+<link href='{{static("compare.css")}}' rel="stylesheet" />
 {% endblock %}

--- a/squad/frontend/templates/squad/compare_builds.jinja2
+++ b/squad/frontend/templates/squad/compare_builds.jinja2
@@ -1,7 +1,9 @@
 {% extends "squad/base.jinja2" %}
+{% set compare_build_action = request.path + strip_get_parameters(['project', 'comparison_type']) %}
 
 {% block content %}
   <h1>{{ _('Compare builds') }}</h1>
+
   {% if comparison %}
     {% with items=comparison.results %}
       {% include "squad/_pagination.jinja2" %}
@@ -19,7 +21,14 @@
       <div class="col-md-6 col-sm-6" ng-app="BuildCompare" ng-controller="BuildCompareController" ng-init="init({{ project.id if project else 0 }})">
         <form>
           <div class="form-group">
-            <select name="project" id="project-select" placeholder="{{ _('Enter project name') }}" onchange="this.form.submit()" class="form-control" {%if project %}disabled{% endif %}>
+            <select
+              name="project"
+              id="project-select"
+              placeholder="{{ _('Enter project name') }}"
+              onchange="window.location='{{ compare_build_action }}&' + $(this.form).serialize()"
+              class="form-control"
+              {%if project %}disabled{% endif %}
+            >
             {% if project %}<option>{{ project.full_name }}</option>{% endif %}
             </select>
           </div>
@@ -48,7 +57,12 @@
           </div>
           <div class="form-group">
             <input type="hidden" name="project" value="{{ project.full_name }}" />
-            <input onclick="this.form.submit()" value="{{ _('Compare') }}" type="button" class="btn btn-default" />
+            <input
+              onclick="window.location='{{ compare_build_action }}&' + $(this.form).serialize()"
+              value="{{ _('Compare') }}"
+              type="button"
+              class="btn btn-default"
+            />
             <input onclick='window.location="{{ request.path }}"' value="{{ _('Start over') }}" type="button" class="btn btn-default" />
           </div>
           {% endif %}

--- a/squad/frontend/templates/squad/compare_projects.jinja2
+++ b/squad/frontend/templates/squad/compare_projects.jinja2
@@ -70,7 +70,7 @@
           </div>
         </div>
         <div class="form-group">
-          <input onclick="this.form.submit()" value="{{ _('Compare') }}" type="button" class="btn btn-default" />
+          <input ng-click="submit()" value="{{ _('Compare') }}" type="button" class="btn btn-default" />
         </div>
       {% endif %}
     </form>

--- a/squad/frontend/templatetags/squad.py
+++ b/squad/frontend/templatetags/squad.py
@@ -165,10 +165,17 @@ def get_page_list(items):
 
 
 @register_global_function(takes_context=True)
-def get_page_url(context, page):
+def strip_get_parameters(context, parameters):
     query_string = context['request'].GET.copy()
-    query_string['page'] = page
+    for parameter in parameters:
+        if query_string.get(parameter):
+            del query_string[parameter]
     return '?' + query_string.urlencode()
+
+
+@register_global_function(takes_context=True)
+def get_page_url(context, page):
+    return '%s&page=%d' % (strip_get_parameters(context, ['page']), page)
 
 
 @register_filter

--- a/test/frontend/test_comparison.py
+++ b/test/frontend/test_comparison.py
@@ -68,7 +68,8 @@ class ProjectComparisonTest(TestCase):
 
     def test_comparison_project_with_default_transition(self):
         # default transitions: pass to fail and fail to pass
-        response = self.client.get('/_/compare/?project=mygroup/project1&project=mygroup/project2')
+        url = '/_/compare/?group=mygroup&project_%d=1&project_%d=1' % (self.project1.id, self.project2.id)
+        response = self.client.get(url)
         self.assertEqual(200, response.status_code)
         self.assertNotIn('d/e', str(response.content))
         self.assertIn('<th>a</th>', str(response.content))

--- a/test/frontend/test_comparison.py
+++ b/test/frontend/test_comparison.py
@@ -57,10 +57,22 @@ class ProjectComparisonTest(TestCase):
         self.build2 = self.project2.builds.last()
 
     def test_comparison_project_sanity_check(self):
-        url = '/_/compare/?group=mygroup&project_%d=1&project_%d=1' % (self.project1.id, self.project2.id)
+        url = '/_/compare/?group=mygroup&project_%d=1&project_%d=1&transitions=ignore' % (self.project1.id, self.project2.id)
         response = self.client.get(url)
         self.assertEqual(200, response.status_code)
         self.assertIn('d/e', str(response.content))
+        self.assertIn('myenv', str(response.content))
+        self.assertIn('otherenv', str(response.content))
+        self.assertIn('pass', str(response.content))
+        self.assertIn('fail', str(response.content))
+
+    def test_comparison_project_with_default_transition(self):
+        # default transitions: pass to fail and fail to pass
+        response = self.client.get('/_/compare/?project=mygroup/project1&project=mygroup/project2')
+        self.assertEqual(200, response.status_code)
+        self.assertNotIn('d/e', str(response.content))
+        self.assertIn('<th>a</th>', str(response.content))
+        self.assertIn('<th>c</th>', str(response.content))
         self.assertIn('myenv', str(response.content))
         self.assertIn('otherenv', str(response.content))
         self.assertIn('pass', str(response.content))

--- a/test/frontend/test_template_tags.py
+++ b/test/frontend/test_template_tags.py
@@ -21,7 +21,13 @@ class FakeGet():
         self.params[key] = value
 
     def __getitem__(self, key):
-        return self.params[key]
+        return self.params.get(key)
+
+    def __delitem__(self, key):
+        del self.params[key]
+
+    def get(self, key):
+        return self.__getitem__(key)
 
     def copy(self):
         return self


### PR DESCRIPTION
Closes https://github.com/Linaro/squad/issues/566

Add a transitions table that allow users to select which transitions from a comparison to be shown.

- All tests that have exact same results along builds and environments are **not** shown
- By default only *pass-to-fail* and *fail-to-pass* transitions are shown
- If a test has at least one differing result, all its results across builds & envs are displayed
- If the transitions selected didn't pick up any change in a specific environment, that column will **not** be displayed
- If no transitions are selected, the frontend will automatically go back to default (*pass-to-fail* and *fail-to-pass*)
- As boxes are checked/unchecked, the frontend will be updated accordingly
- Check "ignore all transitions" box to go back to regular comparison view

![Screenshot from 2019-08-16 12-59-14](https://user-images.githubusercontent.com/2254825/63184280-601bb280-c02d-11e9-8a8f-79ce1903a214.png)
