### PR TITLE
yaml_validator: drop usage of simple yaml.load

### DIFF
--- a/squad/core/utils.py
+++ b/squad/core/utils.py
@@ -60,7 +60,7 @@ def yaml_validator(value):
     if len(value) == 0:
         return
     try:
-        if not isinstance(yaml.load(value), dict):
+        if not isinstance(yaml.safe_load(value), dict):
             raise ValidationError("Dictionary object expected")
     except yaml.YAMLError as e:
         raise ValidationError(e)

--- a/test/core/test_project.py
+++ b/test/core/test_project.py
@@ -75,3 +75,10 @@ class ProjectTest(TestCase):
             p.full_clean()
         p.slug = 'foo-bar'
         p.full_clean()  # it this raises no exception, then we are fine
+
+    def test_validate_project_settings(self):
+        p = Project(group=self.group, slug='foobar', project_settings='1')
+        with self.assertRaises(ValidationError):
+            p.full_clean()
+        p.project_settings = 'foo: bar\n'
+        p.full_clean()


### PR DESCRIPTION
This is insecure, and deprecated.