### PR TITLE
Fix broken JS on test history page

### DIFF
--- a/squad/frontend/templates/squad/test_history.jinja2
+++ b/squad/frontend/templates/squad/test_history.jinja2
@@ -43,7 +43,7 @@
               <td class='{{result.status|slugify}}'>
                 <a href="{{project_url(result.test_run)}}">{{result.status}}</a>
                 {% if result.info['test_description'] or result.info['suite_instructions'] or result.info['test_instructions'] or result.info['test_log'] %}
-                  <a href='#' data-toggle="modal" data-target="#info_modal" data-info="{{ result.info }}"><span data-toggle="tooltip" data-placement="right" title="{{ _('Show info') }}" class='fa fa-info-circle'></span></a>
+                  <a href='#' data-toggle="modal" data-target="#info_modal" data-info="{{ to_json(result.info) }}"><span data-toggle="tooltip" data-placement="right" title="{{ _('Show info') }}" class='fa fa-info-circle'></span></a>
                 {% endif %}
                 {% if known_issues %}
                   <button type='button' class='known-issue btn btn-xs btn-info pull-right' data-toggle='popover'>
@@ -129,7 +129,7 @@
     $('[data-toggle="tooltip"]').tooltip();
     $('#info_modal').on('show.bs.modal', function (event) {
       var button = $(event.relatedTarget);
-      var info = JSON.parse(button.data('info').replace(/'/g, '"').replace(/None/g, null));
+      var info = button.data('info');
       if(info['test_description']) {
         $('#test_description').show();
         $('#test_description_inner').html(info['test_description']);

--- a/squad/frontend/templatetags/squad.py
+++ b/squad/frontend/templatetags/squad.py
@@ -1,3 +1,5 @@
+import json
+
 from crispy_forms.helper import FormHelper
 from crispy_forms.utils import render_crispy_form
 from django import template
@@ -196,3 +198,12 @@ def crispy(context, form, **options):
     for option, value in options.items():
         setattr(helper, option, value)
     return render_crispy_form(form, helper=helper, context=context)
+
+
+@register_global_function()
+def to_json(d):
+    try:
+        json_string = json.dumps(d)
+    except TypeError:
+        json_string = ''
+    return json_string

--- a/test/frontend/test_template_tags.py
+++ b/test/frontend/test_template_tags.py
@@ -5,7 +5,7 @@ from jinja2 import Template
 from django.test import TestCase
 
 
-from squad.frontend.templatetags.squad import get_page_url
+from squad.frontend.templatetags.squad import get_page_url, to_json
 
 
 class FakeRequest():
@@ -48,3 +48,10 @@ class TemplateTagsTest(TestCase):
         self.assertNotIn('page=2', rendered_template)
         self.assertIn('page=42', rendered_template)
         self.assertIn('existing_arg=val', rendered_template)
+
+    def test_to_json(self):
+        self.assertEqual('1', to_json(1))
+        self.assertEqual('"a string"', to_json('a string'))
+        self.assertEqual('[1, 2, 3]', to_json([1, 2, 3]))
+        self.assertEqual('{"key": 42}', to_json({'key': 42}))
+        self.assertEqual('', to_json(FakeGet()))  # non-parsable types return empty string


### PR DESCRIPTION
Example: https://qa-reports.linaro.org/lkft/linux-next-oe/tests/kselftest/binderfs_binderfs_test

When clicking on the "i" icon, a modal window is expected to pop up. Instead, it was triggering an exception:

`Uncaught SyntaxError: Unexpected token d in JSON at position 45`

Also, this fixes: [LSS-145](https://projects.linaro.org/browse/LSS-145)