### PR TITLE
ci: models: backend: handle duplicated testjob as new exception

### DIFF
--- a/squad/api/views.py
+++ b/squad/api/views.py
@@ -93,7 +93,7 @@ def add_test_run(request, group_slug, project_slug, version, environment_slug):
 
     try:
         receive(**test_run_data)
-    except exceptions.invalid_input as e:
+    except (exceptions.invalid_input + (exceptions.DuplicatedTestJob,)) as e:
         logger.warning(request.get_full_path() + ": " + str(e))
         return HttpResponse(str(e), status=400)
 

--- a/squad/ci/models.py
+++ b/squad/ci/models.py
@@ -11,7 +11,7 @@ from dateutil.relativedelta import relativedelta
 from squad.core.tasks import ReceiveTestRun, UpdateProjectStatus
 from squad.core.models import Project, Build, TestRun, slug_validator
 from squad.core.plugins import apply_plugins
-from squad.core.tasks.exceptions import InvalidMetadata
+from squad.core.tasks.exceptions import InvalidMetadata, DuplicatedTestJob
 from squad.core.utils import yaml_validator
 
 
@@ -111,6 +111,8 @@ class Backend(models.Model):
             test_job.testrun = testrun
         except InvalidMetadata as exception:
             test_job.failure = str(exception)
+        except DuplicatedTestJob as exception:
+            logger.error('Failed to fetch test_job(%d): "%s"' % (test_job.id, str(exception)))
 
         # mark test job as fetched to prevent resubmission
         # on next fetch attempt

--- a/squad/core/tasks/__init__.py
+++ b/squad/core/tasks/__init__.py
@@ -138,7 +138,7 @@ class ReceiveTestRun(object):
 
             job_id = metadata_fields['job_id']
             if build.test_runs.filter(job_id=job_id).exists():
-                raise exceptions.InvalidMetadata("There is already a test run with job_id %s" % job_id)
+                raise exceptions.DuplicatedTestJob("There is already a test run with job_id %s" % job_id)
 
         else:
             metadata_fields = {}

--- a/squad/core/tasks/exceptions.py
+++ b/squad/core/tasks/exceptions.py
@@ -1,6 +1,10 @@
 import sys
 
 
+class DuplicatedTestJob(Exception):
+    pass
+
+
 class InvalidMetadataJSON(Exception):
     pass
 

--- a/test/ci/test_models.py
+++ b/test/ci/test_models.py
@@ -188,7 +188,7 @@ class BackendFetchTest(BackendTestBase):
         self.backend.really_fetch(test_job)
 
         self.assertTrue(test_job.fetched)
-        self.assertIsNotNone(test_job.failure)
+        self.assertIsNone(test_job.failure)
 
     @patch('django.utils.timezone.now', return_value=NOW)
     @patch('squad.ci.models.Backend.get_implementation')


### PR DESCRIPTION
Add DuplicatedTestJob exception to handle cases where a testjob is being submitted twice. Before this patch, we were considering that case as `InvalidMetadata`.