### PR TITLE
api: utils: add CursorPaginationWithPageSize

### DIFF
--- a/squad/api/rest.py
+++ b/squad/api/rest.py
@@ -17,9 +17,10 @@ from rest_framework.decorators import action
 from rest_framework.exceptions import NotFound
 from rest_framework.response import Response
 from rest_framework.reverse import reverse as rest_reverse
-from rest_framework.pagination import CursorPagination, PageNumberPagination
+from rest_framework.pagination import PageNumberPagination
 from rest_framework.permissions import AllowAny
 from squad.compat import ComplexFilterBackend
+from squad.api.utils import CursorPaginationWithPageSize
 
 import rest_framework_filters as filters
 
@@ -783,7 +784,7 @@ class TestViewSet(ModelViewSet):
     queryset = Test.objects.all()
     serializer_class = TestSerializer
     filter_class = TestFilter
-    pagination_class = CursorPagination
+    pagination_class = CursorPaginationWithPageSize
     ordering = ('id',)
 
     def get_queryset(self):
@@ -820,7 +821,7 @@ class TestRunViewSet(ModelViewSet):
     filter_class = TestRunFilter
     search_fields = ('environment',)
     ordering_fields = ('id', 'created_at', 'environment', 'datetime')
-    pagination_class = CursorPagination
+    pagination_class = CursorPaginationWithPageSize
     ordering = ('created_at',)
 
     def get_queryset(self):
@@ -923,7 +924,7 @@ class TestJobViewSet(ModelViewSet):
     filter_class = TestJobFilter
     search_fields = ("name", "environment", "last_fetch_attempt")
     ordering_fields = ("id", "name", "environment", "last_fetch_attempt")
-    pagination_class = CursorPagination
+    pagination_class = CursorPaginationWithPageSize
     ordering = ('id',)
 
     def get_queryset(self):

--- a/squad/api/utils.py
+++ b/squad/api/utils.py
@@ -1,7 +1,12 @@
 from django_filters.rest_framework import DjangoFilterBackend
+from rest_framework.pagination import CursorPagination
 
 
 class DisabledHTMLFilterBackend(DjangoFilterBackend):
 
     def to_html(self, request, queryset, view):
         return ""
+
+
+class CursorPaginationWithPageSize(CursorPagination):
+    page_size_query_param = 'limit'

--- a/test/api/test_rest.py
+++ b/test/api/test_rest.py
@@ -450,6 +450,15 @@ class RestApiTest(APITestCase):
         data = self.hit('/api/testjobs/%d/' % self.testjob.id)
         self.assertEqual('myenv', data['environment'])
 
+    def test_tests(self):
+        data = self.hit('/api/tests/')
+        self.assertEqual(list, type(data['results']))
+
+    def test_tests_with_page_size(self):
+        data = self.hit('/api/tests/?limit=2')
+        self.assertEqual(list, type(data['results']))
+        self.assertEqual(2, len(data['results']))
+
     def test_testruns(self):
         data = self.hit('/api/testruns/%d/' % self.testrun.id)
         self.assertEqual(self.testrun.id, data['id'])


### PR DESCRIPTION
Add subclass of rest_frameworks.pagination.CursorPagination in order to enable `page_size_query_param`, allowing custom page sizes.

NOTE: by default, limit can be no greater than 1000. If that limit is to be increased, consider overriding `max_page_size`.