### PR TITLE
Gerrit fixes

### DIFF
--- a/squad/api/rest.py
+++ b/squad/api/rest.py
@@ -512,7 +512,8 @@ class PatchSourceSerializer(serializers.HyperlinkedModelSerializer):
         fields = '__all__'
         extra_kwargs = {
             'token': {'write_only': True},
-            'username': {'write_only': True}
+            'username': {'write_only': True},
+            '_password': {'write_only': True},
         }
 
 

--- a/squad/core/admin.py
+++ b/squad/core/admin.py
@@ -145,7 +145,7 @@ class TestRunAdmin(admin.ModelAdmin):
 
 
 class PatchSourceForm(ModelForm):
-    password = forms.CharField(max_length=128)
+    password = forms.CharField(max_length=128, required=False)
 
     def __init__(self, *args, **kwargs):
         super(PatchSourceForm, self).__init__(*args, **kwargs)

--- a/squad/plugins/gerrit.py
+++ b/squad/plugins/gerrit.py
@@ -80,7 +80,7 @@ class Plugin(BasePlugin):
         ssh += ['-p', DEFAULT_SSH_PORT, '%s@%s' % (patch_source.username, parsed_url.netloc)]
         ssh += [cmd]
         try:
-            result = subprocess.run(ssh, capture_output=True)
+            result = subprocess.run(ssh, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         except subprocess.CalledProcessError as e:
             logger.error('Failed do login to %s: %s' % (parsed_url.netloc, str(e)))
             return False

--- a/test/plugins/test_gerrit.py
+++ b/test/plugins/test_gerrit.py
@@ -13,13 +13,14 @@ class FakeObject():
 
 class FakeSubprocess():
     __last_cmd__ = None
+    PIPE = 0
 
     class CalledProcessError(BaseException):
         def __str__(self):
             return 'Could not establish connection to host'
 
     @staticmethod
-    def run(cmd, capture_output=False):
+    def run(cmd, stdout=0, stderr=0):
         FakeSubprocess.__last_cmd__ = ' '.join(cmd)
         gerrit_cmd = 'gerrit review'
         options = ' '.join(gerrit.DEFAULT_SSH_OPTIONS)


### PR DESCRIPTION
Hopefully that's the last fix for Gerrit plugin for a long time :)

- fix a crash of gerrit notification because it used subprocess passing `capture_output` argument, which is available only in Python 3.7+, but we're at 3.5. 
- add '-1' to the gerrit patchset if a build has complete with at least one failed test
- hide `_password` field from REST apis
- remove the need for `password` field to be required in django admin forms
