### PR TITLE
plugins: gerrit: check patch_id before sending notification

### DIFF
--- a/squad/plugins/gerrit.py
+++ b/squad/plugins/gerrit.py
@@ -94,6 +94,11 @@ class Plugin(BasePlugin):
         return True
 
     def __gerrit_request__(self, build, payload):
+        regex = r'.+[:,].+'
+        if re.match(regex, build.patch_id) is None:
+            logger.warning('patch_id "%s" for build "%s" failed to match "%s"' % (build.patch_id, build.id, regex))
+            return False
+
         if build.patch_source.url.startswith('ssh'):
             return Plugin.__gerrit_ssh__(build, payload)
         else:

--- a/test/plugins/test_gerrit.py
+++ b/test/plugins/test_gerrit.py
@@ -85,6 +85,7 @@ class GerritPluginTest(TestCase):
 
         self.build1 = self.project.builds.create(version='1', patch_source=self.http_patch_source, patch_id='1,1')
         self.build2 = self.project.builds.create(version='2', patch_source=self.ssh_patch_source, patch_id='1,1')
+        self.build3 = self.project.builds.create(version='3', patch_source=self.ssh_patch_source, patch_id=':')
 
     def test_basic_validation(self):
         validation_error = False
@@ -152,3 +153,7 @@ class GerritPluginTest(TestCase):
         self.assertTrue(plugin.notify_patch_build_finished(self.build2))
         self.assertIn('Build finished', FakeSubprocess.given_cmd())
         self.assertIn('Some tests failed (1)', FakeSubprocess.given_cmd())
+
+    def test_malformed_patch_id(self):
+        plugin = self.build3.patch_source.get_implementation()
+        self.assertFalse(plugin.notify_patch_build_created(self.build3))


### PR DESCRIPTION
Make sure patch_id for gerrit plugin follows the format "changeid:patchset".

This will also prevent "fatal: "," is not a valid patch set" errors, for empty patch_ids. There's no way to make sure that the patch_id is valid or not, unless we ask gerrit before attempting sending a notification. Let's assume that if a patch_id is set (and not empty), it'll be valid. We can come back to this later if necessary.