### PR TITLE
settings: split tasks to separate queues

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -68,15 +68,15 @@ an admin user for yourself, use::
 
 These are the command lines to run the other processes:
 
-+-----------+---------------------------+
-| Process   | Command                   |
-+===========+===========================+
-| worker    | celery -A squad worker    |
-+-----------+---------------------------+
-| scheduler | celery -A squad beat      |
-+-----------+---------------------------+
-| listener  | squad-admin listen        |
-+-----------+---------------------------+
++-----------+-------------------------------------------------------------------------------------------------------------------------+
+| Process   | Command                                                                                                                 |
++===========+=========================================================================================================================+
+| worker    | celery -A squad worker -Q core_reporting,core_postprocess,core_quick,core_notification,ci_quick,ci_poll,ci_fetch,celery |
++-----------+-------------------------------------------------------------------------------------------------------------------------+
+| scheduler | celery -A squad beat                                                                                                    |
++-----------+-------------------------------------------------------------------------------------------------------------------------+
+| listener  | squad-admin listen                                                                                                      |
++-----------+-------------------------------------------------------------------------------------------------------------------------+
 
 You most probably want all the processes (including the web interface) being
 managed by a system manager such as systemd__, or a process manager such as

--- a/squad/settings.py
+++ b/squad/settings.py
@@ -289,7 +289,22 @@ CELERY_BEAT_SCHEDULE = {
     }
 }
 CELERY_TASK_ROUTES = {
-    'squad.core.tasks.prepare_report': {'queue': 'reporting_queue'},
+    'squad.core.tasks.prepare_report': {'queue': 'core_reporting'},
+    'squad.core.tasks.postprocess_test_run': {'queue': 'core_postprocess'},
+    'squad.core.tasks.cleanup_old_builds': {'queue': 'core_quick'},
+    'squad.core.tasks.remove_delayed_reports': {'queue': 'core_quick'},
+    'squad.core.tasks.cleanup_build': {'queue': 'core_quick'},
+    'squad.core.tasks.maybe_notify_project_status': {'queue': 'core_notification'},
+    'squad.core.tasks.notify_project_status': {'queue': 'core_notification'},
+    'squad.core.tasks.notification_timeout': {'queue': 'core_notification'},
+    'squad.core.tasks.notify_patch_build_created': {'queue': 'core_notification'},
+    'squad.core.tasks.notify_patch_build_finished': {'queue': 'core_notification'},
+    'squad.core.tasks.notify_delayed_report_callback': {'queue': 'core_notification'},
+    'squad.core.tasks.notify_delayed_report_email': {'queue': 'core_notification'},
+    'squad.ci.tasks.poll': {'queue': 'ci_poll'},
+    'squad.ci.tasks.fetch': {'queue': 'ci_fetch'},
+    'squad.ci.tasks.submit': {'queue': 'ci_quick'},
+    'squad.ci.tasks.send_testjob_resubmit_admin_email': {'queue': 'ci_quick'},
 }
 
 REST_FRAMEWORK = {


### PR DESCRIPTION
This change allows to create multiple celery workers, each dedicated to
specific queues. Some tasks are slower than the other and moving them so
separate queues helps reducing congestions.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>