### PR TITLE
worker: don't constrain concurrency by default

### DIFF
--- a/squad/run/worker.py
+++ b/squad/run/worker.py
@@ -11,7 +11,6 @@ def main():
         '-A', 'squad',
         'worker',
         '--queues=celery,' + ','.join(queues),
-        '--concurrency=1',
         '--max-tasks-per-child=5000',
         '--max-memory-per-child=1500000',
         '--loglevel=INFO'


### PR DESCRIPTION
When no concurrency is specified, celery starts one worker thread for
each CPU thread available (i.e. `nproc`).

In a production environment, one most likely wants to utilize as much
processing as possible, so requiring an explicit parameter for that is
silly. For the cases where fine tuning is necessary, it's still
possible.

In development environments, running with a single worker thread
prevents one from hitting concurrency issues that might come up in
production.