### PR TITLE
Handle lava boot setting

### DIFF
--- a/doc/ci.rst
+++ b/doc/ci.rst
@@ -139,10 +139,13 @@ LAVA backend supports the following settings:
    boolean flag that allows to save LAVA result as both Test and Measurement
    when set to ``True``. Default is ``False``. Can be overwritten for each
    project separately (similar to CI_LAVA_HANDLE_SUITE).
- - CI_LAVA_IGNORE_BOOT
-   boolean flag that avoids parsing LAVA `auto-login-action` as a boot test
-   when set to ``True``. Default is ``False``. Can be overwritten for each
-   project separately (similar to CI_LAVA_HANDLE_SUITE).
+ - CI_LAVA_HANDLE_BOOT
+   boolean flag that parses LAVA `auto-login-action` as a boot
+   test when set to ``True``. Default is ``False``. Can be overwritten for
+   each project separately (similar to CI_LAVA_HANDLE_SUITE). **NOTE**:
+   Before SQUAD 1.x series, the default behavior was to always process
+   `auto-login-action` as boot. After 1.x, the default behavior has changed
+   to do the opposite.
 
 Example LAVA backend settings:
 

--- a/squad/ci/backend/lava.py
+++ b/squad/ci/backend/lava.py
@@ -318,12 +318,12 @@ class Backend(BaseBackend):
         if hasattr(test_job, 'target') and test_job.target.project_settings is not None:
             ps = yaml.safe_load(test_job.target.project_settings) or {}
             handle_lava_suite = self.__resolve_setting__(ps, 'CI_LAVA_HANDLE_SUITE', False)
+            handle_lava_boot = self.__resolve_setting__(ps, 'CI_LAVA_HANDLE_BOOT', False)
             clone_measurements_to_tests = self.__resolve_setting__(ps, 'CI_LAVA_CLONE_MEASUREMENTS', False)
-            ignore_lava_boot = self.__resolve_setting__(ps, 'CI_LAVA_IGNORE_BOOT', False)
         else:
             handle_lava_suite = self.settings.get('CI_LAVA_HANDLE_SUITE', False)
+            handle_lava_boot = self.settings.get('CI_LAVA_HANDLE_BOOT', False)
             clone_measurements_to_tests = self.settings.get('CI_LAVA_CLONE_MEASUREMENTS', False)
-            ignore_lava_boot = self.settings.get('CI_LAVA_IGNORE_BOOT', False)
 
         definition = yaml.safe_load(data['definition'])
         test_job.name = definition['job_name'][:255]
@@ -363,7 +363,7 @@ class Backend(BaseBackend):
                         if clone_measurements_to_tests:
                             res_value = result['result']
                             results.update({res_name: res_value})
-                elif not ignore_lava_boot and result['name'] == 'auto-login-action':
+                elif result['name'] == 'auto-login-action' and handle_lava_boot:
                     # add artificial 'boot' test result for each test job
                     # by default the boot test is named after the device_type
                     boot = "boot-%s" % test_job.name


### PR DESCRIPTION
Closes #562 

Since we're approaching SQUAD 1.0, including other significant changes, it'd be nice to add this behavior change as well.

Default behavior used to consider `auto-login-action` LAVA tests as `boot-*` test in SQUAD. With this patch, that will only happen if the setting `CI_LAVA_HANDLE_BOOT` is true and it's present in either backend_settings or project_settings.

