### PR TITLE
Dockerfile: don't install packages from pip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN ln -sfT container_settings.py /app/squad/local_settings.py && \
     python3 -m squad.frontend && \
     ./manage.py collectstatic --noinput --verbosity 0 && \
     ./manage.py compilemessages && \
-    python3 setup.py develop && \
+    python3 setup.py develop --no-deps && \
     useradd --create-home squad && \
     mkdir -m 0755 /app/tmp && chown squad:squad /app/tmp
 

--- a/scripts/test-docker
+++ b/scripts/test-docker
@@ -4,12 +4,3 @@ set -exu
 
 docker build -t squad .
 docker run squad python3 manage.py test -v 3
-
-rc=0
-for lib in $(docker run squad sh -c 'find /usr/local/lib/python3.* -name "*.egg"'); do
-    set +x
-    echo "E: library installed from outside of Debian: $lib"
-    rc=1
-    set -x
-done
-exit "$rc"


### PR DESCRIPTION
This ensures that the final docker image will contain only Debian
packages.