### PR TITLE
api: ci: fix definition file encoding

### DIFF
--- a/squad/api/ci.py
+++ b/squad/api/ci.py
@@ -32,7 +32,7 @@ def submit_job(request, group_slug, project_slug, version, environment_slug):
     # definition can be received as a file upload or as a POST parameter
     definition = None
     if 'definition' in request.FILES:
-        definition = read_file_upload(request.FILES['definition'])
+        definition = read_file_upload(request.FILES['definition']).decode('utf-8')
     else:
         definition = request.POST.get('definition')
 

--- a/squad/ci/models.py
+++ b/squad/ci/models.py
@@ -192,7 +192,7 @@ class TestJob(models.Model):
         try:
             # we'll loose comments in web UI
             yaml_def = yaml.safe_load(self.definition)
-        except yaml.parser.ParserError:
+        except (yaml.parser.ParserError, yaml.scanner.ScannerError):
             # in case yaml is not valid, return original string
             return self.definition
         if not isinstance(yaml_def, dict):

--- a/test/api/twoline_definition.yaml
+++ b/test/api/twoline_definition.yaml
@@ -1,0 +1,2 @@
+bar: something
+foo: 1


### PR DESCRIPTION
Fix the encoding for a testjob's definition when it is provided as an uploaded file.

This was reported at https://lists.linaro.org/pipermail/squad-dev/2019-September/000183.html