### PR TITLE
requirements.txt: fix minimal version for pyyaml

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ Markdown
 msgpack>=0.5.0
 psycopg2
 python_dateutil
-PyYAML
+PyYAML>=5.1
 pyzmq
 requests
 sqlparse


### PR DESCRIPTION
Fixes /api/schema/ 

Django RestFramework was crashing when schema_view was being invoked, that was due to an old version of pyyaml (3.12) that did not support "sort_keys" for "dump_all".

ref: https://github.com/yaml/pyyaml/commit/07c88c6c1bee51439a00bc07827980fbb161a1ad#diff-2cf6b2c84206cb7fde75192c9a8e2a19R277