### PR TITLE
plugins: linux_log_parser: improve kernel log parsing

### DIFF
--- a/test/plugins/linux_log_parser/multiple_issues_dmesg.log
+++ b/test/plugins/linux_log_parser/multiple_issues_dmesg.log
@@ -1,0 +1,1647 @@
+[    0.000000] Boot CPU: AArch64 Processor [410fd033]
+[   80.740537] [drm] amdgpu kernel modesetting enabled.
+[   80.740592] vga_switcheroo: detected switching method \_SB_.PCI0.VGA_.ATPX handle
+[   80.740537] [drm] amdgpu kernel modesetting enabled.
+[   80.740592] vga_switcheroo: detected switching method \_SB_.PCI0.VGA_.ATPX handle
+[   80.741450] ATPX version 1, functions 0x00000003
+[   80.741577] ATPX Hybrid Graphics
+[   80.741628] fb: switching to amdgpudrmfb from EFI VGA
+[   80.741716] Console: switching to colour dummy device 80x25
+[   80.741450] ATPX version 1, functions 0x00000003
+[   80.741577] ATPX Hybrid Graphics
+[   80.741628] fb: switching to amdgpudrmfb from EFI VGA
+[   80.742429] [drm] initializing kernel modesetting (CARRIZO 0x1002:0x9874 0x1025:0x1201 0xCA).
+[   80.742526] [drm] register mmio base: 0x91600000
+[   80.742530] [drm] register mmio size: 262144
+[   80.742563] [drm] doorbell mmio base: 0x90800000
+[   80.742567] [drm] doorbell mmio size: 8388608
+[   80.741716] Console: switching to colour dummy device 80x25
+[   80.742846] [drm] UVD is enabled in physical mode
+[   80.742853] [drm] VCE enabled in physical mode
+[   80.742904] ATOM BIOS: Stoney
+[   80.742923] [drm] GPU post is not needed
+[   80.742429] [drm] initializing kernel modesetting (CARRIZO 0x1002:0x9874 0x1025:0x1201 0xCA).
+[   80.743354] amdgpu 0000:00:01.0: VRAM: 32M 0x0000000000000000 - 0x0000000001FFFFFF (32M used)
+[   80.743371] amdgpu 0000:00:01.0: GTT: 1024M 0x0000000002000000 - 0x0000000041FFFFFF
+[   80.743404] [drm] Detected VRAM RAM=32M, BAR=32M
+[   80.743408] [drm] RAM width 64bits UNKNOWN
+[   80.742526] [drm] register mmio base: 0x91600000
+[   80.742530] [drm] register mmio size: 262144
+[   80.742563] [drm] doorbell mmio base: 0x90800000
+[   80.742567] [drm] doorbell mmio size: 8388608
+[   80.744268] [TTM] Zone  kernel: Available graphics memory: 984686 kiB
+[   80.744288] [TTM] Initializing pool allocator
+[   80.744300] [TTM] Initializing DMA pool allocator
+[   80.744374] [drm] amdgpu: 32M of VRAM memory ready
+[   80.744381] [drm] amdgpu: 1024M of GTT memory ready.
+[   80.744404] [drm] GART: num cpu pages 262144, num gpu pages 262144
+[   80.742846] [drm] UVD is enabled in physical mode
+[   80.742853] [drm] VCE enabled in physical mode
+[   80.742904] ATOM BIOS: Stoney
+[   80.742923] [drm] GPU post is not needed
+[   80.743354] amdgpu 0000:00:01.0: VRAM: 32M 0x0000000000000000 - 0x0000000001FFFFFF (32M used)
+[   80.743371] amdgpu 0000:00:01.0: GTT: 1024M 0x0000000002000000 - 0x0000000041FFFFFF
+[   80.743404] [drm] Detected VRAM RAM=32M, BAR=32M
+[   80.743408] [drm] RAM width 64bits UNKNOWN
+[   80.745700] [drm] PCIE GART of 1024M enabled (table at 0x0000000000040000).
+[   80.745769] [drm] Supports vblank timestamp caching Rev 2 (21.10.2013).
+[   80.745772] [drm] Driver supports precise vblank timestamp query.
+[   80.745842] amdgpu 0000:00:01.0: amdgpu: using MSI.
+[   80.745866] [drm] amdgpu: irq initialized.
+[   80.745890] amdgpu: [powerplay] amdgpu: powerplay sw initialized
+[   80.745890] amdgpu: [powerplay] amdgpu: powerplay sw initialized
+[   80.744268] [TTM] Zone  kernel: Available graphics memory: 984686 kiB
+[   80.744288] [TTM] Initializing pool allocator
+[   80.744300] [TTM] Initializing DMA pool allocator
+[   80.744374] [drm] amdgpu: 32M of VRAM memory ready
+[   80.744381] [drm] amdgpu: 1024M of GTT memory ready.
+[   80.744404] [drm] GART: num cpu pages 262144, num gpu pages 262144
+[   80.745700] [drm] PCIE GART of 1024M enabled (table at 0x0000000000040000).
+[   80.745769] [drm] Supports vblank timestamp caching Rev 2 (21.10.2013).
+[   80.745772] [drm] Driver supports precise vblank timestamp query.
+[   80.745842] amdgpu 0000:00:01.0: amdgpu: using MSI.
+[   80.745866] [drm] amdgpu: irq initialized.
+[   80.745890] amdgpu: [powerplay] amdgpu: powerplay sw initialized
+[   80.750257] [drm] amdgpu atom DIG backlight initialized
+[   80.750281] [drm] AMDGPU Display Connectors
+[   80.750285] [drm] Connector 0:
+[   80.750289] [drm]   eDP-1
+[   80.750292] [drm]   HPD1
+[   80.750295] [drm]   DDC: 0x4868 0x4868 0x4869 0x4869 0x486a 0x486a 0x486b 0x486b
+[   80.750298] [drm]   Encoders:
+[   80.750301] [drm]     LCD1: INTERNAL_UNIPHY
+[   80.750304] [drm] Connector 1:
+[   80.750307] [drm]   HDMI-A-1
+[   80.750309] [drm]   HPD2
+[   80.750312] [drm]   DDC: 0x486c 0x486c 0x486d 0x486d 0x486e 0x486e 0x486f 0x486f
+[   80.750315] [drm]   Encoders:
+[   80.750316] [drm]     DFP1: INTERNAL_UNIPHY
+[   80.750257] [drm] amdgpu atom DIG backlight initialized
+[   80.750281] [drm] AMDGPU Display Connectors
+[   80.750285] [drm] Connector 0:
+[   80.750289] [drm]   eDP-1
+[   80.750292] [drm]   HPD1
+[   80.750295] [drm]   DDC: 0x4868 0x4868 0x4869 0x4869 0x486a 0x486a 0x486b 0x486b
+[   80.750298] [drm]   Encoders:
+[   80.750301] [drm]     LCD1: INTERNAL_UNIPHY
+[   80.750304] [drm] Connector 1:
+[   80.750307] [drm]   HDMI-A-1
+[   80.750309] [drm]   HPD2
+[   80.750312] [drm]   DDC: 0x486c 0x486c 0x486d 0x486d 0x486e 0x486e 0x486f 0x486f
+[   80.750315] [drm]   Encoders:
+[   80.750316] [drm]     DFP1: INTERNAL_UNIPHY
+[   80.755806] amdgpu 0000:00:01.0: fence driver on ring 0 use gpu addr 0x0000000002000010, cpu addr 0xffff8d5271b60010
+[   80.756004] amdgpu 0000:00:01.0: fence driver on ring 1 use gpu addr 0x0000000002000020, cpu addr 0xffff8d5271b60020
+[   80.756090] amdgpu 0000:00:01.0: fence driver on ring 2 use gpu addr 0x0000000002000030, cpu addr 0xffff8d5271b60030
+[   80.756145] amdgpu 0000:00:01.0: fence driver on ring 3 use gpu addr 0x0000000002000040, cpu addr 0xffff8d5271b60040
+[   80.756196] amdgpu 0000:00:01.0: fence driver on ring 4 use gpu addr 0x0000000002000050, cpu addr 0xffff8d5271b60050
+[   80.756250] amdgpu 0000:00:01.0: fence driver on ring 5 use gpu addr 0x0000000002000060, cpu addr 0xffff8d5271b60060
+[   80.756310] amdgpu 0000:00:01.0: fence driver on ring 6 use gpu addr 0x0000000002000070, cpu addr 0xffff8d5271b60070
+[   80.756367] amdgpu 0000:00:01.0: fence driver on ring 7 use gpu addr 0x0000000002000080, cpu addr 0xffff8d5271b60080
+[   80.755806] amdgpu 0000:00:01.0: fence driver on ring 0 use gpu addr 0x0000000002000010, cpu addr 0xffff8d5271b60010
+[   80.756421] amdgpu 0000:00:01.0: fence driver on ring 8 use gpu addr 0x0000000002000090, cpu addr 0xffff8d5271b60090
+[   80.756481] amdgpu 0000:00:01.0: fence driver on ring 9 use gpu addr 0x00000000020000a0, cpu addr 0xffff8d5271b600a0
+[   80.756966] amdgpu 0000:00:01.0: fence driver on ring 10 use gpu addr 0x00000000020000b0, cpu addr 0xffff8d5271b600b0
+[   80.757057] amdgpu 0000:00:01.0: fence driver on ring 11 use gpu addr 0x00000000020000c0, cpu addr 0xffff8d5271b600c0
+[   80.756004] amdgpu 0000:00:01.0: fence driver on ring 1 use gpu addr 0x0000000002000020, cpu addr 0xffff8d5271b60020
+[   80.756090] amdgpu 0000:00:01.0: fence driver on ring 2 use gpu addr 0x0000000002000030, cpu addr 0xffff8d5271b60030
+[   80.756145] amdgpu 0000:00:01.0: fence driver on ring 3 use gpu addr 0x0000000002000040, cpu addr 0xffff8d5271b60040
+[   80.756196] amdgpu 0000:00:01.0: fence driver on ring 4 use gpu addr 0x0000000002000050, cpu addr 0xffff8d5271b60050
+[   80.756250] amdgpu 0000:00:01.0: fence driver on ring 5 use gpu addr 0x0000000002000060, cpu addr 0xffff8d5271b60060
+[   80.756310] amdgpu 0000:00:01.0: fence driver on ring 6 use gpu addr 0x0000000002000070, cpu addr 0xffff8d5271b60070
+[   80.756367] amdgpu 0000:00:01.0: fence driver on ring 7 use gpu addr 0x0000000002000080, cpu addr 0xffff8d5271b60080
+[   80.756421] amdgpu 0000:00:01.0: fence driver on ring 8 use gpu addr 0x0000000002000090, cpu addr 0xffff8d5271b60090
+[   80.756481] amdgpu 0000:00:01.0: fence driver on ring 9 use gpu addr 0x00000000020000a0, cpu addr 0xffff8d5271b600a0
+[   80.756966] amdgpu 0000:00:01.0: fence driver on ring 10 use gpu addr 0x00000000020000b0, cpu addr 0xffff8d5271b600b0
+[   80.757057] amdgpu 0000:00:01.0: fence driver on ring 11 use gpu addr 0x00000000020000c0, cpu addr 0xffff8d5271b600c0
+[58857.640024] ------------[ cut here ]------------
+[58857.640075] WARNING: CPU: 3 PID: 2549 at ../drivers/gpu/drm/radeon/radeon_object.c:84 radeon_ttm_bo_destroy+0xec/0xf0 [radeon]
+[58857.640094] Modules linked in: rfcomm fuse af_packet nf_log_ipv6 xt_comment nf_log_ipv4 nf_log_common xt_LOG xt_limit ip6t_REJECT nf_reject_ipv6 nf_conntrack_ipv6 nf_defrag_ipv6 ipt_REJECT nf_reject_ipv4 xt_pkttype xt_tcpudp bnep iptable_filter ip6table_mangle nf_conntrack_netbios_ns msr nf_conntrack_broadcast nf_conntrack_ipv4 nf_defrag_ipv4 ip_tables xt_conntrack nf_conntrack libcrc32c vboxpci(O) ip6table_filter vboxnetadp(O) ip6_tables x_tables vboxnetflt(O) vboxdrv(O) it87 hwmon_vid btusb arc4 btrtl btbcm hid_logitech_hidpp uvcvideo btintel videobuf2_vmalloc videobuf2_memops videobuf2_v4l2 videobuf2_core videodev rtl818x_pci mac80211 cfg80211 joydev r8169 bluetooth hid_logitech_dj wacom hid_generic usbhid eeprom_93cx6 rfkill mii intel_powerclamp shpchp snd_hda_codec_realtek snd_hda_codec_generic
+[58857.640201]  snd_hda_codec_hdmi snd_hda_intel snd_hda_codec iTCO_wdt iTCO_vendor_support gpio_ich lpc_ich i2c_i801 coretemp acpi_cpufreq pcspkr mxm_wmi i7core_edac tpm_tis edac_core tpm_tis_core wmi tpm kvm_intel kvm irqbypass button snd_hda_core crc32c_intel snd_usb_audio snd_usbmidi_lib snd_hwdep snd_rawmidi snd_pcm_oss snd_pcm snd_seq snd_seq_device snd_timer snd_mixer_oss snd soundcore amdgpu amdkfd amd_iommu_v2 serio_raw sr_mod radeon cdrom firewire_ohci i2c_algo_bit firewire_core crc_itu_t drm_kms_helper syscopyarea sysfillrect sysimgblt fb_sys_fops ttm uhci_hcd ehci_pci xhci_pci ehci_hcd drm xhci_hcd ata_generic pata_jmicron usbcore sg dm_multipath dm_mod scsi_dh_rdac scsi_dh_emc scsi_dh_alua
+[58857.640289] CPU: 3 PID: 2549 Comm: QThread Tainted: G      D W IO L  4.11.8-2-default #1
+[58857.640308] Hardware name: Gigabyte Technology Co., Ltd. X58A-UD7/X58A-UD7, BIOS F7 08/24/2010
+[58857.640327] Call Trace:
+[58857.640354]  dump_stack+0x5c/0x78
+[58857.640376]  __warn+0xbe/0xe0
+[58857.640406]  radeon_ttm_bo_destroy+0xec/0xf0 [radeon]
+[58857.640434]  ttm_bo_release_list+0xd4/0x1e0 [ttm]
+[58857.640463]  radeon_bo_unref+0x25/0x50 [radeon]
+[58857.640494]  radeon_gem_object_free+0x46/0x50 [radeon]
+[58857.640525]  drm_gem_object_release_handle+0x50/0x90 [drm]
+[58857.640550]  ? drm_gem_object_handle_unreference_unlocked+0xc0/0xc0 [drm]
+[58857.640569]  idr_for_each+0x38/0xb0
+[58857.640594]  drm_gem_release+0x1c/0x30 [drm]
+[58857.640618]  drm_release+0x33d/0x390 [drm]
+[58857.640638]  __fput+0xc7/0x1d0
+[58857.640658]  task_work_run+0x70/0x90
+[58857.640678]  do_exit+0x2d9/0xbc0
+[58857.640698]  ? balance_dirty_pages_ratelimited+0x340/0x450
+[58857.640717]  do_group_exit+0x3a/0xa0
+[58857.640736]  get_signal+0x264/0x650
+[58857.640757]  do_signal+0x23/0x660
+[58857.640778]  exit_to_usermode_loop+0x71/0xb0
+[58857.640798]  syscall_return_slowpath+0x54/0x60
+[58857.640818]  entry_SYSCALL_64_fastpath+0xab/0xad
+[58857.640837] ---[ end trace 479260f3ab02b522 ]---
+[58857.640861] ------------[ cut here ]------------
+[   80.758379] [drm] Found UVD firmware Version: 1.87 Family ID: 11
+[   80.758379] [drm] Found UVD firmware Version: 1.87 Family ID: 11
+[   80.759332] amdgpu 0000:00:01.0: fence driver on ring 12 use gpu addr 0x00000000002946e0, cpu addr 0xffffb20d824416e0
+[   80.759332] amdgpu 0000:00:01.0: fence driver on ring 12 use gpu addr 0x00000000002946e0, cpu addr 0xffffb20d824416e0
+[   80.762438] [drm] Found VCE firmware Version: 52.4 Binary ID: 3
+[   80.762718] amdgpu 0000:00:01.0: fence driver on ring 13 use gpu addr 0x00000000020000e0, cpu addr 0xffff8d5271b600e0
+[   80.762778] amdgpu 0000:00:01.0: fence driver on ring 14 use gpu addr 0x00000000020000f0, cpu addr 0xffff8d5271b600f0
+[   80.762438] [drm] Found VCE firmware Version: 52.4 Binary ID: 3
+[   80.762718] amdgpu 0000:00:01.0: fence driver on ring 13 use gpu addr 0x00000000020000e0, cpu addr 0xffff8d5271b600e0
+[   80.762778] amdgpu 0000:00:01.0: fence driver on ring 14 use gpu addr 0x00000000020000f0, cpu addr 0xffff8d5271b600f0
+[   80.766408] Kernel panic - not syncing: stack-protector: Kernel stack is corrupted in: ffffffffc0c88942
+[   80.766408] 
+[   80.766428] CPU: 1 PID: 1594 Comm: modprobe Not tainted 4.11.3+ #2
+[   80.766431] Hardware name: Acer Aspire A515-41G/Wartortle_BS, BIOS V0.09 04/19/2017
+[   80.766434] Call Trace:
+[   80.766445]  dump_stack+0x63/0x90
+[   80.766451]  panic+0xe8/0x236
+[   80.766526]  ? amdgpu_atombios_crtc_powergate_init+0x52/0x60 [amdgpu]
+[   80.766537]  __stack_chk_fail+0x1b/0x20
+[   80.766571]  amdgpu_atombios_crtc_powergate_init+0x52/0x60 [amdgpu]
+[   80.766610]  dce_v11_0_hw_init+0x3e/0x2d0 [amdgpu]
+[   80.766643]  amdgpu_device_init+0xe23/0x13c0 [amdgpu]
+[   80.766647]  ? kmalloc_order+0x18/0x40
+[   80.766650]  ? kmalloc_order_trace+0x24/0xa0
+[   80.766683]  amdgpu_driver_load_kms+0x5d/0x240 [amdgpu]
+[   80.766708]  drm_dev_register+0x148/0x1e0 [drm]
+[   80.766721]  drm_get_pci_dev+0xa0/0x160 [drm]
+[   80.766754]  amdgpu_pci_probe+0xb9/0xf0 [amdgpu]
+[   80.766759]  local_pci_probe+0x45/0xa0
+[   80.766762]  pci_device_probe+0xf4/0x150
+[   80.766768]  driver_probe_device+0x2c5/0x470
+[   80.766772]  __driver_attach+0xdf/0xf0
+[   80.766776]  ? driver_probe_device+0x470/0x470
+[   80.766780]  bus_for_each_dev+0x6c/0xc0
+[   80.766784]  driver_attach+0x1e/0x20
+[   80.766787]  bus_add_driver+0x45/0x270
+[   80.766790]  ? 0xffffffffc09a8000
+[   80.766794]  driver_register+0x60/0xe0
+[   80.766796]  ? 0xffffffffc09a8000
+[   80.766799]  __pci_register_driver+0x4c/0x50
+[   80.766811]  drm_pci_init+0xed/0x100 [drm]
+[   80.766816]  ? vga_switcheroo_register_handler+0x6c/0x90
+[   80.766819]  ? 0xffffffffc09a8000
+[   80.766850]  amdgpu_init+0x9b/0xac [amdgpu]
+[   80.766855]  do_one_initcall+0x53/0x1c0
+[   80.766860]  ? __vunmap+0x81/0xd0
+[   80.766865]  ? kmem_cache_alloc_trace+0xdb/0x1b0
+[   80.766868]  ? kfree+0x161/0x170
+[   80.766876]  do_init_module+0x60/0x202
+[   80.766881]  load_module+0x2612/0x29f0
+[   80.766885]  SYSC_finit_module+0xa6/0xf0
+[   80.766888]  ? SYSC_finit_module+0xa6/0xf0
+[   80.766892]  SyS_finit_module+0xe/0x10
+[   80.766896]  entry_SYSCALL_64_fastpath+0x1e/0xad
+[   80.766899] RIP: 0033:0x7fa525e60709
+[   80.766902] RSP: 002b:00007fff2f5bbbf8 EFLAGS: 00000246 ORIG_RAX: 0000000000000139
+[   80.766905] RAX: ffffffffffffffda RBX: 00007fa526129760 RCX: 00007fa525e60709
+[   80.766908] RDX: 0000000000000000 RSI: 000055f51f1c9439 RDI: 000000000000000b
+[   80.766910] RBP: 0000000000000070 R08: 0000000000000000 R09: 000055f51fcd83f0
+[   80.766913] R10: 000000000000000b R11: 0000000000000246 R12: 000055f51fcd9ff0
+[   80.766915] R13: 0000000000000007 R14: 00007fa5261297b8 R15: 0000000000002710
+[   80.766931] Kernel Offset: 0x22800000 from 0xffffffff81000000 (relocation range: 0xffffffff80000000-0xffffffffbfffffff)
+[   80.766937] ---[ end Kernel panic - not syncing: stack-protector: Kernel stack is corrupted in: ffffffffc0c88942
+[   80.766937] 
+[   80.766408] Kernel panic - not syncing: stack-protector: Kernel stack is corrupted in: ffffffffc0c88942
+[   80.766408] 
+[   80.766428] CPU: 1 PID: 1594 Comm: modprobe Not tainted 4.11.3+ #2
+[   80.766431] Hardware name: Acer Aspire A515-41G/Wartortle_BS, BIOS V0.09 04/19/2017
+[   80.766434] Call Trace:
+[   80.766445]  dump_stack+0x63/0x90
+[   80.766451]  panic+0xe8/0x236
+[   80.766526]  ? amdgpu_atombios_crtc_powergate_init+0x52/0x60 [amdgpu]
+[   80.766537]  __stack_chk_fail+0x1b/0x20
+[   80.766571]  amdgpu_atombios_crtc_powergate_init+0x52/0x60 [amdgpu]
+[   80.766610]  dce_v11_0_hw_init+0x3e/0x2d0 [amdgpu]
+[   80.766643]  amdgpu_device_init+0xe23/0x13c0 [amdgpu]
+[   80.766647]  ? kmalloc_order+0x18/0x40
+[   80.766650]  ? kmalloc_order_trace+0x24/0xa0
+[   80.766683]  amdgpu_driver_load_kms+0x5d/0x240 [amdgpu]
+[   80.766708]  drm_dev_register+0x148/0x1e0 [drm]
+[   80.766721]  drm_get_pci_dev+0xa0/0x160 [drm]
+[   80.766754]  amdgpu_pci_probe+0xb9/0xf0 [amdgpu]
+[   80.766759]  local_pci_probe+0x45/0xa0
+[   80.766762]  pci_device_probe+0xf4/0x150
+[   80.766768]  driver_probe_device+0x2c5/0x470
+[   80.766772]  __driver_attach+0xdf/0xf0
+[   80.766776]  ? driver_probe_device+0x470/0x470
+[   80.766780]  bus_for_each_dev+0x6c/0xc0
+[   80.766784]  driver_attach+0x1e/0x20
+[   80.766787]  bus_add_driver+0x45/0x270
+[   80.766790]  ? 0xffffffffc09a8000
+[   80.766794]  driver_register+0x60/0xe0
+[   80.766796]  ? 0xffffffffc09a8000
+[   80.766799]  __pci_register_driver+0x4c/0x50
+[   80.766811]  drm_pci_init+0xed/0x100 [drm]
+[   80.766816]  ? vga_switcheroo_register_handler+0x6c/0x90
+[   80.766819]  ? 0xffffffffc09a8000
+[   80.766850]  amdgpu_init+0x9b/0xac [amdgpu]
+[   80.766855]  do_one_initcall+0x53/0x1c0
+[   80.766860]  ? __vunmap+0x81/0xd0
+[   80.766865]  ? kmem_cache_alloc_trace+0xdb/0x1b0
+[   80.766868]  ? kfree+0x161/0x170
+[   80.766876]  do_init_module+0x60/0x202
+[   80.766881]  load_module+0x2612/0x29f0
+[   80.766885]  SYSC_finit_module+0xa6/0xf0
+[   80.766888]  ? SYSC_finit_module+0xa6/0xf0
+[   80.766892]  SyS_finit_module+0xe/0x10
+[   80.766896]  entry_SYSCALL_64_fastpath+0x1e/0xad
+[   80.766899] RIP: 0033:0x7fa525e60709
+[   80.766902] RSP: 002b:00007fff2f5bbbf8 EFLAGS: 00000246 ORIG_RAX: 0000000000000139
+[   80.766905] RAX: ffffffffffffffda RBX: 00007fa526129760 RCX: 00007fa525e60709
+[   80.766908] RDX: 0000000000000000 RSI: 000055f51f1c9439 RDI: 000000000000000b
+[   80.766910] RBP: 0000000000000070 R08: 0000000000000000 R09: 000055f51fcd83f0
+[   80.766913] R10: 000000000000000b R11: 0000000000000246 R12: 000055f51fcd9ff0
+[   80.766915] R13: 0000000000000007 R14: 00007fa5261297b8 R15: 0000000000002710
+[   80.766931] Kernel Offset: 0x22800000 from 0xffffffff81000000 (relocation range: 0xffffffff80000000-0xffffffffbfffffff)
+[   80.766937] ---[ end Kernel panic - not syncing: stack-protector: Kernel stack is corrupted in: ffffffffc0c88942
+[   80.766937]
+[    0.000000] Linux version 5.2.0-2-amd64 (debian-kernel@lists.debian.org) (gcc version 8.3.0 (Debian 8.3.0-21)) #1 SMP Debian 5.2.9-2 (2019-08-21)
+[    0.000000] Command line: BOOT_IMAGE=/boot/vmlinuz-5.2.0-2-amd64 root=UUID=f4cf2e0a-0d97-44e4-9e45-b6398144394b ro quiet
+[    0.000000] x86/fpu: Supporting XSAVE feature 0x001: 'x87 floating point registers'
+[    0.000000] x86/fpu: Supporting XSAVE feature 0x002: 'SSE registers'
+[    0.000000] x86/fpu: Supporting XSAVE feature 0x004: 'AVX registers'
+[    0.000000] x86/fpu: xstate_offset[2]:  576, xstate_sizes[2]:  256
+[    0.000000] x86/fpu: Enabled xstate features 0x7, context size is 832 bytes, using 'standard' format.
+[    0.000000] BIOS-provided physical RAM map:
+[    0.000000] BIOS-e820: [mem 0x0000000000000000-0x000000000009a7ff] usable
+[    0.000000] BIOS-e820: [mem 0x000000000009a800-0x000000000009ffff] reserved
+[    0.000000] BIOS-e820: [mem 0x00000000000e0000-0x00000000000fffff] reserved
+[    0.000000] BIOS-e820: [mem 0x0000000000100000-0x000000001fffffff] usable
+[    0.000000] BIOS-e820: [mem 0x0000000020000000-0x00000000201fffff] reserved
+[    0.000000] BIOS-e820: [mem 0x0000000020200000-0x000000003fffffff] usable
+[    0.000000] BIOS-e820: [mem 0x0000000040000000-0x00000000401fffff] reserved
+[    0.000000] BIOS-e820: [mem 0x0000000040200000-0x00000000caa24fff] usable
+[    0.000000] BIOS-e820: [mem 0x00000000caa25000-0x00000000caa68fff] reserved
+[    0.000000] BIOS-e820: [mem 0x00000000caa69000-0x00000000cadb6fff] usable
+[    0.000000] BIOS-e820: [mem 0x00000000cadb7000-0x00000000cade6fff] reserved
+[    0.000000] BIOS-e820: [mem 0x00000000cade7000-0x00000000cafe6fff] ACPI NVS
+[    0.000000] BIOS-e820: [mem 0x00000000cafe7000-0x00000000caffefff] ACPI data
+[    0.000000] BIOS-e820: [mem 0x00000000cafff000-0x00000000caffffff] usable
+[    0.000000] BIOS-e820: [mem 0x00000000cb800000-0x00000000cf9fffff] reserved
+[    0.000000] BIOS-e820: [mem 0x00000000fed1c000-0x00000000fed1ffff] reserved
+[    0.000000] BIOS-e820: [mem 0x00000000ffc00000-0x00000000ffc1ffff] reserved
+[    0.000000] BIOS-e820: [mem 0x0000000100000000-0x000000042dffffff] usable
+[    0.000000] NX (Execute Disable) protection: active
+[    0.000000] SMBIOS 2.6 present.
+[    0.000000] DMI: Dell Inc. Precision M4600/08V9YG, BIOS A10 03/29/2012
+[    0.000000] tsc: Fast TSC calibration using PIT
+[    0.000000] tsc: Detected 2394.567 MHz processor
+[    0.002206] e820: update [mem 0x00000000-0x00000fff] usable ==> reserved
+[    0.002208] e820: remove [mem 0x000a0000-0x000fffff] usable
+[    0.002214] last_pfn = 0x42e000 max_arch_pfn = 0x400000000
+[    0.002218] MTRR default type: uncachable
+[    0.002219] MTRR fixed ranges enabled:
+[    0.002220]   00000-9FFFF write-back
+[    0.002221]   A0000-BFFFF uncachable
+[    0.002222]   C0000-FFFFF write-protect
+[    0.002223] MTRR variable ranges enabled:
+[    0.002224]   0 base 000000000 mask C00000000 write-back
+[    0.002225]   1 base 400000000 mask FE0000000 write-back
+[    0.002226]   2 base 420000000 mask FF0000000 write-back
+[    0.002227]   3 base 0E0000000 mask FE0000000 uncachable
+[    0.002228]   4 base 0D0000000 mask FF0000000 uncachable
+[    0.002228]   5 base 0CC000000 mask FFC000000 uncachable
+[    0.002229]   6 base 0CB000000 mask FFF000000 uncachable
+[    0.002230]   7 base 42E000000 mask FFE000000 uncachable
+[    0.002231]   8 disabled
+[    0.002231]   9 disabled
+[    0.003303] x86/PAT: Configuration [0-7]: WB  WC  UC- UC  WB  WP  UC- WT  
+[    0.003456] e820: update [mem 0xcb000000-0xffffffff] usable ==> reserved
+[    0.003460] last_pfn = 0xcb000 max_arch_pfn = 0x400000000
+[    0.005476] found SMP MP-table at [mem 0x000f18b0-0x000f18bf]
+[    0.005543] reserving inaccessible SNB gfx pages
+[    0.005549] BRK [0x333801000, 0x333801fff] PGTABLE
+[    0.005551] BRK [0x333802000, 0x333802fff] PGTABLE
+[    0.005552] BRK [0x333803000, 0x333803fff] PGTABLE
+[    0.005607] BRK [0x333804000, 0x333804fff] PGTABLE
+[    0.005609] BRK [0x333805000, 0x333805fff] PGTABLE
+[    0.005902] BRK [0x333806000, 0x333806fff] PGTABLE
+[    0.005917] BRK [0x333807000, 0x333807fff] PGTABLE
+[    0.005931] BRK [0x333808000, 0x333808fff] PGTABLE
+[    0.006002] BRK [0x333809000, 0x333809fff] PGTABLE
+[    0.006094] BRK [0x33380a000, 0x33380afff] PGTABLE
+[    0.006174] BRK [0x33380b000, 0x33380bfff] PGTABLE
+[    0.006455] RAMDISK: [mem 0x33983000-0x35cb8fff]
+[    0.006461] ACPI: Early table checksum verification disabled
+[    0.006542] ACPI: RSDP 0x00000000000FE300 000024 (v02 DELL  )
+[    0.006545] ACPI: XSDT 0x00000000CAFFDE18 000084 (v01 DELL   CBX3     06222004 MSFT 00010013)
+[    0.006551] ACPI: FACP 0x00000000CAF87D98 0000F4 (v04 DELL   CBX3     06222004 MSFT 00010013)
+[    0.006556] ACPI: DSDT 0x00000000CAF54018 008A1A (v02 INT430 SYSFexxx 00001001 INTL 20090903)
+[    0.006559] ACPI: FACS 0x00000000CAFE4E40 000040
+[    0.006561] ACPI: FACS 0x00000000CAFE4D40 000040
+[    0.006564] ACPI: APIC 0x00000000CAFFCF18 0000CC (v02 DELL   CBX3     06222004 MSFT 00010013)
+[    0.006566] ACPI: TCPA 0x00000000CAFE5D18 000032 (v02                 00000000      00000000)
+[    0.006569] ACPI: SSDT 0x00000000CAF88A98 0002F9 (v01 DELLTP TPM      00003000 INTL 20090903)
+[    0.006572] ACPI: MCFG 0x00000000CAFE5C98 00003C (v01 DELL   SNDYBRDG 06222004 MSFT 00000097)
+[    0.006575] ACPI: HPET 0x00000000CAFE5C18 000038 (v01 A M I   PCHHPET 06222004 AMI. 00000003)
+[    0.006578] ACPI: BOOT 0x00000000CAFE5B98 000028 (v01 DELL   CBX3     06222004 AMI  00010013)
+[    0.006581] ACPI: SSDT 0x00000000CAF6B018 000804 (v01 PmRef  Cpu0Ist  00003000 INTL 20090903)
+[    0.006584] ACPI: SSDT 0x00000000CAF6A018 000996 (v01 PmRef  CpuPm    00003000 INTL 20090903)
+[    0.006586] ACPI: DMAR 0x00000000CAF87C18 0000E8 (v01 INTEL  SNB      00000001 INTL 00000001)
+[    0.006589] ACPI: SLIC 0x00000000CAF74C18 000176 (v03 DELL   CBX3     06222004 MSFT 00010013)
+[    0.006592] ACPI: SSDT 0x00000000CAF72018 0018C3 (v01 NvdRef NvdTabl  00001000 INTL 20090903)
+[    0.006602] ACPI: Local APIC address 0xfee00000
+[    0.006684] No NUMA configuration found
+[    0.006685] Faking a node at [mem 0x0000000000000000-0x000000042dffffff]
+[    0.006689] NODE_DATA(0) allocated [mem 0x42dfef000-0x42dff3fff]
+[    0.006725] Zone ranges:
+[    0.006725]   DMA      [mem 0x0000000000001000-0x0000000000ffffff]
+[    0.006727]   DMA32    [mem 0x0000000001000000-0x00000000ffffffff]
+[    0.006728]   Normal   [mem 0x0000000100000000-0x000000042dffffff]
+[    0.006729]   Device   empty
+[    0.006729] Movable zone start for each node
+[    0.006730] Early memory node ranges
+[    0.006731]   node   0: [mem 0x0000000000001000-0x0000000000099fff]
+[    0.006732]   node   0: [mem 0x0000000000100000-0x000000001fffffff]
+[    0.006732]   node   0: [mem 0x0000000020200000-0x000000003fffffff]
+[    0.006733]   node   0: [mem 0x0000000040200000-0x00000000caa24fff]
+[    0.006734]   node   0: [mem 0x00000000caa69000-0x00000000cadb6fff]
+[    0.006734]   node   0: [mem 0x00000000cafff000-0x00000000caffffff]
+[    0.006735]   node   0: [mem 0x0000000100000000-0x000000042dffffff]
+[    0.006962] Zeroed struct page in unavailable ranges: 22259 pages
+[    0.006963] Initmem setup node 0 [mem 0x0000000000001000-0x000000042dffffff]
+[    0.006964] On node 0 totalpages: 4163853
+[    0.006965]   DMA zone: 64 pages used for memmap
+[    0.006966]   DMA zone: 153 pages reserved
+[    0.006967]   DMA zone: 3993 pages, LIFO batch:0
+[    0.007021]   DMA32 zone: 12902 pages used for memmap
+[    0.007022]   DMA32 zone: 825716 pages, LIFO batch:63
+[    0.018688]   Normal zone: 52096 pages used for memmap
+[    0.018690]   Normal zone: 3334144 pages, LIFO batch:63
+[    0.059927] Reserving Intel graphics memory at [mem 0xcba00000-0xcf9fffff]
+[    0.060154] ACPI: PM-Timer IO Port: 0x408
+[    0.060156] ACPI: Local APIC address 0xfee00000
+[    0.060174] IOAPIC[0]: apic_id 2, version 32, address 0xfec00000, GSI 0-23
+[    0.060176] ACPI: INT_SRC_OVR (bus 0 bus_irq 0 global_irq 2 dfl dfl)
+[    0.060178] ACPI: INT_SRC_OVR (bus 0 bus_irq 9 global_irq 9 high level)
+[    0.060179] ACPI: IRQ0 used by override.
+[    0.060180] ACPI: IRQ9 used by override.
+[    0.060182] Using ACPI (MADT) for SMP configuration information
+[    0.060183] ACPI: HPET id: 0x8086a701 base: 0xfed00000
+[    0.060189] smpboot: Allowing 16 CPUs, 8 hotplug CPUs
+[    0.060209] PM: Registered nosave memory: [mem 0x00000000-0x00000fff]
+[    0.060211] PM: Registered nosave memory: [mem 0x0009a000-0x0009afff]
+[    0.060211] PM: Registered nosave memory: [mem 0x0009b000-0x0009ffff]
+[    0.060212] PM: Registered nosave memory: [mem 0x000a0000-0x000dffff]
+[    0.060212] PM: Registered nosave memory: [mem 0x000e0000-0x000fffff]
+[    0.060214] PM: Registered nosave memory: [mem 0x20000000-0x201fffff]
+[    0.060215] PM: Registered nosave memory: [mem 0x40000000-0x401fffff]
+[    0.060217] PM: Registered nosave memory: [mem 0xcaa25000-0xcaa68fff]
+[    0.060218] PM: Registered nosave memory: [mem 0xcadb7000-0xcade6fff]
+[    0.060219] PM: Registered nosave memory: [mem 0xcade7000-0xcafe6fff]
+[    0.060220] PM: Registered nosave memory: [mem 0xcafe7000-0xcaffefff]
+[    0.060221] PM: Registered nosave memory: [mem 0xcb000000-0xcb7fffff]
+[    0.060222] PM: Registered nosave memory: [mem 0xcb800000-0xcf9fffff]
+[    0.060222] PM: Registered nosave memory: [mem 0xcfa00000-0xfed1bfff]
+[    0.060223] PM: Registered nosave memory: [mem 0xfed1c000-0xfed1ffff]
+[    0.060223] PM: Registered nosave memory: [mem 0xfed20000-0xffbfffff]
+[    0.060224] PM: Registered nosave memory: [mem 0xffc00000-0xffc1ffff]
+[    0.060224] PM: Registered nosave memory: [mem 0xffc20000-0xffffffff]
+[    0.060226] [mem 0xcfa00000-0xfed1bfff] available for PCI devices
+[    0.060227] Booting paravirtualized kernel on bare hardware
+[    0.060230] clocksource: refined-jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 7645519600211568 ns
+[    0.163623] setup_percpu: NR_CPUS:512 nr_cpumask_bits:512 nr_cpu_ids:16 nr_node_ids:1
+[    0.164071] percpu: Embedded 53 pages/cpu s176984 r8192 d31912 u262144
+[    0.164082] pcpu-alloc: s176984 r8192 d31912 u262144 alloc=1*2097152
+[    0.164083] pcpu-alloc: [0] 00 01 02 03 04 05 06 07 [0] 08 09 10 11 12 13 14 15 
+[    0.164110] Built 1 zonelists, mobility grouping on.  Total pages: 4098638
+[    0.164111] Policy zone: Normal
+[    0.164113] Kernel command line: BOOT_IMAGE=/boot/vmlinuz-5.2.0-2-amd64 root=UUID=f4cf2e0a-0d97-44e4-9e45-b6398144394b ro quiet
+[    0.168058] Calgary: detecting Calgary via BIOS EBDA area
+[    0.168064] Calgary: Unable to locate Rio Grande table in EBDA - bailing!
+[    0.214002] Memory: 16262400K/16655412K available (10243K kernel code, 1186K rwdata, 3516K rodata, 1640K init, 2168K bss, 393012K reserved, 0K cma-reserved)
+[    0.214010] random: get_random_u64 called from __kmem_cache_create+0x44/0x530 with crng_init=0
+[    0.214150] SLUB: HWalign=64, Order=0-3, MinObjects=0, CPUs=16, Nodes=1
+[    0.214162] Kernel/User page tables isolation: enabled
+[    0.214179] ftrace: allocating 32784 entries in 129 pages
+[    0.227534] rcu: Hierarchical RCU implementation.
+[    0.227535] rcu: 	RCU restricting CPUs from NR_CPUS=512 to nr_cpu_ids=16.
+[    0.227536] rcu: RCU calculated value of scheduler-enlistment delay is 25 jiffies.
+[    0.227537] rcu: Adjusting geometry for rcu_fanout_leaf=16, nr_cpu_ids=16
+[    0.231150] NR_IRQS: 33024, nr_irqs: 552, preallocated irqs: 16
+[    0.233104] Console: colour VGA+ 80x25
+[    0.233109] printk: console [tty0] enabled
+[    0.233128] ACPI: Core revision 20190509
+[    0.233322] clocksource: hpet: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 133484882848 ns
+[    0.233332] hpet clockevent registered
+[    0.233338] APIC: Switch to symmetric I/O mode setup
+[    0.233339] DMAR: Host address width 36
+[    0.233340] DMAR: DRHD base: 0x000000fed90000 flags: 0x0
+[    0.233345] DMAR: dmar0: reg_base_addr fed90000 ver 1:0 cap c0000020e60262 ecap f0101a
+[    0.233346] DMAR: DRHD base: 0x000000fed91000 flags: 0x1
+[    0.233349] DMAR: dmar1: reg_base_addr fed91000 ver 1:0 cap c9008020660262 ecap f0105a
+[    0.233350] DMAR: RMRR base: 0x000000cadc6000 end: 0x000000cadd5fff
+[    0.233351] DMAR: RMRR base: 0x000000cb800000 end: 0x000000cf9fffff
+[    0.233353] DMAR-IR: IOAPIC id 2 under DRHD base  0xfed91000 IOMMU 1
+[    0.233353] DMAR-IR: HPET id 0 under DRHD base 0xfed91000
+[    0.233354] DMAR-IR: Queued invalidation will be enabled to support x2apic and Intr-remapping.
+[    0.233682] DMAR: DRHD: handling fault status reg 2
+[    0.233731] DMAR: [DMA Read] Request device [00:1f.2] fault addr caa35000 [fault reason 06] PTE Read access is not set
+[    0.233856] DMAR-IR: Enabled IRQ remapping in x2apic mode
+[    0.233858] x2apic enabled
+[    0.233864] Switched APIC routing to cluster x2apic.
+[    0.234307] ..TIMER: vector=0x30 apic1=0 pin1=2 apic2=-1 pin2=-1
+[    0.253338] clocksource: tsc-early: mask: 0xffffffffffffffff max_cycles: 0x22842b36192, max_idle_ns: 440795249252 ns
+[    0.253342] Calibrating delay loop (skipped), value calculated using timer frequency.. 4789.13 BogoMIPS (lpj=9578268)
+[    0.253345] pid_max: default: 32768 minimum: 301
+[    0.253380] LSM: Security Framework initializing
+[    0.253385] Yama: disabled by default; enable with sysctl kernel.yama.*
+[    0.253412] AppArmor: AppArmor initialized
+[    0.253414] TOMOYO Linux initialized
+[    0.255673] Dentry cache hash table entries: 2097152 (order: 12, 16777216 bytes)
+[    0.256822] Inode-cache hash table entries: 1048576 (order: 11, 8388608 bytes)
+[    0.256878] Mount-cache hash table entries: 32768 (order: 6, 262144 bytes)
+[    0.256916] Mountpoint-cache hash table entries: 32768 (order: 6, 262144 bytes)
+[    0.257185] mce: CPU0: Thermal monitoring enabled (TM1)
+[    0.257195] process: using mwait in idle threads
+[    0.257198] Last level iTLB entries: 4KB 512, 2MB 8, 4MB 8
+[    0.257198] Last level dTLB entries: 4KB 512, 2MB 32, 4MB 32, 1GB 0
+[    0.257200] Spectre V1 : Mitigation: usercopy/swapgs barriers and __user pointer sanitization
+[    0.257201] Spectre V2 : Mitigation: Full generic retpoline
+[    0.257201] Spectre V2 : Spectre v2 / SpectreRSB mitigation: Filling RSB on context switch
+[    0.257202] Speculative Store Bypass: Vulnerable
+[    0.257206] MDS: Vulnerable: Clear CPU buffers attempted, no microcode
+[    0.257363] Freeing SMP alternatives memory: 24K
+[    0.260080] TSC deadline timer enabled
+[    0.260084] smpboot: CPU0: Intel(R) Core(TM) i7-2760QM CPU @ 2.40GHz (family: 0x6, model: 0x2a, stepping: 0x7)
+[    0.260195] Performance Events: PEBS fmt1+, SandyBridge events, 16-deep LBR, full-width counters, Intel PMU driver.
+[    0.260202] core: PEBS disabled due to CPU errata, please upgrade microcode
+[    0.260204] ... version:                3
+[    0.260205] ... bit width:              48
+[    0.260205] ... generic registers:      4
+[    0.260206] ... value mask:             0000ffffffffffff
+[    0.260207] ... max period:             00007fffffffffff
+[    0.260207] ... fixed-purpose events:   3
+[    0.260208] ... event mask:             000000070000000f
+[    0.260250] rcu: Hierarchical SRCU implementation.
+[    0.261339] NMI watchdog: Enabled. Permanently consumes one hw-PMU counter.
+[    0.261339] smp: Bringing up secondary CPUs ...
+[    0.261339] x86: Booting SMP configuration:
+[    0.261339] .... node  #0, CPUs:        #1  #2  #3  #4
+[    0.267885] MDS CPU bug present and SMT on, data leak possible. See https://www.kernel.org/doc/html/latest/admin-guide/hw-vuln/mds.html for more details.
+[    0.267885]   #5  #6  #7
+[    0.273399] smp: Brought up 1 node, 8 CPUs
+[    0.273399] smpboot: Max logical packages: 2
+[    0.273399] smpboot: Total of 8 processors activated (38313.07 BogoMIPS)
+[    0.277913] devtmpfs: initialized
+[    0.277913] x86/mm: Memory block size: 128MB
+[    0.278641] PM: Registering ACPI NVS region [mem 0xcade7000-0xcafe6fff] (2097152 bytes)
+[    0.278641] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 7645041785100000 ns
+[    0.278641] futex hash table entries: 4096 (order: 6, 262144 bytes)
+[    0.278641] pinctrl core: initialized pinctrl subsystem
+[    0.278641] NET: Registered protocol family 16
+[    0.278641] audit: initializing netlink subsys (disabled)
+[    0.278641] audit: type=2000 audit(1568125429.044:1): state=initialized audit_enabled=0 res=1
+[    0.278641] cpuidle: using governor ladder
+[    0.278641] cpuidle: using governor menu
+[    0.278641] Simple Boot Flag at 0xf3 set to 0x1
+[    0.278641] ACPI FADT declares the system doesn't support PCIe ASPM, so disable it
+[    0.278641] ACPI: bus type PCI registered
+[    0.278641] acpiphp: ACPI Hot Plug PCI Controller Driver version: 0.5
+[    0.278641] PCI: MMCONFIG for domain 0000 [bus 00-3f] at [mem 0xf8000000-0xfbffffff] (base 0xf8000000)
+[    0.278641] PCI: not using MMCONFIG
+[    0.278641] PCI: Using configuration type 1 for base access
+[    0.278641] core: PMU erratum BJ122, BV98, HSD29 worked around, HT is on
+[    0.278641] ENERGY_PERF_BIAS: Set to 'normal', was 'performance'
+[    0.278641] HugeTLB registered 2.00 MiB page size, pre-allocated 0 pages
+[    0.481721] alg: No test for lzo-rle (lzo-rle-generic)
+[    0.481721] alg: No test for lzo-rle (lzo-rle-scomp)
+[    0.481721] ACPI: Added _OSI(Module Device)
+[    0.481721] ACPI: Added _OSI(Processor Device)
+[    0.481721] ACPI: Added _OSI(3.0 _SCP Extensions)
+[    0.481721] ACPI: Added _OSI(Processor Aggregator Device)
+[    0.481721] ACPI: Added _OSI(Linux-Dell-Video)
+[    0.481721] ACPI: Added _OSI(Linux-Lenovo-NV-HDMI-Audio)
+[    0.481721] ACPI: Added _OSI(Linux-HPI-Hybrid-Graphics)
+[    0.487983] ACPI: 5 ACPI AML tables successfully acquired and loaded
+[    0.489244] ACPI: [Firmware Bug]: BIOS _OSI(Linux) query ignored
+[    0.501682] ACPI: Dynamic OEM Table Load:
+[    0.501689] ACPI: SSDT 0xFFFF890F9AC0D000 000727 (v01 PmRef  Cpu0Cst  00003001 INTL 20090903)
+[    0.502055] ACPI: Dynamic OEM Table Load:
+[    0.502059] ACPI: SSDT 0xFFFF890F9AC7CC00 000303 (v01 PmRef  ApIst    00003000 INTL 20090903)
+[    0.502292] ACPI: Dynamic OEM Table Load:
+[    0.502295] ACPI: SSDT 0xFFFF890F9AA6BA00 000119 (v01 PmRef  ApCst    00003000 INTL 20090903)
+[    0.503538] ACPI: EC: EC started
+[    0.503539] ACPI: EC: interrupt blocked
+[    0.504489] ACPI: \_SB_.PCI0.LPCB.ECDV: Used as first EC
+[    0.504491] ACPI: \_SB_.PCI0.LPCB.ECDV: GPE=0x10, EC_CMD/EC_SC=0x934, EC_DATA=0x930
+[    0.504492] ACPI: \_SB_.PCI0.LPCB.ECDV: Boot DSDT EC used to handle transactions
+[    0.504492] ACPI: Interpreter enabled
+[    0.504513] ACPI: (supports S0 S3 S4 S5)
+[    0.504514] ACPI: Using IOAPIC for interrupt routing
+[    0.504539] PCI: MMCONFIG for domain 0000 [bus 00-3f] at [mem 0xf8000000-0xfbffffff] (base 0xf8000000)
+[    0.504936] PCI: MMCONFIG at [mem 0xf8000000-0xfbffffff] reserved in ACPI motherboard resources
+[    0.504940] pmd_set_huge: Cannot satisfy [mem 0xf8000000-0xf8200000] with a huge-page mapping due to MTRR override.
+[    0.505029] PCI: Using host bridge windows from ACPI; if necessary, use "pci=nocrs" and report a bug
+[    0.505214] ACPI: Enabled 5 GPEs in block 00 to 3F
+[    0.514577] ACPI: PCI Root Bridge [PCI0] (domain 0000 [bus 00-3e])
+[    0.514582] acpi PNP0A08:00: _OSC: OS supports [ExtendedConfig ASPM ClockPM Segments MSI HPX-Type3]
+[    0.514615] acpi PNP0A08:00: _OSC failed (AE_ERROR); disabling ASPM
+[    0.515035] PCI host bridge to bus 0000:00
+[    0.515037] pci_bus 0000:00: root bus resource [io  0x0000-0x0cf7 window]
+[    0.515038] pci_bus 0000:00: root bus resource [io  0x0d00-0xffff window]
+[    0.515040] pci_bus 0000:00: root bus resource [mem 0x000a0000-0x000bffff window]
+[    0.515041] pci_bus 0000:00: root bus resource [mem 0xcfa00000-0xfeafffff window]
+[    0.515042] pci_bus 0000:00: root bus resource [mem 0xfed40000-0xfed44fff window]
+[    0.515044] pci_bus 0000:00: root bus resource [bus 00-3e]
+[    0.515051] pci 0000:00:00.0: [8086:0104] type 00 class 0x060000
+[    0.515142] pci 0000:00:01.0: [8086:0101] type 01 class 0x060400
+[    0.515183] pci 0000:00:01.0: PME# supported from D0 D3hot D3cold
+[    0.515262] pci 0000:00:02.0: [8086:0126] type 00 class 0x030000
+[    0.515272] pci 0000:00:02.0: reg 0x10: [mem 0xf0400000-0xf07fffff 64bit]
+[    0.515277] pci 0000:00:02.0: reg 0x18: [mem 0xd0000000-0xdfffffff 64bit pref]
+[    0.515281] pci 0000:00:02.0: reg 0x20: [io  0x8000-0x803f]
+[    0.515385] pci 0000:00:16.0: [8086:1c3a] type 00 class 0x078000
+[    0.515411] pci 0000:00:16.0: reg 0x10: [mem 0xf25b0000-0xf25b000f 64bit]
+[    0.515488] pci 0000:00:16.0: PME# supported from D0 D3hot D3cold
+[    0.515565] pci 0000:00:16.3: [8086:1c3d] type 00 class 0x070002
+[    0.515586] pci 0000:00:16.3: reg 0x10: [io  0x80e0-0x80e7]
+[    0.515595] pci 0000:00:16.3: reg 0x14: [mem 0xf2590000-0xf2590fff]
+[    0.515740] pci 0000:00:19.0: [8086:1502] type 00 class 0x020000
+[    0.515760] pci 0000:00:19.0: reg 0x10: [mem 0xf2500000-0xf251ffff]
+[    0.515768] pci 0000:00:19.0: reg 0x14: [mem 0xf2580000-0xf2580fff]
+[    0.515776] pci 0000:00:19.0: reg 0x18: [io  0x8080-0x809f]
+[    0.515837] pci 0000:00:19.0: PME# supported from D0 D3hot D3cold
+[    0.515915] pci 0000:00:1a.0: [8086:1c2d] type 00 class 0x0c0320
+[    0.515938] pci 0000:00:1a.0: reg 0x10: [mem 0xf2570000-0xf25703ff]
+[    0.516023] pci 0000:00:1a.0: PME# supported from D0 D3hot D3cold
+[    0.516105] pci 0000:00:1b.0: [8086:1c20] type 00 class 0x040300
+[    0.516127] pci 0000:00:1b.0: reg 0x10: [mem 0xf2560000-0xf2563fff 64bit]
+[    0.516203] pci 0000:00:1b.0: PME# supported from D0 D3hot D3cold
+[    0.516283] pci 0000:00:1c.0: [8086:1c10] type 01 class 0x060400
+[    0.516382] pci 0000:00:1c.0: PME# supported from D0 D3hot D3cold
+[    0.516404] pci 0000:00:1c.0: Enabling MPC IRBNCE
+[    0.516407] pci 0000:00:1c.0: Intel PCH root port ACS workaround enabled
+[    0.516484] pci 0000:00:1c.1: [8086:1c12] type 01 class 0x060400
+[    0.516582] pci 0000:00:1c.1: PME# supported from D0 D3hot D3cold
+[    0.516601] pci 0000:00:1c.1: Enabling MPC IRBNCE
+[    0.516604] pci 0000:00:1c.1: Intel PCH root port ACS workaround enabled
+[    0.516681] pci 0000:00:1c.2: [8086:1c14] type 01 class 0x060400
+[    0.516779] pci 0000:00:1c.2: PME# supported from D0 D3hot D3cold
+[    0.516798] pci 0000:00:1c.2: Enabling MPC IRBNCE
+[    0.516801] pci 0000:00:1c.2: Intel PCH root port ACS workaround enabled
+[    0.516879] pci 0000:00:1c.3: [8086:1c16] type 01 class 0x060400
+[    0.516976] pci 0000:00:1c.3: PME# supported from D0 D3hot D3cold
+[    0.516995] pci 0000:00:1c.3: Enabling MPC IRBNCE
+[    0.516998] pci 0000:00:1c.3: Intel PCH root port ACS workaround enabled
+[    0.517078] pci 0000:00:1c.7: [8086:1c1e] type 01 class 0x060400
+[    0.517183] pci 0000:00:1c.7: PME# supported from D0 D3hot D3cold
+[    0.517202] pci 0000:00:1c.7: Enabling MPC IRBNCE
+[    0.517205] pci 0000:00:1c.7: Intel PCH root port ACS workaround enabled
+[    0.517283] pci 0000:00:1d.0: [8086:1c26] type 00 class 0x0c0320
+[    0.517305] pci 0000:00:1d.0: reg 0x10: [mem 0xf2550000-0xf25503ff]
+[    0.517394] pci 0000:00:1d.0: PME# supported from D0 D3hot D3cold
+[    0.517479] pci 0000:00:1f.0: [8086:1c4f] type 00 class 0x060100
+[    0.517660] pci 0000:00:1f.2: [8086:1c03] type 00 class 0x010601
+[    0.517679] pci 0000:00:1f.2: reg 0x10: [io  0x80d0-0x80d7]
+[    0.517687] pci 0000:00:1f.2: reg 0x14: [io  0x80c0-0x80c3]
+[    0.517695] pci 0000:00:1f.2: reg 0x18: [io  0x80b0-0x80b7]
+[    0.517702] pci 0000:00:1f.2: reg 0x1c: [io  0x80a0-0x80a3]
+[    0.517710] pci 0000:00:1f.2: reg 0x20: [io  0x8060-0x807f]
+[    0.517718] pci 0000:00:1f.2: reg 0x24: [mem 0xf2540000-0xf25407ff]
+[    0.517761] pci 0000:00:1f.2: PME# supported from D3hot
+[    0.517836] pci 0000:00:1f.3: [8086:1c22] type 00 class 0x0c0500
+[    0.517855] pci 0000:00:1f.3: reg 0x10: [mem 0xf2530000-0xf25300ff 64bit]
+[    0.517875] pci 0000:00:1f.3: reg 0x20: [io  0x8040-0x805f]
+[    0.518012] pci 0000:01:00.0: [10de:0dda] type 00 class 0x030000
+[    0.518029] pci 0000:01:00.0: reg 0x10: [mem 0xee000000-0xefffffff]
+[    0.518040] pci 0000:01:00.0: reg 0x14: [mem 0xe0000000-0xe7ffffff 64bit pref]
+[    0.518050] pci 0000:01:00.0: reg 0x1c: [mem 0xe8000000-0xebffffff 64bit pref]
+[    0.518056] pci 0000:01:00.0: reg 0x24: [io  0x7000-0x707f]
+[    0.518062] pci 0000:01:00.0: reg 0x30: [mem 0xf0000000-0xf007ffff pref]
+[    0.518069] pci 0000:01:00.0: enabling Extended Tags
+[    0.518283] pci 0000:01:00.1: [10de:0be9] type 00 class 0x040300
+[    0.518301] pci 0000:01:00.1: reg 0x10: [mem 0xf0080000-0xf0083fff]
+[    0.518349] pci 0000:01:00.1: enabling Extended Tags
+[    0.518462] pci 0000:00:01.0: PCI bridge to [bus 01]
+[    0.518464] pci 0000:00:01.0:   bridge window [io  0x7000-0x7fff]
+[    0.518466] pci 0000:00:01.0:   bridge window [mem 0xee000000-0xf00fffff]
+[    0.518468] pci 0000:00:01.0:   bridge window [mem 0xe0000000-0xebffffff 64bit pref]
+[    0.518520] pci 0000:00:1c.0: PCI bridge to [bus 02]
+[    0.518726] pci 0000:03:00.0: [8086:422b] type 00 class 0x028000
+[    0.518930] pci 0000:03:00.0: reg 0x10: [mem 0xf2400000-0xf2401fff 64bit]
+[    0.519685] pci 0000:03:00.0: PME# supported from D0 D3hot D3cold
+[    0.520091] pci 0000:00:1c.1: PCI bridge to [bus 03]
+[    0.520097] pci 0000:00:1c.1:   bridge window [mem 0xf2400000-0xf24fffff]
+[    0.520150] pci 0000:00:1c.2: PCI bridge to [bus 04-09]
+[    0.520154] pci 0000:00:1c.2:   bridge window [io  0x6000-0x6fff]
+[    0.520157] pci 0000:00:1c.2:   bridge window [mem 0xf1900000-0xf22fffff]
+[    0.520163] pci 0000:00:1c.2:   bridge window [mem 0xed200000-0xedbfffff 64bit pref]
+[    0.520250] pci 0000:0a:00.0: [1033:0194] type 00 class 0x0c0330
+[    0.520321] pci 0000:0a:00.0: reg 0x10: [mem 0xf2300000-0xf2301fff 64bit]
+[    0.520578] pci 0000:0a:00.0: PME# supported from D0 D3hot D3cold
+[    0.520737] pci 0000:00:1c.3: PCI bridge to [bus 0a]
+[    0.520743] pci 0000:00:1c.3:   bridge window [mem 0xf2300000-0xf23fffff]
+[    0.520833] pci 0000:0b:00.0: [1217:11f7] type 00 class 0x0c0010
+[    0.520889] pci 0000:0b:00.0: reg 0x10: [mem 0xf0830000-0xf0830fff]
+[    0.521165] pci 0000:0b:00.0: supports D1 D2
+[  513.733164] trace_kprobe: Could not insert probe at abort+0: -22
+[  541.908669] Alignment trap: not handling instruction f46107cf at [<004e5c4c>]
+[  541.916015] Unhandled fault: alignment exception (0x011) at 0x00508ae4
+[  541.922732] pgd = ec340000
+[  541.925613] [00508ae4] *pgd=fb0c2835
+[  541.934792] Unhandled fault: external abort on non-linefetch (0x008) at 0xfa21200c
+[  541.942570] pgd = c0204000
+[  541.945457] [fa21200c] *pgd=afffb841, *pte=48212653, *ppte=48212453
+[  541.952218] Internal error: : 8 [#1] SMP ARM
+[    0.521166] pci 0000:0b:00.0: PME# supported from D0 D1 D2 D3hot D3cold
+[    0.521323] pci 0000:0b:00.1: [1217:8320] type 00 class 0x080501
+[    0.521379] pci 0000:0b:00.1: reg 0x10: [mem 0xf0820000-0xf08201ff]
+[    0.521655] pci 0000:0b:00.1: supports D1 D2
+[    0.521656] pci 0000:0b:00.1: PME# supported from D0 D1 D2 D3hot D3cold
+[    0.521799] pci 0000:0b:00.2: [1217:8330] type 00 class 0x018000
+[    0.521855] pci 0000:0b:00.2: reg 0x10: [mem 0xf0810000-0xf08103ff]
+[    0.521901] pci 0000:0b:00.2: reg 0x18: [mem 0xf0800000-0xf08003ff]
+[    0.522130] pci 0000:0b:00.2: supports D1 D2
+[    0.522131] pci 0000:0b:00.2: PME# supported from D0 D1 D2 D3hot D3cold
+[    0.533418] pci 0000:00:1c.7: PCI bridge to [bus 0b-12]
+[    0.533422] pci 0000:00:1c.7:   bridge window [io  0x2000-0x5fff]
+[    0.533426] pci 0000:00:1c.7:   bridge window [mem 0xf0800000-0xf18fffff]
+[    0.533432] pci 0000:00:1c.7:   bridge window [mem 0xec100000-0xed1fffff 64bit pref]
+[    0.534504] ACPI: PCI Interrupt Link [LNKA] (IRQs 1 3 4 5 6 7 10 12 14 15) *11
+[    0.534551] ACPI: PCI Interrupt Link [LNKB] (IRQs 1 3 4 5 6 7 11 12 14 15) *10
+[    0.534596] ACPI: PCI Interrupt Link [LNKC] (IRQs 1 3 4 5 6 7 10 12 14 15) *11
+[    0.534640] ACPI: PCI Interrupt Link [LNKD] (IRQs 1 3 4 5 6 7 11 12 14 15) *10
+[    0.534685] ACPI: PCI Interrupt Link [LNKE] (IRQs 1 3 4 *5 6 7 10 12 14 15)
+[    0.534729] ACPI: PCI Interrupt Link [LNKF] (IRQs 1 3 4 5 6 7 11 12 14 15) *0, disabled.
+[    0.534773] ACPI: PCI Interrupt Link [LNKG] (IRQs 1 *3 4 5 6 7 10 12 14 15)
+[    0.534817] ACPI: PCI Interrupt Link [LNKH] (IRQs 1 3 4 5 6 7 11 12 14 15) *0, disabled.
+[    0.536041] ACPI: EC: interrupt unblocked
+[    0.536049] ACPI: EC: event unblocked
+[    0.536055] ACPI: \_SB_.PCI0.LPCB.ECDV: GPE=0x10, EC_CMD/EC_SC=0x934, EC_DATA=0x930
+[    0.536057] ACPI: \_SB_.PCI0.LPCB.ECDV: Boot DSDT EC used to handle transactions and events
+[    0.536121] pci 0000:00:02.0: vgaarb: setting as boot VGA device
+[    0.536121] pci 0000:00:02.0: vgaarb: VGA device added: decodes=io+mem,owns=io+mem,locks=none
+[    0.536121] pci 0000:01:00.0: vgaarb: VGA device added: decodes=io+mem,owns=none,locks=none
+[    0.536121] pci 0000:00:02.0: vgaarb: no bridge control possible
+[    0.536121] pci 0000:01:00.0: vgaarb: bridge control possible
+[    0.536121] vgaarb: loaded
+[    0.536121] EDAC MC: Ver: 3.0.0
+[    0.536121] PCI: Using ACPI for IRQ routing
+[    0.538424] PCI: pci_cache_line_size set to 64 bytes
+[    0.538554] e820: reserve RAM buffer [mem 0x0009a800-0x0009ffff]
+[    0.538555] e820: reserve RAM buffer [mem 0xcaa25000-0xcbffffff]
+[    0.538556] e820: reserve RAM buffer [mem 0xcadb7000-0xcbffffff]
+[    0.538557] e820: reserve RAM buffer [mem 0xcb000000-0xcbffffff]
+[    0.538558] e820: reserve RAM buffer [mem 0x42e000000-0x42fffffff]
+[    0.538686] hpet0: at MMIO 0xfed00000, IRQs 2, 8, 0, 0, 0, 0, 0, 0
+[    0.538690] hpet0: 8 comparators, 64-bit 14.318180 MHz counter
+[    0.541364] clocksource: Switched to clocksource tsc-early
+[    0.552712] VFS: Disk quotas dquot_6.6.0
+[    0.552735] VFS: Dquot-cache hash table entries: 512 (order 0, 4096 bytes)
+[    0.552859] AppArmor: AppArmor Filesystem Enabled
+[    0.552877] pnp: PnP ACPI init
+[    0.553054] system 00:00: [mem 0xfed00000-0xfed003ff] has been reserved
+[    0.553061] system 00:00: Plug and Play ACPI device, IDs PNP0103 PNP0c01 (active)
+[    0.553112] system 00:01: [io  0x0680-0x069f] has been reserved
+[    0.553113] system 00:01: [io  0x1000-0x100f] has been reserved
+[    0.553115] system 00:01: [io  0xffff] has been reserved
+[    0.553116] system 00:01: [io  0xffff] has been reserved
+[    0.553118] system 00:01: [io  0x0400-0x047f] has been reserved
+[    0.553119] system 00:01: [io  0x0500-0x057f] has been reserved
+[    0.553120] system 00:01: [io  0x164e-0x164f] has been reserved
+[    0.553124] system 00:01: Plug and Play ACPI device, IDs PNP0c02 (active)
+[    0.553147] pnp 00:02: Plug and Play ACPI device, IDs PNP0b00 (active)
+[    0.553167] pnp 00:03: Plug and Play ACPI device, IDs PNP0303 (active)
+[    0.553901] pnp 00:04: Plug and Play ACPI device, IDs PNP0401 (disabled)
+[    0.553921] pnp 00:05: Plug and Play ACPI device, IDs DLL04a3 PNP0f13 (active)
+[    0.554120] system 00:06: [mem 0xfed1c000-0xfed1ffff] has been reserved
+[    0.554122] system 00:06: [mem 0xfed10000-0xfed17fff] has been reserved
+[    0.554123] system 00:06: [mem 0xfed18000-0xfed18fff] has been reserved
+[    0.554124] system 00:06: [mem 0xfed19000-0xfed19fff] has been reserved
+[    0.554126] system 00:06: [mem 0xf8000000-0xfbffffff] has been reserved
+[    0.554127] system 00:06: [mem 0xfed20000-0xfed3ffff] has been reserved
+[    0.554129] system 00:06: [mem 0xfed90000-0xfed93fff] could not be reserved
+[    0.554130] system 00:06: [mem 0xfed45000-0xfed8ffff] has been reserved
+[    0.554132] system 00:06: [mem 0xff000000-0xffffffff] could not be reserved
+[    0.554133] system 00:06: [mem 0xfee00000-0xfeefffff] has been reserved
+[    0.554137] system 00:06: Plug and Play ACPI device, IDs PNP0c02 (active)
+[    0.555340] system 00:07: [mem 0x20000000-0x201fffff] has been reserved
+[    0.555341] system 00:07: [mem 0x40000000-0x401fffff] has been reserved
+[    0.555345] system 00:07: Plug and Play ACPI device, IDs PNP0c01 (active)
+[    0.555353] pnp: PnP ACPI: found 8 devices
+[    0.561159] clocksource: acpi_pm: mask: 0xffffff max_cycles: 0xffffff, max_idle_ns: 2085701024 ns
+[    0.561172] pci 0000:00:01.0: PCI bridge to [bus 01]
+[    0.561174] pci 0000:00:01.0:   bridge window [io  0x7000-0x7fff]
+[    0.561177] pci 0000:00:01.0:   bridge window [mem 0xee000000-0xf00fffff]
+[    0.561179] pci 0000:00:01.0:   bridge window [mem 0xe0000000-0xebffffff 64bit pref]
+[    0.561182] pci 0000:00:1c.0: PCI bridge to [bus 02]
+[    0.561193] pci 0000:00:1c.1: PCI bridge to [bus 03]
+[    0.561198] pci 0000:00:1c.1:   bridge window [mem 0xf2400000-0xf24fffff]
+[    0.561206] pci 0000:00:1c.2: PCI bridge to [bus 04-09]
+[    0.561209] pci 0000:00:1c.2:   bridge window [io  0x6000-0x6fff]
+[    0.561214] pci 0000:00:1c.2:   bridge window [mem 0xf1900000-0xf22fffff]
+[    0.561218] pci 0000:00:1c.2:   bridge window [mem 0xed200000-0xedbfffff 64bit pref]
+[    0.561224] pci 0000:00:1c.3: PCI bridge to [bus 0a]
+[    0.561228] pci 0000:00:1c.3:   bridge window [mem 0xf2300000-0xf23fffff]
+[    0.561236] pci 0000:00:1c.7: PCI bridge to [bus 0b-12]
+[    0.561239] pci 0000:00:1c.7:   bridge window [io  0x2000-0x5fff]
+[    0.561244] pci 0000:00:1c.7:   bridge window [mem 0xf0800000-0xf18fffff]
+[    0.561248] pci 0000:00:1c.7:   bridge window [mem 0xec100000-0xed1fffff 64bit pref]
+[    0.561255] pci_bus 0000:00: resource 4 [io  0x0000-0x0cf7 window]
+[    0.561256] pci_bus 0000:00: resource 5 [io  0x0d00-0xffff window]
+[    0.561257] pci_bus 0000:00: resource 6 [mem 0x000a0000-0x000bffff window]
+[    0.561259] pci_bus 0000:00: resource 7 [mem 0xcfa00000-0xfeafffff window]
+[    0.561260] pci_bus 0000:00: resource 8 [mem 0xfed40000-0xfed44fff window]
+[    0.561261] pci_bus 0000:01: resource 0 [io  0x7000-0x7fff]
+[    0.561262] pci_bus 0000:01: resource 1 [mem 0xee000000-0xf00fffff]
+[    0.561263] pci_bus 0000:01: resource 2 [mem 0xe0000000-0xebffffff 64bit pref]
+[    0.561264] pci_bus 0000:03: resource 1 [mem 0xf2400000-0xf24fffff]
+[    0.561266] pci_bus 0000:04: resource 0 [io  0x6000-0x6fff]
+[    0.561267] pci_bus 0000:04: resource 1 [mem 0xf1900000-0xf22fffff]
+[    0.561268] pci_bus 0000:04: resource 2 [mem 0xed200000-0xedbfffff 64bit pref]
+[    0.561269] pci_bus 0000:0a: resource 1 [mem 0xf2300000-0xf23fffff]
+[    0.561270] pci_bus 0000:0b: resource 0 [io  0x2000-0x5fff]
+[    0.561271] pci_bus 0000:0b: resource 1 [mem 0xf0800000-0xf18fffff]
+[    0.561272] pci_bus 0000:0b: resource 2 [mem 0xec100000-0xed1fffff 64bit pref]
+[    0.561365] NET: Registered protocol family 2
+[    0.561518] tcp_listen_portaddr_hash hash table entries: 8192 (order: 5, 131072 bytes)
+[    0.561581] TCP established hash table entries: 131072 (order: 8, 1048576 bytes)
+[    0.561803] TCP bind hash table entries: 65536 (order: 8, 1048576 bytes)
+[    0.561926] TCP: Hash tables configured (established 131072 bind 65536)
+[    0.561977] UDP hash table entries: 8192 (order: 6, 262144 bytes)
+[    0.562027] UDP-Lite hash table entries: 8192 (order: 6, 262144 bytes)
+[    0.562118] NET: Registered protocol family 1
+[    0.562123] NET: Registered protocol family 44
+[    0.562134] pci 0000:00:02.0: Video device with shadowed ROM at [mem 0x000c0000-0x000dffff]
+[    0.562815] PCI: CLS 64 bytes, default 64
+[    0.562858] Trying to unpack rootfs image as initramfs...
+[    1.200203] Freeing initrd memory: 36056K
+[    1.200252] DMAR: No ATSR found
+[    1.200333] DMAR: dmar0: Using Queued invalidation
+[    1.200338] DMAR: dmar1: Using Queued invalidation
+[    1.294114] pci 0000:00:02.0: DMAR: Software identity mapping
+[    1.294119] DMAR: Setting RMRR:
+[    1.294121] pci 0000:00:02.0: DMAR: Setting identity map [0xcb800000 - 0xcf9fffff]
+[    1.294634] pci 0000:00:1a.0: DMAR: Setting identity map [0xcadc6000 - 0xcadd5fff]
+[    1.294789] pci 0000:00:1d.0: DMAR: Setting identity map [0xcadc6000 - 0xcadd5fff]
+[    1.294801] DMAR: Prepare 0-16MiB unity mapping for LPC
+[    1.294894] pci 0000:00:1f.0: DMAR: Setting identity map [0x0 - 0xffffff]
+[    1.295127] DMAR: Intel(R) Virtualization Technology for Directed I/O
+[    1.295184] pci 0000:00:00.0: Adding to iommu group 0
+[    1.295202] pci 0000:00:01.0: Adding to iommu group 1
+[    1.295211] pci 0000:00:02.0: Adding to iommu group 2
+[    1.295229] pci 0000:00:16.0: Adding to iommu group 3
+[    1.295237] pci 0000:00:16.3: Adding to iommu group 3
+[    1.295247] pci 0000:00:19.0: Adding to iommu group 4
+[    1.295257] pci 0000:00:1a.0: Adding to iommu group 5
+[    1.295267] pci 0000:00:1b.0: Adding to iommu group 6
+[    1.295277] pci 0000:00:1c.0: Adding to iommu group 7
+[    1.295287] pci 0000:00:1c.1: Adding to iommu group 8
+[    1.295297] pci 0000:00:1c.2: Adding to iommu group 9
+[    1.295307] pci 0000:00:1c.3: Adding to iommu group 10
+[    1.295317] pci 0000:00:1c.7: Adding to iommu group 11
+[    1.295327] pci 0000:00:1d.0: Adding to iommu group 12
+[    1.295349] pci 0000:00:1f.0: Adding to iommu group 13
+[    1.295358] pci 0000:00:1f.2: Adding to iommu group 13
+[    1.295368] pci 0000:00:1f.3: Adding to iommu group 13
+[    1.295373] pci 0000:01:00.0: Adding to iommu group 1
+[    1.295377] pci 0000:01:00.1: Adding to iommu group 1
+[    1.295388] pci 0000:03:00.0: Adding to iommu group 14
+[    1.295397] pci 0000:0a:00.0: Adding to iommu group 15
+[    1.295435] pci 0000:0b:00.0: Adding to iommu group 16
+[    1.295458] pci 0000:0b:00.1: Adding to iommu group 16
+[    1.295479] pci 0000:0b:00.2: Adding to iommu group 16
+[    1.298169] Initialise system trusted keyrings
+[    1.298175] Key type blacklist registered
+[    1.298221] workingset: timestamp_bits=40 max_order=22 bucket_order=0
+[    1.299577] zbud: loaded
+[    1.299934] Platform Keyring initialized
+[    1.299936] Key type asymmetric registered
+[    1.299937] Asymmetric key parser 'x509' registered
+[    1.299944] Block layer SCSI generic (bsg) driver version 0.4 loaded (major 250)
+[    1.299986] io scheduler mq-deadline registered
+[    1.301048] shpchp: Standard Hot Plug PCI Controller Driver version: 0.4
+[    1.301060] intel_idle: MWAIT substates: 0x21120
+[    1.301061] intel_idle: v0.4.1 model 0x2A
+[    1.301397] intel_idle: lapic_timer_reliable_states 0xffffffff
+[    1.302835] thermal LNXTHERM:00: registered as thermal_zone0
+[    1.302836] ACPI: Thermal Zone [THM] (25 C)
+[    1.302954] Serial: 8250/16550 driver, 4 ports, IRQ sharing enabled
+[    1.323862] 0000:00:16.3: ttyS0 at I/O 0x80e0 (irq = 17, base_baud = 115200) is a 16550A
+[    1.324128] Linux agpgart interface v0.103
+[    1.324189] AMD-Vi: AMD IOMMUv2 driver by Joerg Roedel <jroedel@suse.de>
+[    1.324189] AMD-Vi: AMD IOMMUv2 functionality not available on this system
+[    1.324772] i8042: PNP: PS/2 Controller [PNP0303:PS2K,PNP0f13:PS2M] at 0x60,0x64 irq 1,12
+[    1.325146] i8042: Warning: Keylock active
+[    1.326387] serio: i8042 KBD port at 0x60,0x64 irq 1
+[    1.326391] serio: i8042 AUX port at 0x60,0x64 irq 12
+[    1.326530] mousedev: PS/2 mouse device common for all mice
+[    1.326569] rtc_cmos 00:02: RTC can wake from S4
+[    1.326799] rtc_cmos 00:02: registered as rtc0
+[    1.326813] rtc_cmos 00:02: alarms up to one year, y3k, 242 bytes nvram, hpet irqs
+[    1.326823] intel_pstate: Intel P-state driver initializing
+[    1.327746] ledtrig-cpu: registered to indicate activity on CPUs
+[    1.327783] input: AT Translated Set 2 keyboard as /devices/platform/i8042/serio0/input/input0
+[    1.329394] NET: Registered protocol family 10
+[    1.355242] Segment Routing with IPv6
+[    1.355301] mip6: Mobile IPv6
+[    1.355307] NET: Registered protocol family 17
+[    1.355564] mpls_gso: MPLS GSO support
+[    1.356981] mce: Using 9 MCE banks
+[    1.357148] microcode: sig=0x206a7, pf=0x10, revision=0x23
+[    1.357289] microcode: Microcode Update Driver: v2.2.
+[    1.357313] sched_clock: Marking stable (1354942208, 1992713)->(1367029414, -10094493)
+[    1.358039] registered taskstats version 1
+[    1.358042] Loading compiled-in X.509 certificates
+[    1.401492] Loaded X.509 cert 'Debian Secure Boot CA: 6ccece7e4c6c0d1f6149f3dd27dfcc5cbb419ea1'
+[    1.401552] Loaded X.509 cert 'Debian Secure Boot Signer: 00a7468def'
+[    1.401617] zswap: loaded using pool lzo/zbud
+[    1.401812] AppArmor: AppArmor sha1 policy hashing enabled
+[    1.402420] rtc_cmos 00:02: setting system clock to 2019-09-10T14:23:50 UTC (1568125430)
+[    1.404961] Freeing unused kernel image memory: 1640K
+[    1.481515] Write protecting the kernel read-only data: 16384k
+[    1.482953] Freeing unused kernel image memory: 2036K
+[    1.483478] Freeing unused kernel image memory: 580K
+[    1.500360] x86/mm: Checked W+X mappings: passed, no W+X pages found.
+[    1.500361] x86/mm: Checking user space page tables
+[    1.506208] x86/mm: Checked W+X mappings: passed, no W+X pages found.
+[    1.506209] Run /init as init process
+[    1.593899] input: Lid Switch as /devices/LNXSYSTM:00/LNXSYBUS:00/PNP0C0D:00/input/input2
+[    1.593917] ACPI: Lid Switch [LID]
+[    1.593954] input: Power Button as /devices/LNXSYSTM:00/LNXSYBUS:00/PNP0C0C:00/input/input3
+[    1.593960] ACPI: Power Button [PBTN]
+[    1.593988] input: Sleep Button as /devices/LNXSYSTM:00/LNXSYBUS:00/PNP0C0E:00/input/input4
+[    1.593993] ACPI: Sleep Button [SBTN]
+[    1.594026] input: Power Button as /devices/LNXSYSTM:00/LNXPWRBN:00/input/input5
+[    1.594032] ACPI: Power Button [PWRF]
+[    1.599345] wmi_bus wmi_bus-PNP0C14:00: WQBC data block query control method not found
+[    1.600070] pps_core: LinuxPPS API ver. 1 registered
+[    1.600071] pps_core: Software ver. 5.3.6 - Copyright 2005-2007 Rodolfo Giometti <giometti@linux.it>
+[    1.601802] PTP clock support registered
+[    1.615311] sdhci: Secure Digital Host Controller Interface driver
+[    1.615312] sdhci: Copyright(c) Pierre Ossman
+[    1.619129] ACPI: bus type USB registered
+[    1.619152] usbcore: registered new interface driver usbfs
+[    1.619163] usbcore: registered new interface driver hub
+[    1.619201] usbcore: registered new device driver usb
+[    1.620465] e1000e: Intel(R) PRO/1000 Network Driver - 3.2.6-k
+[    1.620466] e1000e: Copyright(c) 1999 - 2015 Intel Corporation.
+[    1.620665] e1000e 0000:00:19.0: Interrupt Throttling Rate (ints/sec) set to dynamic conservative mode
+[    1.624719] sdhci-pci 0000:0b:00.1: SDHCI controller found [1217:8320] (rev 5)
+[    1.624997] mmc0 bounce up to 128 segments into one, max segment size 65536 bytes
+[    1.625304] ehci_hcd: USB 2.0 'Enhanced' Host Controller (EHCI) Driver
+[    1.626280] ehci-pci: EHCI PCI platform driver
+[    1.626460] ehci-pci 0000:00:1a.0: EHCI Host Controller
+[    1.626469] ehci-pci 0000:00:1a.0: new USB bus registered, assigned bus number 1
+[    1.626484] ehci-pci 0000:00:1a.0: debug port 2
+[    1.630395] ehci-pci 0000:00:1a.0: cache line size of 64 is not supported
+[    1.635189] i801_smbus 0000:00:1f.3: SMBus using PCI interrupt
+[    1.635421] ehci-pci 0000:00:1a.0: irq 16, io mem 0xf2570000
+[    1.638254] mmc0: SDHCI controller on PCI [0000:0b:00.1] using DMA
+[    1.639630] ACPI Warning: SystemIO range 0x0000000000000428-0x000000000000042F conflicts with OpRegion 0x0000000000000400-0x000000000000047F (\PMIO) (20190509/utaddress-213)
+[    1.639638] ACPI: If an ACPI driver is available for this device, you should use it instead of the native driver
+[    1.639874] ACPI Warning: SystemIO range 0x0000000000000540-0x000000000000054F conflicts with OpRegion 0x0000000000000500-0x0000000000000563 (\GPIO) (20190509/utaddress-213)
+[    1.639880] ACPI: If an ACPI driver is available for this device, you should use it instead of the native driver
+[    1.639913] ACPI Warning: SystemIO range 0x0000000000000530-0x000000000000053F conflicts with OpRegion 0x0000000000000500-0x000000000000053F (\_SB.PCI0.PEG0.VID.GPSP) (20190509/utaddress-213)
+[    1.639918] ACPI Warning: SystemIO range 0x0000000000000530-0x000000000000053F conflicts with OpRegion 0x0000000000000500-0x0000000000000563 (\GPIO) (20190509/utaddress-213)
+[    1.639924] ACPI: If an ACPI driver is available for this device, you should use it instead of the native driver
+[    1.640032] ACPI Warning: SystemIO range 0x0000000000000500-0x000000000000052F conflicts with OpRegion 0x0000000000000500-0x000000000000053F (\_SB.PCI0.PEG0.VID.GPSP) (20190509/utaddress-213)
+[    1.640036] ACPI Warning: SystemIO range 0x0000000000000500-0x000000000000052F conflicts with OpRegion 0x0000000000000500-0x0000000000000563 (\GPIO) (20190509/utaddress-213)
+[    1.640042] ACPI: If an ACPI driver is available for this device, you should use it instead of the native driver
+[    1.640043] lpc_ich: Resource conflict(s) found affecting gpio_ich
+[    1.643491] SCSI subsystem initialized
+[    1.649355] ehci-pci 0000:00:1a.0: USB 2.0 started, EHCI 1.00
+[    1.649399] usb usb1: New USB device found, idVendor=1d6b, idProduct=0002, bcdDevice= 5.02
+[    1.649400] usb usb1: New USB device strings: Mfr=3, Product=2, SerialNumber=1
+[    1.649401] usb usb1: Product: EHCI Host Controller
+[    1.649402] usb usb1: Manufacturer: Linux 5.2.0-2-amd64 ehci_hcd
+[    1.649403] usb usb1: SerialNumber: 0000:00:1a.0
+[    1.650130] hub 1-0:1.0: USB hub found
+[    1.650137] hub 1-0:1.0: 3 ports detected
+[    1.657515] libata version 3.00 loaded.
+[    1.661171] ahci 0000:00:1f.2: version 3.0
+[    1.677175] xhci_hcd 0000:0a:00.0: xHCI Host Controller
+[    1.677183] xhci_hcd 0000:0a:00.0: new USB bus registered, assigned bus number 2
+[    1.677194] ahci 0000:00:1f.2: SSS flag set, parallel bus scan disabled
+[    1.677289] ahci 0000:00:1f.2: AHCI 0001.0300 32 slots 6 ports 6 Gbps 0x39 impl SATA mode
+[    1.677291] ahci 0000:00:1f.2: flags: 64bit ncq sntf stag pm led clo pio slum part ems sxs apst 
+[    1.677434] firewire_ohci 0000:0b:00.0: added OHCI v1.10 device as card 0, 8 IR + 8 IT contexts, quirks 0x10
+[    1.677554] xhci_hcd 0000:0a:00.0: hcc params 0x014042cb hci version 0x96 quirks 0x0000000000000004
+[    1.677917] usb usb2: New USB device found, idVendor=1d6b, idProduct=0002, bcdDevice= 5.02
+[    1.677918] usb usb2: New USB device strings: Mfr=3, Product=2, SerialNumber=1
+[    1.677919] usb usb2: Product: xHCI Host Controller
+[    1.677920] usb usb2: Manufacturer: Linux 5.2.0-2-amd64 xhci-hcd
+[    1.677921] usb usb2: SerialNumber: 0000:0a:00.0
+[    1.678039] hub 2-0:1.0: USB hub found
+[    1.678049] hub 2-0:1.0: 2 ports detected
+[    1.678147] ehci-pci 0000:00:1d.0: EHCI Host Controller
+[    1.678157] ehci-pci 0000:00:1d.0: new USB bus registered, assigned bus number 3
+[    1.678158] xhci_hcd 0000:0a:00.0: xHCI Host Controller
+[    1.678161] xhci_hcd 0000:0a:00.0: new USB bus registered, assigned bus number 4
+[    1.678163] xhci_hcd 0000:0a:00.0: Host supports USB 3.0 SuperSpeed
+[    1.678177] ehci-pci 0000:00:1d.0: debug port 2
+[    1.680791] usb usb4: We don't know the algorithms for LPM for this host, disabling LPM.
+[    1.680817] usb usb4: New USB device found, idVendor=1d6b, idProduct=0003, bcdDevice= 5.02
+[    1.680818] usb usb4: New USB device strings: Mfr=3, Product=2, SerialNumber=1
+[    1.680819] usb usb4: Product: xHCI Host Controller
+[    1.680820] usb usb4: Manufacturer: Linux 5.2.0-2-amd64 xhci-hcd
+[    1.680821] usb usb4: SerialNumber: 0000:0a:00.0
+[    1.680948] hub 4-0:1.0: USB hub found
+[    1.680961] hub 4-0:1.0: 2 ports detected
+[    1.682119] ehci-pci 0000:00:1d.0: cache line size of 64 is not supported
+[    1.682133] ehci-pci 0000:00:1d.0: irq 17, io mem 0xf2550000
+[    1.697353] ehci-pci 0000:00:1d.0: USB 2.0 started, EHCI 1.00
+[    1.697495] usb usb3: New USB device found, idVendor=1d6b, idProduct=0002, bcdDevice= 5.02
+[    1.697496] usb usb3: New USB device strings: Mfr=3, Product=2, SerialNumber=1
+[    1.697497] usb usb3: Product: EHCI Host Controller
+[    1.697498] usb usb3: Manufacturer: Linux 5.2.0-2-amd64 ehci_hcd
+[    1.697499] usb usb3: SerialNumber: 0000:00:1d.0
+[    1.703524] hub 3-0:1.0: USB hub found
+[    1.703540] hub 3-0:1.0: 3 ports detected
+[    1.724504] [drm] Disabling ppGTT for VT-d support
+[    1.724525] [drm] VT-d active for gfx access
+[    1.724529] i915 0000:00:02.0: vgaarb: deactivate vga console
+[    1.725004] Console: switching to colour dummy device 80x25
+[    1.725280] [drm] DMAR active, disabling use of stolen memory
+[    1.725325] scsi host0: ahci
+[    1.725732] scsi host1: ahci
+[    1.725839] scsi host2: ahci
+[    1.725959] scsi host3: ahci
+[    1.726053] scsi host4: ahci
+[    1.726144] scsi host5: ahci
+[    1.726193] ata1: SATA max UDMA/133 abar m2048@0xf2540000 port 0xf2540100 irq 33
+[    1.726193] ata2: DUMMY
+[    1.726194] ata3: DUMMY
+[    1.726196] ata4: SATA max UDMA/133 abar m2048@0xf2540000 port 0xf2540280 irq 33
+[    1.726198] ata5: SATA max UDMA/133 abar m2048@0xf2540000 port 0xf2540300 irq 33
+[    1.726201] ata6: SATA max UDMA/133 abar m2048@0xf2540000 port 0xf2540380 irq 33
+[    1.727746] e1000e 0000:00:19.0 0000:00:19.0 (uninitialized): registered PHC clock
+[    1.744568] [drm] Supports vblank timestamp caching Rev 2 (21.10.2013).
+[    1.744569] [drm] Driver supports precise vblank timestamp query.
+[    1.744805] ACPI Warning: \_SB.PCI0.PEG0.VID._DSM: Argument #4 type mismatch - Found [Buffer], ACPI requires [Package] (20190509/nsarguments-66)
+[    1.745945] pci 0000:01:00.0: optimus capabilities: enabled, status dynamic power, hda bios codec supported
+[    1.745956] VGA switcheroo: detected Optimus DSM method \_SB_.PCI0.PEG0.VID_ handle
+[    1.745981] nouveau 0000:01:00.0: enabling device (0004 -> 0007)
+[    1.746164] nouveau 0000:01:00.0: NVIDIA GF106 (0c3d00a1)
+[    1.746565] i915 0000:00:02.0: vgaarb: changed VGA decodes: olddecodes=io+mem,decodes=none:owns=io+mem
+[    1.835039] e1000e 0000:00:19.0 eth0: (PCI Express:2.5GT/s:Width x1) d0:67:e5:4e:a2:26
+[    1.835040] e1000e 0000:00:19.0 eth0: Intel(R) PRO/1000 Network Connection
+[    1.835253] e1000e 0000:00:19.0 eth0: MAC: 10, PHY: 11, PBA No: 0041FF-0FF
+[    1.836152] e1000e 0000:00:19.0 eno1: renamed from eth0
+[    1.890091] [drm] Initialized i915 1.6.0 20190417 for 0000:00:02.0 on minor 0
+[    1.893612] nouveau 0000:01:00.0: bios: version 70.06.36.00.03
+[    1.894152] nouveau 0000:01:00.0: mxm: BIOS version 3.0
+[    1.894456] ACPI: Video Device [VID] (multi-head: yes  rom: yes  post: no)
+[    2.009356] usb 1-1: new high-speed USB device number 2 using ehci-pci
+[    2.017357] usb 2-2: new low-speed USB device number 2 using xhci_hcd
+[    2.018986] nouveau 0000:01:00.0: fb: 2048 MiB DDR3
+[    2.044776] ata1: SATA link up 6.0 Gbps (SStatus 133 SControl 300)
+[    2.046941] ata1.00: ACPI cmd 00/00:00:00:00:00:a0 (NOP) rejected by device (Stat=0x51 Err=0x04)
+[    2.047249] ata1.00: ATA-9: SanDisk SSD PLUS 240GB, UF4500RL, max UDMA/133
+[    2.047250] ata1.00: 468877312 sectors, multi 1: LBA48 NCQ (depth 32)
+[    2.047370] acpi device:2b: registered as cooling_device8
+[    2.048035] input: Video Bus as /devices/LNXSYSTM:00/LNXSYBUS:00/PNP0A08:00/device:28/LNXVIDEO:00/input/input7
+[    2.061355] usb 3-1: new high-speed USB device number 2 using ehci-pci
+[    2.081128] vga_switcheroo: enabled
+[    2.081205] [TTM] Zone  kernel: Available graphics memory: 8184328 KiB
+[    2.081205] [TTM] Zone   dma32: Available graphics memory: 2097152 KiB
+[    2.081206] [TTM] Initializing pool allocator
+[    2.081218] [TTM] Initializing DMA pool allocator
+[    2.081226] nouveau 0000:01:00.0: DRM: VRAM: 2048 MiB
+[    2.081227] nouveau 0000:01:00.0: DRM: GART: 1048576 MiB
+[    2.081229] nouveau 0000:01:00.0: DRM: TMDS table version 2.0
+[    2.081230] nouveau 0000:01:00.0: DRM: DCB version 4.0
+[    2.081232] nouveau 0000:01:00.0: DRM: DCB outp 03: 080153d6 0f220020
+[    2.081233] nouveau 0000:01:00.0: DRM: DCB outp 04: 08015392 00020020
+[    2.081234] nouveau 0000:01:00.0: DRM: DCB outp 05: 080143c6 0f220010
+[    2.081234] nouveau 0000:01:00.0: DRM: DCB outp 06: 08014382 00020010
+[    2.081235] nouveau 0000:01:00.0: DRM: DCB outp 10: 020273a6 0f220010
+[    2.081236] nouveau 0000:01:00.0: DRM: DCB outp 11: 02027362 00020010
+[    2.081237] nouveau 0000:01:00.0: DRM: DCB conn 00: 00000040
+[    2.081238] nouveau 0000:01:00.0: DRM: DCB conn 01: 00001161
+[    2.081238] nouveau 0000:01:00.0: DRM: DCB conn 02: 00001231
+[    2.081239] nouveau 0000:01:00.0: DRM: DCB conn 03: 01000331
+[    2.081240] nouveau 0000:01:00.0: DRM: DCB conn 04: 01000446
+[    2.081240] nouveau 0000:01:00.0: DRM: DCB conn 05: 02000546
+[    2.081241] nouveau 0000:01:00.0: DRM: DCB conn 06: 00010631
+[    2.081242] nouveau 0000:01:00.0: DRM: DCB conn 07: 00010746
+[    2.081243] nouveau 0000:01:00.0: DRM: DCB conn 08: 00020846
+[    2.081243] nouveau 0000:01:00.0: DRM: DCB conn 09: 00000900
+[    2.082171] nouveau 0000:01:00.0: DRM: MM: using COPY0 for buffer copies
+[    2.083134] [drm] Supports vblank timestamp caching Rev 2 (21.10.2013).
+[    2.083135] [drm] Driver supports precise vblank timestamp query.
+[    2.165778] usb 1-1: New USB device found, idVendor=8087, idProduct=0024, bcdDevice= 0.00
+[    2.165779] usb 1-1: New USB device strings: Mfr=0, Product=0, SerialNumber=0
+[    2.166029] hub 1-1:1.0: USB hub found
+[    2.166091] hub 1-1:1.0: 6 ports detected
+[    2.185492] firewire_core 0000:0b:00.0: created device fw0: GUID 07822f21354fc000, S400
+[    2.194903] usb 2-2: New USB device found, idVendor=1bcf, idProduct=0005, bcdDevice= 0.14
+[    2.194904] usb 2-2: New USB device strings: Mfr=0, Product=2, SerialNumber=0
+[    2.194905] usb 2-2: Product: USB Optical Mouse
+[    2.205743] hidraw: raw HID events driver (C) Jiri Kosina
+[    2.221740] usb 3-1: New USB device found, idVendor=8087, idProduct=0024, bcdDevice= 0.00
+[    2.221741] usb 3-1: New USB device strings: Mfr=0, Product=0, SerialNumber=0
+[    2.222010] hub 3-1:1.0: USB hub found
+[    2.222019] usbcore: registered new interface driver usbhid
+[    2.222019] usbhid: USB HID core driver
+[    2.222088] hub 3-1:1.0: 8 ports detected
+[    2.223303] input: USB Optical Mouse as /devices/pci0000:00/0000:00:1c.3/0000:0a:00.0/usb2/2-2/2-2:1.0/0003:1BCF:0005.0001/input/input8
+[    2.223377] hid-generic 0003:1BCF:0005.0001: input,hidraw0: USB HID v1.10 Mouse [USB Optical Mouse] on usb-0000:0a:00.0-2/input0
+[    2.273364] [drm] Cannot find any crtc or sizes
+[    2.277506] [drm] Initialized nouveau 1.3.1 20120801 for 0000:01:00.0 on minor 1
+[    2.313371] tsc: Refined TSC clocksource calibration: 2394.554 MHz
+[    2.313379] clocksource: tsc: mask: 0xffffffffffffffff max_cycles: 0x22841efec24, max_idle_ns: 440795272178 ns
+[    2.321376] clocksource: Switched to clocksource tsc
+[    2.453349] usb 1-1.4: new full-speed USB device number 3 using ehci-pci
+[    2.465370] [drm] Cannot find any crtc or sizes
+[    2.509354] usb 3-1.8: new full-speed USB device number 3 using ehci-pci
+[    2.529678] ACPI: Video Device [VID1] (multi-head: yes  rom: no  post: no)
+[    2.529778] ata1.00: ACPI cmd 00/00:00:00:00:00:a0 (NOP) rejected by device (Stat=0x51 Err=0x04)
+[    2.529973] ata1.00: configured for UDMA/133
+[    2.540334] scsi 0:0:0:0: Direct-Access     ATA      SanDisk SSD PLUS 00RL PQ: 0 ANSI: 5
+[    2.563709] random: fast init done
+[    2.566383] usb 1-1.4: New USB device found, idVendor=413c, idProduct=8187, bcdDevice= 5.17
+[    2.566384] usb 1-1.4: New USB device strings: Mfr=1, Product=2, SerialNumber=3
+[    2.566385] usb 1-1.4: Product: DW375 Bluetooth Module
+[    2.566386] usb 1-1.4: Manufacturer: Dell Computer Corp
+[    2.566386] usb 1-1.4: SerialNumber: 9CB70D0077E8
+[    2.629738] usb 3-1.8: config 0 has an invalid interface number: 3 but max is 2
+[    2.629740] usb 3-1.8: config 0 has no interface number 2
+[    2.644489] usb 3-1.8: New USB device found, idVendor=0a5c, idProduct=5801, bcdDevice= 1.01
+[    2.644490] usb 3-1.8: New USB device strings: Mfr=1, Product=2, SerialNumber=3
+[    2.644491] usb 3-1.8: Product: 5880
+[    2.644492] usb 3-1.8: Manufacturer: Broadcom Corp
+[    2.644493] usb 3-1.8: SerialNumber: 0123456789ABCD
+[    2.657354] usb 1-1.5: new high-speed USB device number 4 using ehci-pci
+[    2.657361] [drm] Cannot find any crtc or sizes
+[    2.657583] usb 3-1.8: config 0 descriptor??
+[    2.677403] acpi device:3e: registered as cooling_device9
+[    2.677785] input: Video Bus as /devices/LNXSYSTM:00/LNXSYBUS:00/PNP0A08:00/LNXVIDEO:01/input/input9
+[    2.695415] fbcon: i915drmfb (fb0) is primary device
+[    2.857012] ata4: SATA link up 3.0 Gbps (SStatus 123 SControl 300)
+[    2.932396] usb 1-1.5: New USB device found, idVendor=1bcf, idProduct=280b, bcdDevice= 3.10
+[    2.932401] usb 1-1.5: New USB device strings: Mfr=1, Product=2, SerialNumber=0
+[    2.932405] usb 1-1.5: Product: Laptop_Integrated_Webcam_FHD
+[    2.932408] usb 1-1.5: Manufacturer: CN0CJ3P27248724OB4B1A01
+[    3.052956] input: AlpsPS/2 ALPS DualPoint Stick as /devices/platform/i8042/serio1/input/input10
+[    3.066593] input: AlpsPS/2 ALPS DualPoint TouchPad as /devices/platform/i8042/serio1/input/input6
+[    3.159347] ata4.00: ATA-8: ST9750420AS, 0005DEM1, max UDMA/133
+[    3.159350] ata4.00: 1465149168 sectors, multi 16: LBA48 NCQ (depth 32)
+[    3.160915] ata4.00: configured for UDMA/133
+[    3.161807] scsi 3:0:0:0: Direct-Access     ATA      ST9750420AS      DEM1 PQ: 0 ANSI: 5
+[    3.477106] ata5: SATA link down (SStatus 0 SControl 300)
+[    3.586395] Console: switching to colour frame buffer device 240x67
+[    3.614233] i915 0000:00:02.0: fb0: i915drmfb frame buffer device
+[    3.793422] ata6: SATA link down (SStatus 0 SControl 300)
+[    3.806585] sd 0:0:0:0: [sda] 468877312 512-byte logical blocks: (240 GB/224 GiB)
+[    3.806593] sd 0:0:0:0: [sda] Write Protect is off
+[    3.806594] sd 0:0:0:0: [sda] Mode Sense: 00 3a 00 00
+[    3.806603] sd 0:0:0:0: [sda] Write cache: enabled, read cache: enabled, doesn't support DPO or FUA
+[    3.806617] sd 3:0:0:0: [sdb] 1465149168 512-byte logical blocks: (750 GB/699 GiB)
+[    3.806619] sd 3:0:0:0: [sdb] 4096-byte physical blocks
+[    3.806628] sd 3:0:0:0: [sdb] Write Protect is off
+[    3.806630] sd 3:0:0:0: [sdb] Mode Sense: 00 3a 00 00
+[    3.806645] sd 3:0:0:0: [sdb] Write cache: enabled, read cache: enabled, doesn't support DPO or FUA
+[    3.807656]  sda: sda1 sda2 < sda5 >
+[    3.808178] sd 0:0:0:0: [sda] Attached SCSI disk
+[    3.869929]  sdb: sdb1 sdb2 sdb3 sdb4 < sdb5 sdb6 sdb7 >
+[    3.872095] sd 3:0:0:0: [sdb] Attached SCSI disk
+[    4.842459] PM: Image not found (code -22)
+[    4.980114] EXT4-fs (sda1): mounted filesystem with ordered data mode. Opts: (null)
+[    5.082769] Not activating Mandatory Access Control as /sbin/tomoyo-init does not exist.
+[    5.256787] systemd[1]: RTC configured in localtime, applying delta of -180 minutes to system time.
+[    5.312752] systemd[1]: Inserted module 'autofs4'
+[    5.335560] systemd[1]: systemd 242 running in system mode. (+PAM +AUDIT +SELINUX +IMA +APPARMOR +SMACK +SYSVINIT +UTMP +LIBCRYPTSETUP +GCRYPT +GNUTLS +ACL +XZ +LZ4 +SECCOMP +BLKID +ELFUTILS +KMOD +IDN2 -IDN +PCRE2 default-hierarchy=hybrid)
+[    5.353673] systemd[1]: Detected architecture x86-64.
+[    5.358380] systemd[1]: Set hostname to <debie>.
+[    5.359227] systemd[1]: Failed to bump fs.file-max, ignoring: Invalid argument
+[    5.600270] systemd[1]: /lib/systemd/system/dbus.socket:4: ListenStream= references a path below legacy directory /var/run/, updating /var/run/dbus/system_bus_socket → /run/dbus/system_bus_socket; please update the unit file accordingly.
+[    5.658084] systemd[1]: /lib/systemd/system/docker.socket:5: ListenStream= references a path below legacy directory /var/run/, updating /var/run/docker.sock → /run/docker.sock; please update the unit file accordingly.
+[    5.685278] random: systemd: uninitialized urandom read (16 bytes read)
+[    5.685415] systemd[1]: Listening on Journal Socket (/dev/log).
+[    5.685461] random: systemd: uninitialized urandom read (16 bytes read)
+[    5.685531] systemd[1]: Listening on udev Kernel Socket.
+[    5.685546] random: systemd: uninitialized urandom read (16 bytes read)
+[    5.685614] systemd[1]: Listening on Syslog Socket.
+[    5.685732] systemd[1]: Listening on Journal Audit Socket.
+[    5.710681] EXT4-fs (sda1): re-mounted. Opts: errors=remount-ro
+[    5.739848] lp: driver loaded but no devices found
+[    5.743991] ppdev: user-space parallel port driver
+[    5.752345] parport_pc 00:04: [io  0x0378-0x037b]
+[    5.752428] parport_pc 00:04: [irq 5]
+[    5.753777] parport_pc 00:04: activated
+[    5.753780] parport_pc 00:04: reported by Plug and Play ACPI
+[    5.950515] ACPI: AC Adapter [AC] (on-line)
+[    5.978611] battery: ACPI: Battery Slot [BAT0] (battery present)
+[    6.007716] sd 0:0:0:0: Attached scsi generic sg0 type 0
+[    6.007755] sd 3:0:0:0: Attached scsi generic sg1 type 0
+[    6.014704] iTCO_vendor_support: vendor-support=0
+[    6.022079] dcdbas dcdbas: Dell Systems Management Base Driver (version 5.6.0-3.3)
+[    6.023035] iTCO_wdt: Intel TCO WatchDog Timer Driver v1.11
+[    6.023068] iTCO_wdt: Found a Cougar Point TCO device (Version=2, TCOBASE=0x0460)
+[    6.023508] iTCO_wdt: initialized. heartbeat=30 sec (nowayout=0)
+[    6.027376] dell-smbios A80593CE-A997-11DA-B012-B622A1EF5492: WMI SMBIOS userspace interface not supported(0), try upgrading to a newer BIOS
+[    6.028505] input: PC Speaker as /devices/platform/pcspkr/input/input11
+[    6.030105] input: Dell WMI hotkeys as /devices/platform/PNP0C14:00/wmi_bus/wmi_bus-PNP0C14:00/9DBB5994-A997-11DA-B012-B622A1EF5492/input/input12
+[    6.106389] RAPL PMU: API unit is 2^-32 Joules, 3 fixed counters, 163840 ms ovfl timer
+[    6.106391] RAPL PMU: hw unit of domain pp0-core 2^-16 Joules
+[    6.106392] RAPL PMU: hw unit of domain package 2^-16 Joules
+[    6.106392] RAPL PMU: hw unit of domain pp1-gpu 2^-16 Joules
+[    6.142650] media: Linux media interface: v0.10
+[    6.142888] systemd-journald[342]: Received request to flush runtime journal from PID 1
+[    6.209389] Adding 19494908k swap on /dev/sda5.  Priority:-2 extents:1 across:19494908k SSFS
+[    6.212103] videodev: Linux video capture interface: v2.00
+[    6.215512] alg: No test for fips(ansi_cprng) (fips_ansi_cprng)
+[    6.216088] cryptd: max_cpu_qlen set to 1000
+[    6.245843] snd_hda_intel 0000:00:1b.0: bound 0000:00:02.0 (ops i915_audio_component_bind_ops [i915])
+[    6.252369] snd_hda_intel 0000:01:00.1: Disabling MSI
+[    6.252379] snd_hda_intel 0000:01:00.1: Handle vga_switcheroo audio client
+[    6.282557] Intel(R) Wireless WiFi driver for Linux
+[    6.282558] Copyright(c) 2003- 2015 Intel Corporation
+[    6.283089] AVX version of gcm_enc/dec engaged.
+[    6.283090] AES CTR mode by8 optimization enabled
+[    6.283751] iwlwifi 0000:03:00.0: can't disable ASPM; OS doesn't have ASPM control
+[    6.286036] dell_laptop: Using i8042 filter function for receiving events
+[    6.290084] snd_hda_codec_idt hdaudioC0D0: autoconfig for 92HD90BXX: line_outs=1 (0xe/0x0/0x0/0x0/0x0) type:line
+[    6.290086] snd_hda_codec_idt hdaudioC0D0:    speaker_outs=1 (0xd/0x0/0x0/0x0/0x0)
+[    6.290088] snd_hda_codec_idt hdaudioC0D0:    hp_outs=1 (0xb/0x0/0x0/0x0/0x0)
+[    6.290089] snd_hda_codec_idt hdaudioC0D0:    mono: mono_out=0x0
+[    6.290091] snd_hda_codec_idt hdaudioC0D0:    inputs:
+[    6.290092] snd_hda_codec_idt hdaudioC0D0:      Dock Mic=0xf
+[    6.290094] snd_hda_codec_idt hdaudioC0D0:      Internal Mic=0x11
+[    6.290095] snd_hda_codec_idt hdaudioC0D0:      Mic=0xa
+[    6.295630] iwlwifi 0000:03:00.0: firmware: direct-loading firmware iwlwifi-6000-4.ucode
+[    6.295707] iwlwifi 0000:03:00.0: loaded firmware version 9.221.4.1 build 25532 op_mode iwldvm
+[    6.313371] uvcvideo: Found UVC 1.00 device Laptop_Integrated_Webcam_FHD (1bcf:280b)
+[    6.352928] uvcvideo 1-1.5:1.0: Entity type for entity Extension 4 was not initialized!
+[    6.352929] uvcvideo 1-1.5:1.0: Entity type for entity Extension 3 was not initialized!
+[    6.352930] uvcvideo 1-1.5:1.0: Entity type for entity Processing 2 was not initialized!
+[    6.352931] uvcvideo 1-1.5:1.0: Entity type for entity Camera 1 was not initialized!
+[    6.352989] input: Laptop_Integrated_Webcam_FHD: I as /devices/pci0000:00/0000:00:1a.0/usb1/1-1/1-1.5/1-1.5:1.0/input/input18
+[    6.353041] usbcore: registered new interface driver uvcvideo
+[    6.353042] USB Video Class driver (1.1.1)
+[    6.382387] input: HDA Digital PCBeep as /devices/pci0000:00/0000:00:1b.0/sound/card0/input13
+[    6.382472] input: HDA Intel PCH Dock Mic as /devices/pci0000:00/0000:00:1b.0/sound/card0/input14
+[    6.382752] input: HDA Intel PCH Mic as /devices/pci0000:00/0000:00:1b.0/sound/card0/input15
+[    6.383592] input: HDA Intel PCH Dock Line Out as /devices/pci0000:00/0000:00:1b.0/sound/card0/input16
+[    6.383662] input: HDA Intel PCH Headphone as /devices/pci0000:00/0000:00:1b.0/sound/card0/input17
+[    6.398513] Bluetooth: Core ver 2.22
+[    6.398526] NET: Registered protocol family 31
+[    6.398526] Bluetooth: HCI device and connection manager initialized
+[    6.398531] Bluetooth: HCI socket layer initialized
+[    6.398533] Bluetooth: L2CAP socket layer initialized
+[    6.398536] Bluetooth: SCO socket layer initialized
+[    6.444152] iwlwifi 0000:03:00.0: CONFIG_IWLWIFI_DEBUG disabled
+[    6.444156] iwlwifi 0000:03:00.0: CONFIG_IWLWIFI_DEBUGFS disabled
+[    6.444158] iwlwifi 0000:03:00.0: CONFIG_IWLWIFI_DEVICE_TRACING disabled
+[    6.444162] iwlwifi 0000:03:00.0: Detected Intel(R) Centrino(R) Ultimate-N 6300 AGN, REV=0x74
+[    6.454352] usbcore: registered new interface driver btusb
+[    6.505556] ieee80211 phy0: Selected rate control algorithm 'iwl-agn-rs'
+[    6.511135] iwlwifi 0000:03:00.0 wlp3s0: renamed from wlan0
+[    6.721102] intel_rapl: Found RAPL domain package
+[    6.721107] intel_rapl: Found RAPL domain core
+[    6.721110] intel_rapl: Found RAPL domain uncore
+[    6.721124] intel_rapl: RAPL package 0 domain package locked by BIOS
+[    6.887584] random: crng init done
+[    6.887591] random: 7 urandom warning(s) missed due to ratelimiting
+[    7.482925] EXT4-fs (sdb6): mounted filesystem with ordered data mode. Opts: errors=remount-ro
+[    7.564643] audit: type=1400 audit(1568136236.658:2): apparmor="STATUS" operation="profile_load" profile="unconfined" name="libreoffice-senddoc" pid=672 comm="apparmor_parser"
+[    7.565624] audit: type=1400 audit(1568136236.662:3): apparmor="STATUS" operation="profile_load" profile="unconfined" name="libreoffice-oopslash" pid=677 comm="apparmor_parser"
+[    7.566064] audit: type=1400 audit(1568136236.662:4): apparmor="STATUS" operation="profile_load" profile="unconfined" name="/usr/bin/man" pid=675 comm="apparmor_parser"
+[    7.566070] audit: type=1400 audit(1568136236.662:5): apparmor="STATUS" operation="profile_load" profile="unconfined" name="man_filter" pid=675 comm="apparmor_parser"
+[    7.566074] audit: type=1400 audit(1568136236.662:6): apparmor="STATUS" operation="profile_load" profile="unconfined" name="man_groff" pid=675 comm="apparmor_parser"
+[    7.567122] audit: type=1400 audit(1568136236.662:7): apparmor="STATUS" operation="profile_load" profile="unconfined" name="/usr/sbin/cups-browsed" pid=673 comm="apparmor_parser"
+[    7.567844] audit: type=1400 audit(1568136236.662:8): apparmor="STATUS" operation="profile_load" profile="unconfined" name="lsb_release" pid=680 comm="apparmor_parser"
+[    7.568617] audit: type=1400 audit(1568136236.662:9): apparmor="STATUS" operation="profile_load" profile="unconfined" name="libreoffice-xpdfimport" pid=681 comm="apparmor_parser"
+[    7.569814] audit: type=1400 audit(1568136236.666:10): apparmor="STATUS" operation="profile_load" profile="unconfined" name="nvidia_modprobe" pid=682 comm="apparmor_parser"
+[    7.569818] audit: type=1400 audit(1568136236.666:11): apparmor="STATUS" operation="profile_load" profile="unconfined" name="nvidia_modprobe//kmod" pid=682 comm="apparmor_parser"
+[    7.916489] Bluetooth: BNEP (Ethernet Emulation) ver 1.3
+[    7.916490] Bluetooth: BNEP filters: protocol multicast
+[    7.916494] Bluetooth: BNEP socket layer initialized
+[    8.467486] iwlwifi 0000:03:00.0: Radio type=0x0-0x3-0x1
+[    8.550258] input: HDA NVidia HDMI/DP,pcm=3 as /devices/pci0000:00/0000:00:01.0/0000:01:00.1/sound/card1/input19
+[    8.550399] input: HDA NVidia HDMI/DP,pcm=7 as /devices/pci0000:00/0000:00:01.0/0000:01:00.1/sound/card1/input20
+[    8.550496] input: HDA NVidia HDMI/DP,pcm=8 as /devices/pci0000:00/0000:00:01.0/0000:01:00.1/sound/card1/input21
+[    8.550588] input: HDA NVidia HDMI/DP,pcm=9 as /devices/pci0000:00/0000:00:01.0/0000:01:00.1/sound/card1/input22
+[    8.709773] iwlwifi 0000:03:00.0: Radio type=0x0-0x3-0x1
+[    8.829671] iwlwifi 0000:03:00.0: Radio type=0x0-0x3-0x1
+[    9.073792] iwlwifi 0000:03:00.0: Radio type=0x0-0x3-0x1
+[   12.504641] iwlwifi 0000:03:00.0: Radio type=0x0-0x3-0x1
+[   12.751197] iwlwifi 0000:03:00.0: Radio type=0x0-0x3-0x1
+[   14.402913] Bluetooth: RFCOMM TTY layer initialized
+[   14.402925] Bluetooth: RFCOMM socket layer initialized
+[   14.402932] Bluetooth: RFCOMM ver 1.11
+[   16.022557] wlp3s0: authenticate with 06:72:23:95:f2:2d
+[   16.054751] wlp3s0: send auth to 06:72:23:95:f2:2d (try 1/3)
+[   16.096307] wlp3s0: authenticated
+[   16.097360] wlp3s0: associate with 06:72:23:95:f2:2d (try 1/3)
+[   16.100142] wlp3s0: RX AssocResp from 06:72:23:95:f2:2d (capab=0x511 status=0 aid=75)
+[   16.103621] wlp3s0: associated
+[   16.197339] wlp3s0: Limiting TX power to 30 (30 - 0) dBm as advertised by 06:72:23:95:f2:2d
+[   16.288063] IPv6: ADDRCONF(NETDEV_CHANGE): wlp3s0: link becomes ready
+[   16.963479] kauditd_printk_skb: 12 callbacks suppressed
+[   16.963481] audit: type=1400 audit(1568136246.058:24): apparmor="STATUS" operation="profile_load" profile="unconfined" name="docker-default" pid=1169 comm="apparmor_parser"
+[   17.100021] bridge: filtering via arp/ip/ip6tables is no longer available by default. Update your scripts to load br_netfilter if you need this.
+[   17.102299] Bridge firewalling registered
+[   17.457758] Initializing XFRM netlink socket
+[   24.518466] fuse: init (API version 7.31)
+[   26.948163] rfkill: input handler disabled
+[ 2972.536155] usb 2-2: USB disconnect, device number 2
+[12322.366105] usb 3-1.1: new low-speed USB device number 4 using ehci-pci
+[12322.479619] usb 3-1.1: New USB device found, idVendor=1bcf, idProduct=0005, bcdDevice= 0.14
+[12322.479627] usb 3-1.1: New USB device strings: Mfr=0, Product=2, SerialNumber=0
+[12322.479630] usb 3-1.1: Product: USB Optical Mouse
+[12322.486732] input: USB Optical Mouse as /devices/pci0000:00/0000:00:1d.0/usb3/3-1/3-1.1/3-1.1:1.0/0003:1BCF:0005.0002/input/input23
+[12322.487449] hid-generic 0003:1BCF:0005.0002: input,hidraw0: USB HID v1.10 Mouse [USB Optical Mouse] on usb-0000:00:1d.0-1.1/input0
+[14450.895252] mce: CPU6: Core temperature above threshold, cpu clock throttled (total events = 1)
+[14450.895253] mce: CPU2: Core temperature above threshold, cpu clock throttled (total events = 1)
+[14450.895255] mce: CPU3: Package temperature above threshold, cpu clock throttled (total events = 1)
+[14450.895257] mce: CPU5: Package temperature above threshold, cpu clock throttled (total events = 1)
+[14450.895258] mce: CPU7: Package temperature above threshold, cpu clock throttled (total events = 1)
+[14450.895261] mce: CPU1: Package temperature above threshold, cpu clock throttled (total events = 1)
+[14450.895262] mce: CPU2: Package temperature above threshold, cpu clock throttled (total events = 1)
+[14450.895267] mce: CPU6: Package temperature above threshold, cpu clock throttled (total events = 1)
+[14450.895279] mce: CPU0: Package temperature above threshold, cpu clock throttled (total events = 1)
+[14450.895280] mce: CPU4: Package temperature above threshold, cpu clock throttled (total events = 1)
+[14450.896223] mce: CPU6: Core temperature/speed normal
+[14450.896224] mce: CPU2: Core temperature/speed normal
+[14450.896225] mce: CPU3: Package temperature/speed normal
+[14450.896226] mce: CPU5: Package temperature/speed normal
+[14450.896227] mce: CPU7: Package temperature/speed normal
+[14450.896228] mce: CPU1: Package temperature/speed normal
+[14450.896228] mce: CPU2: Package temperature/speed normal
+[14450.896229] mce: CPU6: Package temperature/speed normal
+[14450.896252] mce: CPU4: Package temperature/speed normal
+[14450.896253] mce: CPU0: Package temperature/speed normal
+[18414.009627] perf: interrupt took too long (2520 > 2500), lowering kernel.perf_event_max_sample_rate to 79250
+[22180.121066] pci_bus 0000:02: Allocating resources
+[22180.121075] pcieport 0000:00:1c.0: bridge window [io  0x1000-0x0fff] to [bus 02] add_size 1000
+[22180.121079] pcieport 0000:00:1c.0: bridge window [mem 0x00100000-0x000fffff 64bit pref] to [bus 02] add_size 200000 add_align 100000
+[22180.121082] pcieport 0000:00:1c.0: bridge window [mem 0x00100000-0x000fffff] to [bus 02] add_size 200000 add_align 100000
+[22180.121094] pci_bus 0000:03: Allocating resources
+[22180.121134] pcieport 0000:00:1c.1: bridge window [io  0x1000-0x0fff] to [bus 03] add_size 1000
+[22180.121137] pcieport 0000:00:1c.1: bridge window [mem 0x00100000-0x000fffff 64bit pref] to [bus 03] add_size 200000 add_align 100000
+[22180.121150] pci_bus 0000:04: Allocating resources
+[22180.121163] pci_bus 0000:0a: Allocating resources
+[22180.121222] pcieport 0000:00:1c.3: bridge window [io  0x1000-0x0fff] to [bus 0a] add_size 1000
+[22180.121225] pcieport 0000:00:1c.3: bridge window [mem 0x00100000-0x000fffff 64bit pref] to [bus 0a] add_size 200000 add_align 100000
+[22180.121237] pci_bus 0000:0b: Allocating resources
+[22180.121276] pcieport 0000:00:1c.0: BAR 14: assigned [mem 0xcfa00000-0xcfbfffff]
+[22180.121284] pcieport 0000:00:1c.0: BAR 15: assigned [mem 0xcfc00000-0xcfdfffff 64bit pref]
+[22180.121290] pcieport 0000:00:1c.1: BAR 15: assigned [mem 0xcfe00000-0xcfffffff 64bit pref]
+[22180.121296] pcieport 0000:00:1c.3: BAR 15: assigned [mem 0xedc00000-0xeddfffff 64bit pref]
+[22180.121301] pcieport 0000:00:1c.0: BAR 13: assigned [io  0x9000-0x9fff]
+[22180.121305] pcieport 0000:00:1c.1: BAR 13: assigned [io  0xa000-0xafff]
+[22180.121308] pcieport 0000:00:1c.3: BAR 13: assigned [io  0xb000-0xbfff]
+[22180.121527] pci_bus 0000:01: Allocating resources
+[22181.969850] PM: suspend entry (deep)
+[22182.695821] Filesystems sync: 0.725 seconds
+[22182.696413] (NULL device *): firmware: direct-loading firmware iwlwifi-6000-4.ucode
+[22182.696713] Freezing user space processes ... (elapsed 0.004 seconds) done.
+[22182.700812] OOM killer disabled.
+[22182.700813] Freezing remaining freezable tasks ... (elapsed 0.001 seconds) done.
+[22182.702206] printk: Suspending console(s) (use no_console_suspend to debug)
+[22182.807143] wlp3s0: deauthenticating from 06:72:23:95:f2:2d by local choice (Reason: 3=DEAUTH_LEAVING)
+[22182.824987] e1000e: EEE TX LPI TIMER: 00000011
+[22182.827454] sd 3:0:0:0: [sdb] Synchronizing SCSI cache
+[22182.827956] sd 3:0:0:0: [sdb] Stopping disk
+[22182.829516] sd 0:0:0:0: [sda] Synchronizing SCSI cache
+[22182.829916] sd 0:0:0:0: [sda] Stopping disk
+[22183.359456] ACPI: EC: interrupt blocked
+[22183.379415] ACPI: Preparing to enter system sleep state S3
+[22183.382155] ACPI: EC: event blocked
+[22183.382157] ACPI: EC: EC stopped
+[22183.382158] PM: Saving platform NVS memory
+[22183.382189] Disabling non-boot CPUs ...
+[22183.384573] smpboot: CPU 1 is now offline
+[22183.389910] smpboot: CPU 2 is now offline
+[22183.393477] smpboot: CPU 3 is now offline
+[22183.396992] smpboot: CPU 4 is now offline
+[22183.400396] smpboot: CPU 5 is now offline
+[22183.404491] smpboot: CPU 6 is now offline
+[22183.408038] smpboot: CPU 7 is now offline
+[22183.411592] ACPI: Low-level resume complete
+[22183.411636] ACPI: EC: EC started
+[22183.411636] PM: Restoring platform NVS memory
+[22183.412151] Enabling non-boot CPUs ...
+[22183.412195] x86: Booting SMP configuration:
+[22183.412196] smpboot: Booting Node 0 Processor 1 APIC 0x2
+[22183.415160] CPU1 is up
+[22183.415226] smpboot: Booting Node 0 Processor 2 APIC 0x4
+[22183.418330] CPU2 is up
+[22183.418388] smpboot: Booting Node 0 Processor 3 APIC 0x6
+[22183.422543] CPU3 is up
+[22183.422605] smpboot: Booting Node 0 Processor 4 APIC 0x1
+[22183.426638] CPU4 is up
+[22183.426706] smpboot: Booting Node 0 Processor 5 APIC 0x3
+[22183.430440] CPU5 is up
+[22183.430508] smpboot: Booting Node 0 Processor 6 APIC 0x5
+[22183.433669] CPU6 is up
+[22183.433741] smpboot: Booting Node 0 Processor 7 APIC 0x7
+[22183.436972] CPU7 is up
+[22183.444195] ACPI: Waking up from system sleep state S3
+[22183.452584] ACPI: EC: interrupt unblocked
+[22183.452865] pcieport 0000:00:1c.0: Enabling MPC IRBNCE
+[22183.452866] pcieport 0000:00:1c.1: Enabling MPC IRBNCE
+[22183.452867] pcieport 0000:00:1c.3: Enabling MPC IRBNCE
+[22183.452868] pcieport 0000:00:1c.2: Enabling MPC IRBNCE
+[22183.452870] pcieport 0000:00:1c.7: Enabling MPC IRBNCE
+[22183.452871] pcieport 0000:00:1c.0: Intel PCH root port ACS workaround enabled
+[22183.452871] pcieport 0000:00:1c.1: Intel PCH root port ACS workaround enabled
+[22183.452872] pcieport 0000:00:1c.3: Intel PCH root port ACS workaround enabled
+[22183.452873] pcieport 0000:00:1c.2: Intel PCH root port ACS workaround enabled
+[22183.452874] pcieport 0000:00:1c.7: Intel PCH root port ACS workaround enabled
+[22183.493567] ACPI: EC: event unblocked
+[22183.500546] iwlwifi 0000:03:00.0: Radio type=0x0-0x3-0x1
+[22183.503817] sd 3:0:0:0: [sdb] Starting disk
+[22183.503831] sd 0:0:0:0: [sda] Starting disk
+[22183.745300] iwlwifi 0000:03:00.0: Radio type=0x0-0x3-0x1
+[22183.780406] usb 1-1.4: reset full-speed USB device number 3 using ehci-pci
+[22183.871043] ata1: SATA link up 6.0 Gbps (SStatus 133 SControl 300)
+[22183.871094] ata5: SATA link down (SStatus 0 SControl 300)
+[22183.871138] ata6: SATA link down (SStatus 0 SControl 300)
+[22183.952860] ata1.00: ACPI cmd 00/00:00:00:00:00:a0 (NOP) rejected by device (Stat=0x51 Err=0x04)
+[22183.960424] usb 3-1.1: reset low-speed USB device number 4 using ehci-pci
+[22183.963028] ata1.00: ACPI cmd 00/00:00:00:00:00:a0 (NOP) rejected by device (Stat=0x51 Err=0x04)
+[22183.963208] ata1.00: configured for UDMA/133
+[22183.972399] usb 1-1.5: reset high-speed USB device number 4 using ehci-pci
+[22184.076494] firewire_core 0000:0b:00.0: rediscovered device fw0
+[22184.266553] OOM killer enabled.
+[22184.266556] Restarting tasks ... 
+[22184.275436] pci_bus 0000:02: Allocating resources
+[22184.275452] pci_bus 0000:03: Allocating resources
+[22184.275500] pci_bus 0000:04: Allocating resources
+[22184.275512] pci_bus 0000:0a: Allocating resources
+[22184.275581] pci_bus 0000:0b: Allocating resources
+[22184.275895] pci_bus 0000:01: Allocating resources
+[22184.276606] acpi PNP0401:00: Already enumerated
+[22184.277010] acpi PNP0501:00: Still not present
+[22184.278433] pci_bus 0000:02: Allocating resources
+[22184.278442] pci_bus 0000:03: Allocating resources
+[22184.278477] pci_bus 0000:04: Allocating resources
+[22184.278484] pci_bus 0000:0a: Allocating resources
+[22184.278495] pci_bus 0000:0b: Allocating resources
+[22184.278657] pci_bus 0000:01: Allocating resources
+[22184.283533] done.
+[22184.312829] video LNXVIDEO:00: Restoring backlight state
+[22184.312832] video LNXVIDEO:01: Restoring backlight state
+[22184.448321] PM: suspend exit
+[22184.602129] e1000e: eno1 NIC Link is Down
+[22184.940800] iwlwifi 0000:03:00.0: Radio type=0x0-0x3-0x1
+[22185.184835] iwlwifi 0000:03:00.0: Radio type=0x0-0x3-0x1
+[22185.296802] iwlwifi 0000:03:00.0: Radio type=0x0-0x3-0x1
+[22185.540870] iwlwifi 0000:03:00.0: Radio type=0x0-0x3-0x1
+[22185.652416] ata4: SATA link up 3.0 Gbps (SStatus 123 SControl 300)
+[22185.655525] ata4.00: configured for UDMA/133
+[22188.539353] iwlwifi 0000:03:00.0: Radio type=0x0-0x3-0x1
+[22188.786589] iwlwifi 0000:03:00.0: Radio type=0x0-0x3-0x1
+[22191.844839] wlp3s0: authenticate with 06:72:23:95:f2:2d
+[22191.848139] wlp3s0: send auth to 06:72:23:95:f2:2d (try 1/3)
+[22191.941889] wlp3s0: authenticated
+[22191.944452] wlp3s0: associate with 06:72:23:95:f2:2d (try 1/3)
+[22191.947649] wlp3s0: RX AssocResp from 06:72:23:95:f2:2d (capab=0x511 status=0 aid=87)
+[22191.952000] wlp3s0: associated
+[22192.042963] wlp3s0: Limiting TX power to 30 (30 - 0) dBm as advertised by 06:72:23:95:f2:2d
+[22192.073002] IPv6: ADDRCONF(NETDEV_CHANGE): wlp3s0: link becomes ready
+[22502.566530] perf: interrupt took too long (3152 > 3150), lowering kernel.perf_event_max_sample_rate to 63250
+[28367.730258] perf: interrupt took too long (3958 > 3940), lowering kernel.perf_event_max_sample_rate to 50500
+[36961.320394] usb 3-1.1: USB disconnect, device number 4
+[37548.180450] pci_bus 0000:02: Allocating resources
+[37548.180468] pci_bus 0000:03: Allocating resources
+[37548.180534] pci_bus 0000:04: Allocating resources
+[37548.180547] pci_bus 0000:0a: Allocating resources
+[37548.180617] pci_bus 0000:0b: Allocating resources
+[37548.180910] pci_bus 0000:01: Allocating resources
+[37549.939541] PM: suspend entry (deep)
+[37550.206530] Filesystems sync: 0.266 seconds
+[37550.207108] (NULL device *): firmware: direct-loading firmware iwlwifi-6000-4.ucode
+[37550.207409] Freezing user space processes ... (elapsed 0.018 seconds) done.
+[37550.225810] OOM killer disabled.
+[37550.225812] Freezing remaining freezable tasks ... (elapsed 0.001 seconds) done.
+[37550.227544] printk: Suspending console(s) (use no_console_suspend to debug)
+[37550.228135] wlp3s0: deauthenticating from 06:72:23:95:f2:2d by local choice (Reason: 3=DEAUTH_LEAVING)
+[37550.246966] e1000e: EEE TX LPI TIMER: 00000011
+[37550.256913] sd 3:0:0:0: [sdb] Synchronizing SCSI cache
+[37550.264392] sd 0:0:0:0: [sda] Synchronizing SCSI cache
+[37550.264739] sd 0:0:0:0: [sda] Stopping disk
+[37550.289410] sd 3:0:0:0: [sdb] Stopping disk
+[37550.754047] ACPI: EC: interrupt blocked
+[37550.773906] ACPI: Preparing to enter system sleep state S3
+[37550.776857] ACPI: EC: event blocked
+[37550.776859] ACPI: EC: EC stopped
+[37550.776860] PM: Saving platform NVS memory
+[37550.776895] Disabling non-boot CPUs ...
+[37550.778707] smpboot: CPU 1 is now offline
+[37550.783364] smpboot: CPU 2 is now offline
+[37550.787038] smpboot: CPU 3 is now offline
+[37550.790603] smpboot: CPU 4 is now offline
+[37550.794279] smpboot: CPU 5 is now offline
+[37550.797477] smpboot: CPU 6 is now offline
+[37550.800756] smpboot: CPU 7 is now offline
+[37550.803707] ACPI: Low-level resume complete
+[37550.803752] ACPI: EC: EC started
+[37550.803752] PM: Restoring platform NVS memory
+[37550.804261] Enabling non-boot CPUs ...
+[37550.804306] x86: Booting SMP configuration:
+[37550.804307] smpboot: Booting Node 0 Processor 1 APIC 0x2
+[37550.807321] CPU1 is up
+[37550.807395] smpboot: Booting Node 0 Processor 2 APIC 0x4
+[37550.810956] CPU2 is up
+[37550.811023] smpboot: Booting Node 0 Processor 3 APIC 0x6
+[37550.814637] CPU3 is up
+[37550.814702] smpboot: Booting Node 0 Processor 4 APIC 0x1
+[37550.818664] CPU4 is up
+[37550.818731] smpboot: Booting Node 0 Processor 5 APIC 0x3
+[37550.821905] CPU5 is up
+[37550.821987] smpboot: Booting Node 0 Processor 6 APIC 0x5
+[37550.825099] CPU6 is up
+[37550.825167] smpboot: Booting Node 0 Processor 7 APIC 0x7
+[37550.828387] CPU7 is up
+[37550.835205] ACPI: Waking up from system sleep state S3
+[37550.847330] ACPI: EC: interrupt unblocked
+[37550.847557] pcieport 0000:00:1c.0: Enabling MPC IRBNCE
+[37550.847560] pcieport 0000:00:1c.0: Intel PCH root port ACS workaround enabled
+[37550.847567] pcieport 0000:00:1c.1: Enabling MPC IRBNCE
+[37550.847569] pcieport 0000:00:1c.2: Enabling MPC IRBNCE
+[37550.847570] pcieport 0000:00:1c.3: Enabling MPC IRBNCE
+[37550.847571] pcieport 0000:00:1c.1: Intel PCH root port ACS workaround enabled
+[37550.847573] pcieport 0000:00:1c.7: Enabling MPC IRBNCE
+[37550.847573] pcieport 0000:00:1c.2: Intel PCH root port ACS workaround enabled
+[37550.847574] pcieport 0000:00:1c.3: Intel PCH root port ACS workaround enabled
+[37550.847576] pcieport 0000:00:1c.7: Intel PCH root port ACS workaround enabled
+[37550.888215] ACPI: EC: event unblocked
+[37550.889056] sd 0:0:0:0: [sda] Starting disk
+[37550.889058] sd 3:0:0:0: [sdb] Starting disk
+[37550.895642] iwlwifi 0000:03:00.0: Radio type=0x0-0x3-0x1
+[37551.139590] iwlwifi 0000:03:00.0: Radio type=0x0-0x3-0x1
+[37551.175069] usb 1-1.4: reset full-speed USB device number 3 using ehci-pci
+[37551.269847] ata1: SATA link up 6.0 Gbps (SStatus 133 SControl 300)
+[37551.269911] ata5: SATA link down (SStatus 0 SControl 300)
+[37551.269951] ata6: SATA link down (SStatus 0 SControl 300)
+[37551.340912] ata1.00: ACPI cmd 00/00:00:00:00:00:a0 (NOP) rejected by device (Stat=0x51 Err=0x04)
+[37551.352821] ata1.00: ACPI cmd 00/00:00:00:00:00:a0 (NOP) rejected by device (Stat=0x51 Err=0x04)
+[37551.352995] ata1.00: configured for UDMA/133
+[37551.363079] usb 1-1.5: reset high-speed USB device number 4 using ehci-pci
+[37551.471194] firewire_core 0000:0b:00.0: rediscovered device fw0
+[37551.619129] OOM killer enabled.
+[37551.619132] Restarting tasks ... 
+[37551.624720] pci_bus 0000:02: Allocating resources
+[37551.624736] pci_bus 0000:03: Allocating resources
+[37551.624784] pci_bus 0000:04: Allocating resources
+[37551.624796] pci_bus 0000:0a: Allocating resources
+[37551.624858] pci_bus 0000:0b: Allocating resources
+[37551.625134] pci_bus 0000:01: Allocating resources
+[37551.626176] done.
+[37551.635893] acpi PNP0401:00: Already enumerated
+[37551.637455] video LNXVIDEO:00: Restoring backlight state
+[37551.637458] video LNXVIDEO:01: Restoring backlight state
+[37551.656325] acpi PNP0501:00: Still not present
+[37551.723655] pci_bus 0000:02: Allocating resources
+[37551.723665] pci_bus 0000:03: Allocating resources
+[37551.723700] pci_bus 0000:04: Allocating resources
+[37551.723708] pci_bus 0000:0a: Allocating resources
+[37551.723721] pci_bus 0000:0b: Allocating resources
+[37551.723885] pci_bus 0000:01: Allocating resources
+[37551.785085] PM: suspend exit
+[37551.920747] e1000e: eno1 NIC Link is Down
+[37552.236445] iwlwifi 0000:03:00.0: Radio type=0x0-0x3-0x1
+[37552.482909] iwlwifi 0000:03:00.0: Radio type=0x0-0x3-0x1
+[37552.595079] iwlwifi 0000:03:00.0: Radio type=0x0-0x3-0x1
+[37552.840996] iwlwifi 0000:03:00.0: Radio type=0x0-0x3-0x1
+[37553.087081] ata4: SATA link up 3.0 Gbps (SStatus 123 SControl 300)
+[37553.089170] ata4.00: configured for UDMA/133
+[37555.943553] iwlwifi 0000:03:00.0: Radio type=0x0-0x3-0x1
+[37556.188767] iwlwifi 0000:03:00.0: Radio type=0x0-0x3-0x1
+[37559.370479] wlp3s0: authenticate with 06:72:23:95:f2:2d
+[37559.373586] wlp3s0: send auth to 06:72:23:95:f2:2d (try 1/3)
+[37559.456980] wlp3s0: authenticated
+[37559.459099] wlp3s0: associate with 06:72:23:95:f2:2d (try 1/3)
+[37559.461987] wlp3s0: RX AssocResp from 06:72:23:95:f2:2d (capab=0x511 status=0 aid=89)
+[37559.466515] wlp3s0: associated
+[58857.645226] Oops: 0003 [#5] PREEMPT SMP
+[37559.558074] wlp3s0: Limiting TX power to 30 (30 - 0) dBm as advertised by 06:72:23:95:f2:2d
+[37559.592862] IPv6: ADDRCONF(NETDEV_CHANGE): wlp3s0: link becomes ready
+[42247.121322] perf: interrupt took too long (4954 > 4947), lowering kernel.perf_event_max_sample_rate to 40250
+[43552.357558] perf: interrupt took too long (6224 > 6192), lowering kernel.perf_event_max_sample_rate to 32000
+[49830.135813] usb 3-1.2: new low-speed USB device number 5 using ehci-pci
+[49830.253180] usb 3-1.2: New USB device found, idVendor=1bcf, idProduct=0005, bcdDevice= 0.14
+[49830.253187] usb 3-1.2: New USB device strings: Mfr=0, Product=2, SerialNumber=0
+[49830.253191] usb 3-1.2: Product: USB Optical Mouse
+[49830.259916] input: USB Optical Mouse as /devices/pci0000:00/0000:00:1d.0/usb3/3-1/3-1.2/3-1.2:1.0/0003:1BCF:0005.0003/input/input24
+[49830.260449] hid-generic 0003:1BCF:0005.0003: input,hidraw0: USB HID v1.10 Mouse [USB Optical Mouse] on usb-0000:00:1d.0-1.2/input0
+[53268.903917] pci_bus 0000:02: Allocating resources
+[53268.903936] pci_bus 0000:03: Allocating resources
+[53268.904002] pci_bus 0000:04: Allocating resources
+[53268.904015] pci_bus 0000:0a: Allocating resources
+[53268.904084] pci_bus 0000:0b: Allocating resources
+[53268.904407] pci_bus 0000:01: Allocating resources
+[53270.692017] PM: suspend entry (deep)
+[53270.924538] Filesystems sync: 0.232 seconds
+[53270.925066] (NULL device *): firmware: direct-loading firmware iwlwifi-6000-4.ucode
+[53270.925391] Freezing user space processes ... (elapsed 0.051 seconds) done.
+[53270.976917] OOM killer disabled.
+[53270.976919] Freezing remaining freezable tasks ... (elapsed 0.001 seconds) done.
+[53270.978842] printk: Suspending console(s) (use no_console_suspend to debug)
+[53271.084461] wlp3s0: deauthenticating from 06:72:23:95:f2:2d by local choice (Reason: 3=DEAUTH_LEAVING)
+[53271.099695] e1000e: EEE TX LPI TIMER: 00000011
+[53271.115903] sd 0:0:0:0: [sda] Synchronizing SCSI cache
+[53271.115906] sd 3:0:0:0: [sdb] Synchronizing SCSI cache
+[53271.116339] sd 3:0:0:0: [sdb] Stopping disk
+[53271.116340] sd 0:0:0:0: [sda] Stopping disk
+[53271.596946] ACPI: EC: interrupt blocked
+[53271.616697] ACPI: Preparing to enter system sleep state S3
+[53271.619514] ACPI: EC: event blocked
+[53271.619515] ACPI: EC: EC stopped
+[53271.619516] PM: Saving platform NVS memory
+[    3.792262] WARNING: CPU: 1 PID: 30 at drivers/regulator/core.c:2042 _regulator_put.part.8+0x3c/#
+[53271.619548] Disabling non-boot CPUs ...
+[53271.621354] smpboot: CPU 1 is now offline
+[53271.626573] smpboot: CPU 2 is now offline
+[53271.630506] smpboot: CPU 3 is now offline
+[53271.633872] smpboot: CPU 4 is now offline
+[53271.638957] smpboot: CPU 5 is now offline
+[53271.642198] smpboot: CPU 6 is now offline
+[53271.645772] smpboot: CPU 7 is now offline
+[53271.649056] ACPI: Low-level resume complete
+[53271.649100] ACPI: EC: EC started
+[53271.649101] PM: Restoring platform NVS memory
+[53271.649670] Enabling non-boot CPUs ...
+[53271.649772] x86: Booting SMP configuration:
+[53271.649774] smpboot: Booting Node 0 Processor 1 APIC 0x2
+[53271.653325] CPU1 is up
+[53271.653388] smpboot: Booting Node 0 Processor 2 APIC 0x4
+[53271.657167] CPU2 is up
+[53271.657231] smpboot: Booting Node 0 Processor 3 APIC 0x6
+[53271.660833] CPU3 is up
+[53271.660893] smpboot: Booting Node 0 Processor 4 APIC 0x1
+[53271.664978] CPU4 is up
+[53271.665055] smpboot: Booting Node 0 Processor 5 APIC 0x3
+[53271.668104] CPU5 is up
+[53271.668167] smpboot: Booting Node 0 Processor 6 APIC 0x5
+[53271.671879] CPU6 is up
+[53271.671943] smpboot: Booting Node 0 Processor 7 APIC 0x7
+[53271.675165] CPU7 is up
+[53271.682135] ACPI: Waking up from system sleep state S3
+[53271.690099] ACPI: EC: interrupt unblocked
+[53271.690283] pcieport 0000:00:1c.1: Enabling MPC IRBNCE
+[53271.690286] pcieport 0000:00:1c.1: Intel PCH root port ACS workaround enabled
+[53271.690295] pcieport 0000:00:1c.7: Enabling MPC IRBNCE
+[53271.690297] pcieport 0000:00:1c.2: Enabling MPC IRBNCE
+[53271.690299] pcieport 0000:00:1c.0: Enabling MPC IRBNCE
+[53271.690302] pcieport 0000:00:1c.7: Intel PCH root port ACS workaround enabled
+[53271.690303] pcieport 0000:00:1c.2: Intel PCH root port ACS workaround enabled
+[53271.690305] pcieport 0000:00:1c.0: Intel PCH root port ACS workaround enabled
+[53271.690629] pcieport 0000:00:1c.3: Enabling MPC IRBNCE
+[53271.690632] pcieport 0000:00:1c.3: Intel PCH root port ACS workaround enabled
+[53271.731357] ACPI: EC: event unblocked
+[53271.741448] sd 0:0:0:0: [sda] Starting disk
+[58857.640075] WARNING: CPU: 3 PID: 2549 at ../drivers/gpu/drm/radeon/radeon_object.c:84 radeon_ttm_bo_destroy+0xec/0xf0 [radeon]
+[53271.741460] sd 3:0:0:0: [sdb] Starting disk
+[53271.744677] iwlwifi 0000:03:00.0: Radio type=0x0-0x3-0x1
+[53271.985824] usb 1-1.4: reset full-speed USB device number 3 using ehci-pci
+[53271.991598] iwlwifi 0000:03:00.0: Radio type=0x0-0x3-0x1
+[53272.096361] ata5: SATA link down (SStatus 0 SControl 300)
+[53272.096406] ata1: SATA link up 6.0 Gbps (SStatus 133 SControl 300)
+[53272.096464] ata6: SATA link down (SStatus 0 SControl 300)
+[53272.173917] usb 1-1.5: reset high-speed USB device number 4 using ehci-pci
+[53272.185551] ata1.00: ACPI cmd 00/00:00:00:00:00:a0 (NOP) rejected by device (Stat=0x51 Err=0x04)
+[53272.197825] usb 3-1.2: reset low-speed USB device number 5 using ehci-pci
+[53272.199867] ata1.00: ACPI cmd 00/00:00:00:00:00:a0 (NOP) rejected by device (Stat=0x51 Err=0x04)
+[53272.200040] ata1.00: configured for UDMA/133
+[53272.305956] firewire_core 0000:0b:00.0: rediscovered device fw0
+[53272.503665] OOM killer enabled.
+[53272.503667] Restarting tasks ... 
+[53272.511264] pci_bus 0000:02: Allocating resources
+[53272.511278] pci_bus 0000:03: Allocating resources
+[53272.511316] pci_bus 0000:04: Allocating resources
+[53272.511326] pci_bus 0000:0a: Allocating resources
+[53272.511387] pci_bus 0000:0b: Allocating resources
+[53272.511586] pci_bus 0000:01: Allocating resources
+[53272.512265] acpi PNP0401:00: Already enumerated
+[53272.512720] acpi PNP0501:00: Still not present
+[    3.534112] WARNING: CPU: 1 PID: 30 at drivers/regulator/core.c:2042 _regulator_put.part.8+0x3c/0xf8
+[53272.514473] done.
+[53272.534600] pci_bus 0000:02: Allocating resources
+[53272.534609] pci_bus 0000:03: Allocating resources
+[53272.534645] pci_bus 0000:04: Allocating resources
+[53272.534652] pci_bus 0000:0a: Allocating resources
+[53272.534714] pci_bus 0000:0b: Allocating resources
+[53272.534895] pci_bus 0000:01: Allocating resources
+[53272.535404] video LNXVIDEO:00: Restoring backlight state
+[53272.535406] video LNXVIDEO:01: Restoring backlight state
+[53272.690415] PM: suspend exit
+[53272.819444] e1000e: eno1 NIC Link is Down
+[53273.160077] iwlwifi 0000:03:00.0: Radio type=0x0-0x3-0x1
+[53273.402315] iwlwifi 0000:03:00.0: Radio type=0x0-0x3-0x1
+[53273.517427] iwlwifi 0000:03:00.0: Radio type=0x0-0x3-0x1
+[53273.763574] iwlwifi 0000:03:00.0: Radio type=0x0-0x3-0x1
+[53273.881812] ata4: SATA link up 3.0 Gbps (SStatus 123 SControl 300)
+[53273.883886] ata4.00: configured for UDMA/133
+[53276.845408] iwlwifi 0000:03:00.0: Radio type=0x0-0x3-0x1
+[53277.091486] iwlwifi 0000:03:00.0: Radio type=0x0-0x3-0x1
+[53280.249750] wlp3s0: authenticate with 06:72:23:95:f2:2d
+[53280.252550] wlp3s0: send auth to 06:72:23:95:f2:2d (try 1/3)
+[53280.310789] wlp3s0: authenticated
+[53280.313815] wlp3s0: associate with 06:72:23:95:f2:2d (try 1/3)
+[53280.316569] wlp3s0: RX AssocResp from 06:72:23:95:f2:2d (capab=0x511 status=0 aid=102)
+[53280.320568] wlp3s0: associated
+[53280.382113] wlp3s0: Limiting TX power to 30 (30 - 0) dBm as advertised by 06:72:23:95:f2:2d
+[53280.435212] IPv6: ADDRCONF(NETDEV_CHANGE): wlp3s0: link becomes ready

--- a/test/plugins/linux_log_parser/rcu_warning.log
+++ b/test/plugins/linux_log_parser/rcu_warning.log
@@ -1,0 +1,9651 @@
+Trying 127.0.1.1...
+Connected to lkft-slave04.lkftlab.
+Escape character is '^]'.
+
+lkft Juno 08 7003 [115200 N81]
+
+�
+
+ARM V2M-Juno Boot loader v1.0.0
+HBI0262 build 2054
+
+ARM V2M_Juno r2 Firmware v1.4.9
+Build Date: May  2 2017
+
+Time :  12:18:11 
+Date :  22:11:2019 
+
+Press Enter to stop auto boot...
+
+
+Powering up system...
+
+Switching on ATXPSU...
+PMIC RAM configuration (pms_v105.bin)...
+MBtemp   : 34 degC
+
+Configuring motherboard (rev D, var A)...
+IOFPGA image \MB\HBI0262D\io_b118.bit
+IOFPGA  config: PASSED
+OSC CLK config: PASSED
+
+Configuring SCC registers...
+Writing SCC 0x00000054 with 0x0007FFFE
+Writing SCC 0x0000005C with 0x00FE001E
+Writing SCC 0x00000100 with 0x00271000
+Writing SCC 0x00000104 with 0x00013100
+Writing SCC 0x00000108 with 0x003F1000
+Writing SCC 0x0000010C with 0x0001F300
+Writing SCC 0x00000118 with 0x003F1000
+Writing SCC 0x0000011C with 0x0001F100
+Writing SCC 0x000000F8 with 0x0BEC0000
+Writing SCC 0x000000FC with 0xABE40000
+Writing SCC 0x00000A14 with 0x00000000
+Writing SCC 0x0000000C with 0x000000C2
+Writing SCC 0x00000010 with 0x000000C2
+
+Peripheral ID0:0x000000AD
+Peripheral ID1:0x000000B0
+Peripheral ID2:0x0000001B
+Peripheral ID3:0x00000000
+Peripheral ID4:0x0000000D
+Peripheral ID5:0x000000F0
+Peripheral ID6:0x00000005
+Peripheral ID7:0x000000B1
+
+Programming NOR Flash
+PCIE clock configured...
+
+Testing motherboard interfaces (FPGA build 118)...
+SRAM 32MB test: PASSED
+LAN9118   test: PASSED
+KMI1/2    test: PASSED
+MMC       test: PASSED
+PB/LEDs   test: PASSED
+FPGA UART test: PASSED
+PCIe init test: PASSED
+PCIe MAC addresss 0002-F700-670B
+MAC addrs test: PASSED
+
+SMC MAC address 0002-F700-6709
+Setting HDMI0 mode for SVGA.
+Setting HDMI1 mode for SVGA.
+
+SoC SMB clock enabled.
+
+Testing SMB clock...
+SMB clock running
+Releasing system resets...
+
+UART0 set to SoC UART0
+UART1 set to SoC UART1
+
+NOTICE:  Booting Trusted Firmware
+NOTICE:  BL1: v1.4(release):v1.4-360-ge83769c07
+NOTICE:  BL1: Built : 04:51:36, Jun 25 2019
+NOTICE:  BL1: Booting BL2
+NOTICE:  BL2: v1.4(release):v1.4-360-ge83769c07
+NOTICE:  BL2: Built : 04:51:36, Jun 25 2019
+NOTICE:  BL1: Booting BL31
+NOTICE:  BL31: v1.4(release):v1.4-360-ge83769c07
+NOTICE:  BL31: Built : 04:51:36, Jun 25 2019
+
+
+U-Boot 2017.07-rc3 (Feb 27 2019 - 20:15:07 +0000) vexpress_aemv8a juno aarch64
+
+DRAM:  8 GiB
+PCIe XR3 Host Bridge enabled: x4 link (Gen 2)
+Flash: 64 MiB
+*** Warning - bad CRC, using default environment
+
+In:    serial_pl01x
+Out:   serial_pl01x
+Err:   serial_pl01x
+Net:   smc911x-0
+Hit any key to stop autoboot:  1 
+ 0 
+juno# setenv autoload no
+setenv autoload no
+juno# setenv bootdelay 1
+setenv bootdelay 1
+juno# setenv ethact smc911x-0
+setenv ethact smc911x-0
+juno# setenv initrd_high 0xffffffffffffffff
+setenv initrd_high 0xffffffffffffffff
+juno# setenv fdt_high 0xffffffffffffffff
+setenv fdt_high 0xffffffffffffffff
+juno# setenv loadkernel 'tftp 0x80080000 1019767/tftp-deploy-clc7gh9i/kernel/Image--4.14+git0+d40687ee9e-r0-juno-20191122113837-653.bin'
+setenv loadkernel 'tftp 0x80080000 1019767/tftp-deploy-clc7gh9i/kernel/Image--4.14+git0+d40687ee9e-r0-juno-20191122113837-653.bin'
+juno# setenv loadinitrd 'tftp - {RAMDISK}; setenv initrd_size ${filesize}'
+setenv loadinitrd 'tftp - {RAMDISK}; setenv initrd_size ${filesize}'
+juno# setenv loadfdt 'tftp 0x83000000 1019767/tftp-deploy-clc7gh9i/dtb/Image--4.14+git0+d40687ee9e-r0-juno-r2-20191122113837-653.dtb'
+setenv loadfdt 'tftp 0x83000000 1019767/tftp-deploy-clc7gh9i/dtb/Image--4.14+git0+d40687ee9e-r0-juno-r2-20191122113837-653.dtb'
+juno# setenv nfsargs 'setenv bootargs console=ttyAMA0,115200n8 root=/dev/nfs rw nfsroot=10.66.16.123:/var/lib/lava/dispatcher/tmp/1019767/extract-nfsrootfs-3fstuc8a,tcp,hard,intr,vers=3 rootwait earlycon=pl011,0x7ff80000 debug systemd.log_target=null user_debug=31 androidboot.hardware=juno loglevel=9 sky2.mac_address=0x00,0x02,0xf7,0x00,0x67,0x0b ip=dhcp'
+setenv nfsargs 'setenv bootargs console=ttyAMA0,115200n8 root=/dev/nfs rw nfsroot=10.66.16.123:/var/lib/lava/dispatcher/tmp/1019767/extract-nfsrootfs-3fstuc8a,tcp,hard,intr,vers=3 rootwait earlycon=pl011,0x7ff80000 debug systemd.log_target=null user_debug=31 androidboot.hardware=juno loglevel=9 sky2.mac_address=0x00,0x02,0xf7,0x00,0x67,0x0b ip=dhcp'
+juno# setenv bootcmd 'dhcp; setenv serverip 10.66.16.123; run loadkernel; run loadinitrd; run loadfdt; run nfsargs; booti 0x80080000 - 0x83000000'
+setenv bootcmd 'dhcp; setenv serverip 10.66.16.123; run loadkernel; run loadinitrd; run loadfdt; run nfsargs; booti 0x80080000 - 0x83000000'
+juno# run bootcmd
+run bootcmd
+smc911x: MAC 00:02:f7:00:67:09
+smc911x: detected LAN9118 controller
+smc911x: phy initialized
+smc911x: MAC 00:02:f7:00:67:09
+BOOTP broadcast 1
+BOOTP broadcast 2
+BOOTP broadcast 3
+BOOTP broadcast 4
+BOOTP broadcast 5
+BOOTP broadcast 6
+DHCP client bound to address 10.66.16.40 (5758 ms)
+smc911x: MAC 00:02:f7:00:67:09
+smc911x: MAC 00:02:f7:00:67:09
+smc911x: detected LAN9118 controller
+smc911x: phy initialized
+smc911x: MAC 00:02:f7:00:67:09
+Using smc911x-0 device
+TFTP from server 10.66.16.123; our IP address is 10.66.16.40
+Filename '1019767/tftp-deploy-clc7gh9i/kernel/Image--4.14+git0+d40687ee9e-r0-juno-20191122113837-653.bin'.
+Load address: 0x80080000
+Loading: *#################################################################
+	 #################################################################
+	 #################################################################
+	 #################################################################
+	 #################################################################
+	 #################################################################
+	 #################################################################
+	 #################################################################
+	 #################################################################
+	 #################################################################
+	 #################################################################
+	 #################################################################
+	 #################################################################
+	 #################################################################
+	 #################################################################
+	 #################################################################
+	 #################################################################
+	 #################################################################
+	 #################################################################
+	 #################################################################
+	 #################################################################
+	 #################################################################
+	 #################################################################
+	 #############################
+	 2 MiB/s
+done
+Bytes transferred = 22370816 (1555a00 hex)
+smc911x: MAC 00:02:f7:00:67:09
+smc911x: MAC 00:02:f7:00:67:09
+smc911x: detected LAN9118 controller
+smc911x: phy initialized
+smc911x: MAC 00:02:f7:00:67:09
+Using smc911x-0 device
+TFTP from server 10.66.16.123; our IP address is 10.66.16.40
+Filename '{RAMDISK}'.
+Load address: 0x0
+Loading: *
+TFTP error: 'File not found' (1)
+Not retrying...
+smc911x: MAC 00:02:f7:00:67:09
+smc911x: MAC 00:02:f7:00:67:09
+smc911x: MAC 00:02:f7:00:67:09
+smc911x: detected LAN9118 controller
+smc911x: phy initialized
+smc911x: MAC 00:02:f7:00:67:09
+Using smc911x-0 device
+TFTP from server 10.66.16.123; our IP address is 10.66.16.40
+Filename '1019767/tftp-deploy-clc7gh9i/dtb/Image--4.14+git0+d40687ee9e-r0-juno-r2-20191122113837-653.dtb'.
+Load address: 0x83000000
+Loading: *##
+	 4.9 KiB/s
+done
+Bytes transferred = 25383 (6327 hex)
+smc911x: MAC 00:02:f7:00:67:09
+## Flattened Device Tree blob at 83000000
+   Booting using the fdt blob at 0x83000000
+   Using Device Tree in place at 0000000083000000, end 0000000083009326
+
+Starting kernel ...
+
+[    0.000000] Booting Linux on physical CPU 0x100
+[    0.000000] Linux version 4.14.156-rc1 (oe-user@oe-host) (gcc version 7.3.0 (GCC)) #1 SMP PREEMPT Fri Nov 22 11:42:47 UTC 2019
+[    0.000000] Boot CPU: AArch64 Processor [410fd033]
+[    0.000000] Machine model: ARM Juno development board (r2)
+[    0.000000] earlycon: pl11 at MMIO 0x000000007ff80000 (options '')
+[    0.000000] bootconsole [pl11] enabled
+[    0.000000] efi: Getting EFI parameters from FDT:
+[    0.000000] efi: UEFI not found.
+[    0.000000] cma: Reserved 16 MiB at 0x00000000fe000000
+[    0.000000] NUMA: No NUMA configuration found
+[    0.000000] NUMA: Faking a node at [mem 0x0000000080000000-0x00000009ffffffff]
+[    0.000000] NUMA: NODE_DATA [mem 0x9fffc6f80-0x9fffc8bff]
+[    0.000000] Zone ranges:
+[    0.000000]   DMA      [mem 0x0000000080000000-0x00000000ffffffff]
+[    0.000000]   Normal   [mem 0x0000000100000000-0x00000009ffffffff]
+[    0.000000] Movable zone start for each node
+[    0.000000] Early memory node ranges
+[    0.000000]   node   0: [mem 0x0000000080000000-0x00000000feffffff]
+[    0.000000]   node   0: [mem 0x0000000880000000-0x00000009ffffffff]
+[    0.000000] Initmem setup node 0 [mem 0x0000000080000000-0x00000009ffffffff]
+[    0.000000] On node 0 totalpages: 2093056
+[    0.000000]   DMA zone: 8192 pages used for memmap
+[    0.000000]   DMA zone: 0 pages reserved
+[    0.000000]   DMA zone: 520192 pages, LIFO batch:31
+[    0.000000]   Normal zone: 24576 pages used for memmap
+[    0.000000]   Normal zone: 1572864 pages, LIFO batch:31
+[    0.000000] psci: probing for conduit method from DT.
+[    0.000000] psci: PSCIv1.1 detected in firmware.
+[    0.000000] psci: Using standard PSCI v0.2 function IDs
+[    0.000000] psci: Trusted OS migration not required
+[    0.000000] psci: SMC Calling Convention v1.0
+[    0.000000] percpu: Embedded 25 pages/cpu s62280 r8192 d31928 u102400
+[    0.000000] pcpu-alloc: s62280 r8192 d31928 u102400 alloc=25*4096
+[    0.000000] pcpu-alloc: [0] 0 [0] 1 [0] 2 [0] 3 [0] 4 [0] 5 
+[    0.000000] Detected VIPT I-cache on CPU0
+[    0.000000] CPU features: enabling workaround for ARM erratum 845719
+[    0.000000] Built 1 zonelists, mobility grouping on.  Total pages: 2060288
+[    0.000000] Policy zone: Normal
+[    0.000000] Kernel command line: console=ttyAMA0,115200n8 root=/dev/nfs rw nfsroot=10.66.16.123:/var/lib/lava/dispatcher/tmp/1019767/extract-nfsrootfs-3fstuc8a,tcp,hard,intr,vers=3 rootwait earlycon=pl011,0x7ff80000 debug systemd.log_target=null user_debug=31 androidboot.hardware=juno loglevel=9 sky2.mac_address=0x00,0x02,0xf7,0x00,0x67,0x0b ip=dhcp
+[    0.000000] PID hash table entries: 4096 (order: 3, 32768 bytes)
+[    0.000000] software IO TLB: mapped [mem 0xf9fff000-0xfdfff000] (64MB)
+[    0.000000] Memory: 8123672K/8372224K available (12988K kernel code, 1878K rwdata, 5192K rodata, 1728K init, 12355K bss, 232168K reserved, 16384K cma-reserved)
+[    0.000000] Virtual kernel memory layout:
+[    0.000000]     modules : 0xffff000000000000 - 0xffff000008000000   (   128 MB)
+[    0.000000]     vmalloc : 0xffff000008000000 - 0xffff7dffbfff0000   (129022 GB)
+[    0.000000]       .text : 0xffff000008080000 - 0xffff000008d30000   ( 12992 KB)
+[    0.000000]     .rodata : 0xffff000008d30000 - 0xffff000009250000   (  5248 KB)
+[    0.000000]       .init : 0xffff000009250000 - 0xffff000009400000   (  1728 KB)
+[    0.000000]       .data : 0xffff000009400000 - 0xffff0000095d5a00   (  1879 KB)
+[    0.000000]        .bss : 0xffff0000095d5a00 - 0xffff00000a1e68c0   ( 12356 KB)
+[    0.000000]     fixed   : 0xffff7dfffe7f9000 - 0xffff7dfffec00000   (  4124 KB)
+[    0.000000]     PCI I/O : 0xffff7dfffee00000 - 0xffff7dffffe00000   (    16 MB)
+[    0.000000]     vmemmap : 0xffff7e0000000000 - 0xffff800000000000   (  2048 GB maximum)
+[    0.000000]               0xffff7e0000000000 - 0xffff7e0026000000   (   608 MB actual)
+[    0.000000]     memory  : 0xffff800000000000 - 0xffff800980000000   ( 38912 MB)
+[    0.000000] SLUB: HWalign=64, Order=0-3, MinObjects=0, CPUs=6, Nodes=1
+[    0.000000] ftrace: allocating 43996 entries in 172 pages
+[    0.000000] Running RCU self tests
+[    0.000000] Preemptible hierarchical RCU implementation.
+[    0.000000] 	RCU lockdep checking is enabled.
+[    0.000000] 	RCU restricting CPUs from NR_CPUS=64 to nr_cpu_ids=6.
+[    0.000000] 	Tasks RCU enabled.
+[    0.000000] RCU: Adjusting geometry for rcu_fanout_leaf=16, nr_cpu_ids=6
+[    0.000000] NR_IRQS: 64, nr_irqs: 64, preallocated irqs: 0
+[    0.000000] GIC: Using split EOI/Deactivate mode
+[    0.000000] GICv2m: range[mem 0x2c1c0000-0x2c1c0fff], SPI[224:255]
+[    0.000000] arch_timer: cp15 and mmio timer(s) running at 50.00MHz (phys/phys).
+[    0.000000] clocksource: arch_sys_counter: mask: 0xffffffffffffff max_cycles: 0xb8812736b, max_idle_ns: 440795202655 ns
+[    0.000006] sched_clock: 56 bits at 50MHz, resolution 20ns, wraps every 4398046511100ns
+[    0.008754] clocksource: arm,sp804: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 1911260446275 ns
+[    0.018501] Failed to initialize '/smb@8000000/motherboard/iofpga@3,00000000/timer@120000': -22
+[    0.027732] Console: colour dummy device 80x25
+[    0.032233] Lock dependency validator: Copyright (c) 2006 Red Hat, Inc., Ingo Molnar
+[    0.040024] ... MAX_LOCKDEP_SUBCLASSES:  8
+[    0.044155] ... MAX_LOCK_DEPTH:          48
+[    0.048372] ... MAX_LOCKDEP_KEYS:        8191
+[    0.052763] ... CLASSHASH_SIZE:          4096
+[    0.057154] ... MAX_LOCKDEP_ENTRIES:     32768
+[    0.061631] ... MAX_LOCKDEP_CHAINS:      65536
+[    0.066111] ... CHAINHASH_SIZE:          32768
+[    0.070591]  memory used by lock dependency info: 7391 kB
+[    0.076027]  per task-struct memory footprint: 1920 bytes
+[    0.081560] Calibrating delay loop (skipped), value calculated using timer frequency.. 100.00 BogoMIPS (lpj=200000)
+[    0.092067] pid_max: default: 32768 minimum: 301
+[    0.096940] Security Framework initialized
+[    0.105245] Dentry cache hash table entries: 1048576 (order: 11, 8388608 bytes)
+[    0.114678] Inode-cache hash table entries: 524288 (order: 10, 4194304 bytes)
+[    0.121966] Mount-cache hash table entries: 16384 (order: 5, 131072 bytes)
+[    0.128960] Mountpoint-cache hash table entries: 16384 (order: 5, 131072 bytes)
+[    0.152534] ASID allocator initialised with 32768 entries
+[    0.166072] Hierarchical SRCU implementation.
+[    0.179879] EFI services will not be available.
+[    0.192544] smp: Bringing up secondary CPUs ...
+[    0.225702] ARM_SMCCC_ARCH_WORKAROUND_1 missing from firmware
+[    0.225712] Detected PIPT I-cache on CPU1
+[    0.225765] CPU1: Booted secondary processor [410fd080]
+[    0.225985] 
+[    0.242613] =============================
+[    0.246660] WARNING: suspicious RCU usage
+[    0.250703] 4.14.156-rc1 #1 Not tainted
+[    0.254555] -----------------------------
+[    0.258600] /usr/src/kernel/include/linux/radix-tree.h:238 suspicious rcu_dereference_check() usage!
+[    0.267797] 
+[    0.267797] other info that might help us debug this:
+[    0.267797] 
+[    0.275859] 
+[    0.275859] rcu_scheduler_active = 1, debug_locks = 1
+[    0.282436] 2 locks held by cpuhp/1/13:
+[    0.286286]  #0:  (cpuhp_state-up){+.+.}, at: [<ffff0000080e84f0>] cpuhp_thread_fun+0x58/0x260
+[    0.294995]  #1:  (wq_pool_mutex){+.+.}, at: [<ffff00000810d7e8>] workqueue_online_cpu+0x40/0x3a8
+[    0.303958] 
+[    0.303958] stack backtrace:
+[    0.308353] CPU: 1 PID: 13 Comm: cpuhp/1 Not tainted 4.14.156-rc1 #1
+[    0.314738] Hardware name: ARM Juno development board (r2) (DT)
+[    0.320684] Call trace:
+[    0.323146] [<ffff00000808c4a8>] dump_backtrace+0x0/0x240
+[    0.328571] [<ffff00000808c70c>] show_stack+0x24/0x30
+[    0.333646] [<ffff000008cf48bc>] dump_stack+0xc8/0x104
+[    0.338808] [<ffff000008148cc4>] lockdep_rcu_suspicious+0xcc/0x110
+[    0.345021] [<ffff000008cf8084>] idr_get_next+0x144/0x178
+[    0.350445] [<ffff00000810d854>] workqueue_online_cpu+0xac/0x3a8
+[    0.356482] [<ffff0000080e6e58>] cpuhp_invoke_callback+0x100/0xf60
+[    0.362692] [<ffff0000080e8668>] cpuhp_thread_fun+0x1d0/0x260
+[    0.368466] [<ffff00000811766c>] smpboot_thread_fn+0x19c/0x2a0
+[    0.374327] [<ffff000008112388>] kthread+0x138/0x140
+[    0.379315] [<ffff000008085be4>] ret_from_fork+0x10/0x1c
+[    0.410508] Detected PIPT I-cache on CPU2
+[    0.410540] CPU2: Booted secondary processor [410fd080]
+[    0.438737] Detected VIPT I-cache on CPU3
+[    0.438797] CPU3: Booted secondary processor [410fd033]
+[    0.466950] Detected VIPT I-cache on CPU4
+[    0.466996] CPU4: Booted secondary processor [410fd033]
+[    0.495183] Detected VIPT I-cache on CPU5
+[    0.495228] CPU5: Booted secondary processor [410fd033]
+[    0.495522] smp: Brought up 1 node, 6 CPUs
+[    0.537036] SMP: Total of 6 processors activated.
+[    0.541801] CPU features: detected: 32-bit EL0 Support
+[    0.549312] CPU: All CPU(s) started at EL2
+[    0.553601] alternatives: patching kernel code
+[    0.560649] devtmpfs: initialized
+[    0.586060] random: get_random_u32 called from bucket_table_alloc+0x120/0x258 with crng_init=0
+[    0.598556] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 7645041785100000 ns
+[    0.608540] futex hash table entries: 2048 (order: 6, 262144 bytes)
+[    0.616250] pinctrl core: initialized pinctrl subsystem
+[    0.625152] DMI not present or invalid.
+[    0.630262] NET: Registered protocol family 16
+[    0.639866] cpuidle: using governor menu
+[    0.645091] vdso: 2 pages (1 code @ ffff000008d36000, 1 data @ ffff000009405000)
+[    0.652647] hw-breakpoint: found 6 breakpoint and 4 watchpoint registers.
+[    0.662719] DMA: preallocated 256 KiB pool for atomic allocations
+[    0.670211] Serial: AMBA PL011 UART driver
+[    0.688312] 7ff80000.uart: ttyAMA0 at MMIO 0x7ff80000 (irq = 25, base_baud = 0) is a PL011 rev3
+[    0.697197] console [ttyAMA0] enabled
+[    0.697197] console [ttyAMA0] enabled
+[    0.704546] bootconsole [pl11] disabled
+[    0.704546] bootconsole [pl11] disabled
+[    0.774354] HugeTLB registered 2.00 MiB page size, pre-allocated 0 pages
+[    0.784711] ACPI: Interpreter disabled.
+[    0.791657] vgaarb: loaded
+[    0.795281] SCSI subsystem initialized
+[    0.800232] libata version 3.00 loaded.
+[    0.804979] usbcore: registered new interface driver usbfs
+[    0.810657] usbcore: registered new interface driver hub
+[    0.816281] usbcore: registered new device driver usb
+[    0.824644] media: Linux media interface: v0.10
+[    0.829306] Linux video capture interface: v2.00
+[    0.834113] pps_core: LinuxPPS API ver. 1 registered
+[    0.839076] pps_core: Software ver. 5.3.6 - Copyright 2005-2007 Rodolfo Giometti <giometti@linux.it>
+[    0.848239] PTP clock support registered
+[    0.852534] EDAC MC: Ver: 3.0.0
+[    0.856605] dmi: Firmware registration failed.
+[    0.861851] Advanced Linux Sound Architecture Driver Initialized.
+[    0.870730] clocksource: Switched to clocksource arch_sys_counter
+[    1.055635] VFS: Disk quotas dquot_6.6.0
+[    1.059705] VFS: Dquot-cache hash table entries: 512 (order 0, 4096 bytes)
+[    1.067110] pnp: PnP ACPI: disabled
+[    1.097011] NET: Registered protocol family 2
+[    1.102930] TCP established hash table entries: 65536 (order: 7, 524288 bytes)
+[    1.112595] TCP bind hash table entries: 65536 (order: 10, 4194304 bytes)
+[    1.128468] TCP: Hash tables configured (established 65536 bind 65536)
+[    1.135819] UDP hash table entries: 4096 (order: 7, 655360 bytes)
+[    1.143465] UDP-Lite hash table entries: 4096 (order: 7, 655360 bytes)
+[    1.151641] NET: Registered protocol family 1
+[    1.157194] RPC: Registered named UNIX socket transport module.
+[    1.163169] RPC: Registered udp transport module.
+[    1.167886] RPC: Registered tcp transport module.
+[    1.172594] RPC: Registered tcp NFSv4.1 backchannel transport module.
+[    1.179027] PCI: CLS 0 bytes, default 128
+[    1.186038] hw perfevents: enabled with armv8_cortex_a72 PMU driver, 7 counters available
+[    1.195528] hw perfevents: enabled with armv8_cortex_a53 PMU driver, 7 counters available
+[    1.203888] kvm [1]: 8-bit VMID
+[    1.216306] kvm [1]: vgic interrupt IRQ1
+[    1.220646] kvm [1]: Hyp mode initialized successfully
+[    1.236173] audit: initializing netlink subsys (disabled)
+[    1.241988] audit: type=2000 audit(1.132:1): state=initialized audit_enabled=0 res=1
+[    1.244498] workingset: timestamp_bits=44 max_order=21 bucket_order=0
+[    1.287907] squashfs: version 4.0 (2009/01/31) Phillip Lougher
+[    1.296562] NFS: Registering the id_resolver key type
+[    1.301837] Key type id_resolver registered
+[    1.306078] Key type id_legacy registered
+[    1.310116] nfs4filelayout_init: NFSv4 File Layout Driver Registering...
+[    1.317268] 9p: Installing v9fs 9p2000 file system support
+[    1.330130] Block layer SCSI generic (bsg) driver version 0.4 loaded (major 245)
+[    1.337571] io scheduler noop registered
+[    1.342281] io scheduler cfq registered (default)
+[    1.347015] io scheduler mq-deadline registered
+[    1.351566] io scheduler kyber registered
+[    1.356041] test_firmware: interface ready
+[    1.372318] pl061_gpio 1c1d0000.gpio: PL061 GPIO chip @0x000000001c1d0000 registered
+[    1.382604] OF: PCI: host bridge /pcie@40000000 ranges:
+[    1.387884] OF: PCI:    IO 0x5f800000..0x5fffffff -> 0x00000000
+[    1.393870] OF: PCI:   MEM 0x50000000..0x57ffffff -> 0x50000000
+[    1.399816] OF: PCI:   MEM 0x4000000000..0x40ffffffff -> 0x4000000000
+[    1.406335] pci-host-generic 40000000.pcie: ECAM at [mem 0x40000000-0x4fffffff] for [bus 00-ff]
+[    1.415501] pci-host-generic 40000000.pcie: PCI host bridge to bus 0000:00
+[    1.422375] pci_bus 0000:00: root bus resource [bus 00-ff]
+[    1.427882] pci_bus 0000:00: root bus resource [io  0x0000-0x7fffff]
+[    1.434231] pci_bus 0000:00: root bus resource [mem 0x50000000-0x57ffffff]
+[    1.441111] pci_bus 0000:00: root bus resource [mem 0x4000000000-0x40ffffffff pref]
+[    1.448864] pci 0000:00:00.0: [1556:1100] type 01 class 0x060400
+[    1.454935] pci 0000:00:00.0: reg 0x10: [mem 0x00000000-0x00003fff 64bit pref]
+[    1.462294] pci 0000:00:00.0: supports D1 D2
+[    1.466593] pci 0000:00:00.0: PME# supported from D0 D1 D2 D3hot D3cold
+[    1.473920] pci 0000:00:00.0: bridge configuration invalid ([bus 00-00]), reconfiguring
+[    1.482238] pci 0000:01:00.0: [111d:8090] type 01 class 0x060400
+[    1.488365] pci 0000:01:00.0: enabling Extended Tags
+[    1.493499] pci 0000:01:00.0: PME# supported from D0 D3hot D3cold
+[    1.510839] pci 0000:01:00.0: bridge configuration invalid ([bus 00-00]), reconfiguring
+[    1.519177] pci 0000:02:01.0: [111d:8090] type 01 class 0x060400
+[    1.525305] pci 0000:02:01.0: enabling Extended Tags
+[    1.530446] pci 0000:02:01.0: PME# supported from D0 D3hot D3cold
+[    1.537147] pci 0000:02:02.0: [111d:8090] type 01 class 0x060400
+[    1.543275] pci 0000:02:02.0: enabling Extended Tags
+[    1.548425] pci 0000:02:02.0: PME# supported from D0 D3hot D3cold
+[    1.555167] pci 0000:02:03.0: [111d:8090] type 01 class 0x060400
+[    1.561294] pci 0000:02:03.0: enabling Extended Tags
+[    1.566453] pci 0000:02:03.0: PME# supported from D0 D3hot D3cold
+[    1.573180] pci 0000:02:0c.0: [111d:8090] type 01 class 0x060400
+[    1.579325] pci 0000:02:0c.0: enabling Extended Tags
+[    1.584466] pci 0000:02:0c.0: PME# supported from D0 D3hot D3cold
+[    1.591225] pci 0000:02:10.0: [111d:8090] type 01 class 0x060400
+[    1.597352] pci 0000:02:10.0: enabling Extended Tags
+[    1.602479] pci 0000:02:10.0: PME# supported from D0 D3hot D3cold
+[    1.609240] pci 0000:02:1f.0: [111d:8090] type 01 class 0x060400
+[    1.615368] pci 0000:02:1f.0: enabling Extended Tags
+[    1.620518] pci 0000:02:1f.0: PME# supported from D0 D3hot D3cold
+[    1.627233] pci 0000:02:01.0: bridge configuration invalid ([bus 00-00]), reconfiguring
+[    1.635238] pci 0000:02:02.0: bridge configuration invalid ([bus 00-00]), reconfiguring
+[    1.643256] pci 0000:02:03.0: bridge configuration invalid ([bus 00-00]), reconfiguring
+[    1.651256] pci 0000:02:0c.0: bridge configuration invalid ([bus 00-00]), reconfiguring
+[    1.659273] pci 0000:02:10.0: bridge configuration invalid ([bus 00-00]), reconfiguring
+[    1.667274] pci 0000:02:1f.0: bridge configuration invalid ([bus 00-00]), reconfiguring
+[    1.675631] pci 0000:03:00.0: [1095:3132] type 00 class 0x018000
+[    1.681705] pci 0000:03:00.0: reg 0x10: [mem 0x00000000-0x0000007f 64bit]
+[    1.688526] pci 0000:03:00.0: reg 0x18: [mem 0x00000000-0x00003fff 64bit]
+[    1.695323] pci 0000:03:00.0: reg 0x20: [io  0x0000-0x007f]
+[    1.700940] pci 0000:03:00.0: reg 0x30: [mem 0x00000000-0x0007ffff pref]
+[    1.707783] pci 0000:03:00.0: supports D1 D2
+[    1.712533] pci 0000:03:00.0: disabling ASPM on pre-1.1 PCIe device.  You can enable it with 'pcie_aspm=force'
+[    1.722530] pci_bus 0000:03: busn_res: [bus 03-ff] end is updated to 03
+[    1.729474] pci_bus 0000:04: busn_res: [bus 04-ff] end is updated to 04
+[    1.736394] pci_bus 0000:05: busn_res: [bus 05-ff] end is updated to 05
+[    1.743334] pci_bus 0000:06: busn_res: [bus 06-ff] end is updated to 06
+[    1.750249] pci_bus 0000:07: busn_res: [bus 07-ff] end is updated to 07
+[    1.757219] pci 0000:08:00.0: [11ab:4380] type 00 class 0x020000
+[    1.763291] pci 0000:08:00.0: reg 0x10: [mem 0x00000000-0x00003fff 64bit]
+[    1.770107] pci 0000:08:00.0: reg 0x18: [io  0x0000-0x00ff]
+[    1.775889] pci 0000:08:00.0: supports D1 D2
+[    1.780185] pci 0000:08:00.0: PME# supported from D0 D1 D2 D3hot D3cold
+[    1.787456] pci_bus 0000:08: busn_res: [bus 08-ff] end is updated to 08
+[    1.794088] pci_bus 0000:02: busn_res: [bus 02-ff] end is updated to 08
+[    1.800706] pci_bus 0000:01: busn_res: [bus 01-ff] end is updated to 08
+[    1.807527] pci 0000:00:00.0: BAR 14: assigned [mem 0x50000000-0x501fffff]
+[    1.814398] pci 0000:00:00.0: BAR 0: assigned [mem 0x4000000000-0x4000003fff 64bit pref]
+[    1.822493] pci 0000:00:00.0: BAR 13: assigned [io  0x1000-0x2fff]
+[    1.828682] pci 0000:01:00.0: BAR 14: assigned [mem 0x50000000-0x501fffff]
+[    1.835566] pci 0000:01:00.0: BAR 13: assigned [io  0x1000-0x2fff]
+[    1.841759] pci 0000:02:01.0: BAR 14: assigned [mem 0x50000000-0x500fffff]
+[    1.848648] pci 0000:02:1f.0: BAR 14: assigned [mem 0x50100000-0x501fffff]
+[    1.855522] pci 0000:02:01.0: BAR 13: assigned [io  0x1000-0x1fff]
+[    1.861697] pci 0000:02:1f.0: BAR 13: assigned [io  0x2000-0x2fff]
+[    1.867887] pci 0000:03:00.0: BAR 6: assigned [mem 0x50000000-0x5007ffff pref]
+[    1.875099] pci 0000:03:00.0: BAR 2: assigned [mem 0x50080000-0x50083fff 64bit]
+[    1.882418] pci 0000:03:00.0: BAR 0: assigned [mem 0x50084000-0x5008407f 64bit]
+[    1.889734] pci 0000:03:00.0: BAR 4: assigned [io  0x1000-0x107f]
+[    1.895839] pci 0000:02:01.0: PCI bridge to [bus 03]
+[    1.900811] pci 0000:02:01.0:   bridge window [io  0x1000-0x1fff]
+[    1.906907] pci 0000:02:01.0:   bridge window [mem 0x50000000-0x500fffff]
+[    1.913701] pci 0000:02:02.0: PCI bridge to [bus 04]
+[    1.918735] pci 0000:02:03.0: PCI bridge to [bus 05]
+[    1.923733] pci 0000:02:0c.0: PCI bridge to [bus 06]
+[    1.929134] pci 0000:02:10.0: PCI bridge to [bus 07]
+[    1.934152] pci 0000:08:00.0: BAR 0: assigned [mem 0x50100000-0x50103fff 64bit]
+[    1.941469] pci 0000:08:00.0: BAR 2: assigned [io  0x2000-0x20ff]
+[    1.947565] pci 0000:02:1f.0: PCI bridge to [bus 08]
+[    1.952537] pci 0000:02:1f.0:   bridge window [io  0x2000-0x2fff]
+[    1.958633] pci 0000:02:1f.0:   bridge window [mem 0x50100000-0x501fffff]
+[    1.965426] pci 0000:01:00.0: PCI bridge to [bus 02-08]
+[    1.970655] pci 0000:01:00.0:   bridge window [io  0x1000-0x2fff]
+[    1.976751] pci 0000:01:00.0:   bridge window [mem 0x50000000-0x501fffff]
+[    1.983544] pci 0000:00:00.0: PCI bridge to [bus 01-08]
+[    1.988771] pci 0000:00:00.0:   bridge window [io  0x1000-0x2fff]
+[    1.994861] pci 0000:00:00.0:   bridge window [mem 0x50000000-0x501fffff]
+[    2.002099] pcieport 0000:00:00.0: enabling device (0000 -> 0003)
+[    2.009007] pcieport 0000:00:00.0: Signaling PME with IRQ 44
+[    2.015481] pcieport 0000:00:00.0: AER enabled with IRQ 44
+[    2.021362] pcieport 0000:01:00.0: enabling device (0000 -> 0003)
+[    2.028070] pcieport 0000:02:01.0: enabling device (0000 -> 0003)
+[    2.039431] pcieport 0000:02:1f.0: enabling device (0000 -> 0003)
+[    2.058313] dma-pl330 7ff00000.dma: Loaded driver for PL330 DMAC-341330
+[    2.064945] dma-pl330 7ff00000.dma: 	DBUFF-1024x16bytes Num_Chans-8 Num_Peri-8 Num_Events-8
+[    2.089766] Serial: 8250/16550 driver, 4 ports, IRQ sharing enabled
+[    2.102921] SuperH (H)SCI(F) driver initialized
+[    2.108291] msm_serial: driver initialized
+[    2.113601] arm-smmu 7fb10000.iommu: probing hardware configuration...
+[    2.120131] arm-smmu 7fb10000.iommu: SMMUv1 with:
+[    2.124846] arm-smmu 7fb10000.iommu: 	stage 2 translation
+[    2.130245] arm-smmu 7fb10000.iommu: 	non-coherent table walk
+[    2.136002] arm-smmu 7fb10000.iommu: 	(IDR0.CTTW overridden by FW configuration)
+[    2.143385] arm-smmu 7fb10000.iommu: 	stream matching with 2 register groups
+[    2.150440] arm-smmu 7fb10000.iommu: 	1 context banks (1 stage-2 only)
+[    2.156964] arm-smmu 7fb10000.iommu: 	Supported page sizes: 0x60211000
+[    2.163501] arm-smmu 7fb10000.iommu: 	Stage-2: 40-bit IPA -> 40-bit PA
+[    2.170917] arm-smmu 7fb20000.iommu: probing hardware configuration...
+[    2.177445] arm-smmu 7fb20000.iommu: SMMUv1 with:
+[    2.182171] arm-smmu 7fb20000.iommu: 	stage 2 translation
+[    2.187570] arm-smmu 7fb20000.iommu: 	non-coherent table walk
+[    2.193334] arm-smmu 7fb20000.iommu: 	(IDR0.CTTW overridden by FW configuration)
+[    2.200716] arm-smmu 7fb20000.iommu: 	stream matching with 2 register groups
+[    2.207774] arm-smmu 7fb20000.iommu: 	1 context banks (1 stage-2 only)
+[    2.214304] arm-smmu 7fb20000.iommu: 	Supported page sizes: 0x60211000
+[    2.220844] arm-smmu 7fb20000.iommu: 	Stage-2: 40-bit IPA -> 40-bit PA
+[    2.227933] arm-smmu 7fb30000.iommu: probing hardware configuration...
+[    2.234479] arm-smmu 7fb30000.iommu: SMMUv1 with:
+[    2.239198] arm-smmu 7fb30000.iommu: 	stage 2 translation
+[    2.244617] arm-smmu 7fb30000.iommu: 	coherent table walk
+[    2.250027] arm-smmu 7fb30000.iommu: 	stream matching with 2 register groups
+[    2.257070] arm-smmu 7fb30000.iommu: 	1 context banks (1 stage-2 only)
+[    2.263599] arm-smmu 7fb30000.iommu: 	Supported page sizes: 0x60211000
+[    2.270136] arm-smmu 7fb30000.iommu: 	Stage-2: 40-bit IPA -> 40-bit PA
+[    2.307767] loop: module loaded
+[    2.315036] sata_sil24 0000:03:00.0: version 1.1
+[    2.319708] sata_sil24 0000:03:00.0: enabling device (0000 -> 0003)
+[    2.330042] scsi host0: sata_sil24
+[    2.334762] scsi host1: sata_sil24
+[    2.338648] ata1: SATA max UDMA/100 host m128@0x50084000 port 0x50080000 irq 51
+[    2.345974] ata2: SATA max UDMA/100 host m128@0x50084000 port 0x50082000 irq 51
+[    2.359339] libphy: Fixed MDIO Bus: probed
+[    2.366760] e1000e: Intel(R) PRO/1000 Network Driver - 3.2.6-k
+[    2.372590] e1000e: Copyright(c) 1999 - 2015 Intel Corporation.
+[    2.378741] igb: Intel(R) Gigabit Ethernet Network Driver - version 5.4.0-k
+[    2.385686] igb: Copyright (c) 2007-2014 Intel Corporation.
+[    2.391423] igbvf: Intel(R) Gigabit Virtual Function Network Driver - version 2.4.0-k
+[    2.399243] igbvf: Copyright (c) 2009 - 2012 Intel Corporation.
+[    2.405972] sky2: driver version 1.30
+[    2.410024] sky2 0000:08:00.0: enabling device (0000 -> 0003)
+[    2.416006] sky2 0000:08:00.0: Yukon-2 UL 2 chip revision 0
+[    2.421672] sky2 0000:08:00.0 (unnamed net_device) (uninitialized): Invalid MAC address, defaulting to random
+[    2.433618] sky2 0000:08:00.0 eth0: addr 4a:48:a6:e0:75:a7
+[    2.464175] libphy: smsc911x-mdio: probed
+[    2.469345] smsc911x 18000000.ethernet eth1: MAC Address: 00:02:f7:00:67:09
+[    2.476657] usbcore: registered new interface driver asix
+[    2.482190] usbcore: registered new interface driver ax88179_178a
+[    2.488397] usbcore: registered new interface driver cdc_ether
+[    2.494330] usbcore: registered new interface driver net1080
+[    2.500106] usbcore: registered new interface driver cdc_subset
+[    2.506131] usbcore: registered new interface driver zaurus
+[    2.511864] usbcore: registered new interface driver cdc_ncm
+[    2.518121] VFIO - User Level meta-driver version: 0.3
+[    2.526563] ehci_hcd: USB 2.0 'Enhanced' Host Controller (EHCI) Driver
+[    2.533091] ehci-pci: EHCI PCI platform driver
+[    2.537694] ehci-platform: EHCI generic platform driver
+[    2.543537] iommu: Adding device 7ffc0000.ehci to group 0
+[    2.549522] ehci-platform 7ffc0000.ehci: EHCI Host Controller
+[    2.555471] ehci-platform 7ffc0000.ehci: new USB bus registered, assigned bus number 1
+[    2.563918] ehci-platform 7ffc0000.ehci: irq 28, io mem 0x7ffc0000
+[    2.582790] ehci-platform 7ffc0000.ehci: USB 2.0 started, EHCI 1.00
+[    2.592190] hub 1-0:1.0: USB hub found
+[    2.596189] hub 1-0:1.0: 1 port detected
+[    2.601930] ehci-orion: EHCI orion driver
+[    2.606203] ehci-exynos: EHCI EXYNOS driver
+[    2.610614] ehci-msm: Qualcomm On-Chip EHCI Host Controller
+[    2.616392] ohci_hcd: USB 1.1 'Open' Host Controller (OHCI) Driver
+[    2.622611] ohci-pci: OHCI PCI platform driver
+[    2.627219] ohci-platform: OHCI generic platform driver
+[    2.632690] iommu: Adding device 7ffb0000.ohci to group 0
+[    2.638296] ohci-platform 7ffb0000.ohci: Generic Platform OHCI controller
+[    2.645132] ohci-platform 7ffb0000.ohci: new USB bus registered, assigned bus number 2
+[    2.653315] ohci-platform 7ffb0000.ohci: irq 27, io mem 0x7ffb0000
+[    2.740666] hub 2-0:1.0: USB hub found
+[    2.744528] hub 2-0:1.0: 1 port detected
+[    2.749640] ohci-exynos: OHCI EXYNOS driver
+[    2.754992] usbcore: registered new interface driver usb-storage
+[    2.768932] rtc-pl031 1c170000.rtc: rtc core: registered pl031 as rtc0
+[    2.776765] i2c /dev entries driver
+[    2.792711] mmci-pl18x 1c050000.mmci: mmc0: PL180 manf 41 rev0 at 0x1c050000 irq 32,0 (pio)
+[    2.801057] mmci-pl18x 1c050000.mmci: DMA channels RX none, TX none
+[    2.847227] sdhci: Secure Digital Host Controller Interface driver
+[    2.853554] sdhci: Copyright(c) Pierre Ossman
+[    2.861619] Synopsys Designware Multimedia Card Interface Driver
+[    2.869451] sdhci-pltfm: SDHCI platform and OF driver helper
+[    2.879424] leds-syscon 1c010000.apbregs:led0: registered LED vexpress:0
+[    2.886994] leds-syscon 1c010000.apbregs:led1: registered LED vexpress:1
+[    2.894095] leds-syscon 1c010000.apbregs:led2: registered LED vexpress:2
+[    2.901314] leds-syscon 1c010000.apbregs:led3: registered LED vexpress:3
+[    2.908419] leds-syscon 1c010000.apbregs:led4: registered LED vexpress:4
+[    2.915536] leds-syscon 1c010000.apbregs:led5: registered LED vexpress:5
+[    2.922759] leds-syscon 1c010000.apbregs:led6: registered LED vexpress:6
+[    2.929909] leds-syscon 1c010000.apbregs:led7: registered LED vexpress:7
+[    2.934921] usb 1-1: new high-speed USB device number 2 using ehci-platform
+[    2.943930] ledtrig-cpu: registered to indicate activity on CPUs
+[    2.951984] usbcore: registered new interface driver usbhid
+[    2.957538] usbhid: USB HID core driver
+[    2.961498] mhu 2b1f0000.mhu: ARM MHU Mailbox registered
+[    2.971301] NET: Registered protocol family 10
+[    2.977593] Segment Routing with IPv6
+[    2.981319] sit: IPv6, IPv4 and MPLS over IPv4 tunneling driver
+[    2.988062] NET: Registered protocol family 17
+[    2.992639] 9pnet: Installing 9P2000 support
+[    2.997009] Key type dns_resolver registered
+[    3.001276] start plist test
+[    3.008977] end plist test
+[    3.013567] registered taskstats version 1
+[    3.054873] scpi_protocol scpi: incorrect or no SCP firmware found
+[    3.061150] scpi_protocol: probe of scpi failed with error -110
+[    3.069019] input: smb@8000000:motherboard:gpio_keys as /devices/platform/smb@8000000/smb@8000000:motherboard/smb@8000000:motherboard:gpio_keys/input/input1
+[    3.085548] rtc-pl031 1c170000.rtc: setting system clock to 2019-11-22 12:20:27 UTC (1574425227)
+[    3.098057] sky2 0000:08:00.0 eth0: enabling interface
+[    3.101987] hub 1-1:1.0: USB hub found
+[    3.107027] IPv6: ADDRCONF(NETDEV_UP): eth0: link is not ready
+[    3.113019] hub 1-1:1.0: 4 ports detected
+[    3.115700] Generic PHY 18000000.ethernet-ffffffff:01: attached PHY driver [Generic PHY] (mii_bus:phy_addr=18000000.ethernet-ffffffff:01, irq=POLL)
+[    3.130979] smsc911x 18000000.ethernet eth1: SMSC911x/921x identified at 0xffff00000d740000, IRQ: 31
+[    3.140531] IPv6: ADDRCONF(NETDEV_UP): eth1: link is not ready
+[    3.782912] atkbd serio0: keyboard reset failed on 1c060000.kmi
+[    4.521110] ata1: SATA link up 3.0 Gbps (SStatus 123 SControl 0)
+[    4.529449] ata1.00: ATA-9: SanDisk SSD PLUS 120GB, UE5000RL, max UDMA/133
+[    4.536328] ata1.00: 234455040 sectors, multi 1: LBA48 NCQ (depth 31/32)
+[    4.548290] ata1.00: configured for UDMA/100
+[    4.554769] scsi 0:0:0:0: Direct-Access     ATA      SanDisk SSD PLUS 00RL PQ: 0 ANSI: 5
+[    4.566908] sd 0:0:0:0: [sda] 234455040 512-byte logical blocks: (120 GB/112 GiB)
+[    4.574627] sd 0:0:0:0: [sda] Write Protect is off
+[    4.579447] sd 0:0:0:0: [sda] Mode Sense: 00 3a 00 00
+[    4.584688] sd 0:0:0:0: [sda] Write cache: enabled, read cache: enabled, doesn't support DPO or FUA
+[    4.602466] sd 0:0:0:0: [sda] Attached SCSI disk
+[    5.030975] atkbd serio1: keyboard reset failed on 1c070000.kmi
+[    5.047060] random: fast init done
+[    5.203031] IPv6: ADDRCONF(NETDEV_CHANGE): eth1: link becomes ready
+[    5.222858] Sending DHCP requests .
+[    6.100200] sky2 0000:08:00.0 eth0: Link is up at 1000 Mbps, full duplex, flow control rx
+[    6.111887] IPv6: ADDRCONF(NETDEV_CHANGE): eth0: link becomes ready
+[    6.618994] ata2: SATA link down (SStatus 0 SControl 0)
+[    7.598957] .., OK
+[   11.769066] IP-Config: Got DHCP answer from 10.66.16.10, my address is 10.66.16.40
+[   11.776635] IP-Config: Complete:
+[   11.779904]      device=eth1, hwaddr=00:02:f7:00:67:09, ipaddr=10.66.16.40, mask=255.255.254.0, gw=10.66.16.1
+[   11.789772]      host=10.66.16.40, domain=lkftlab, nis-domain=(none)
+[   11.796132]      bootserver=0.0.0.0, rootserver=10.66.16.123, rootpath=     nameserver0=10.66.16.10
+[   11.806446] sky2 0000:08:00.0 eth0: disabling interface
+[   11.813265] ALSA device list:
+[   11.816263]   No soundcards found.
+[   11.820657] uart-pl011 7ff80000.uart: no DMA platform data
+[   11.873584] VFS: Mounted root (nfs filesystem) on device 0:16.
+[   11.880607] devtmpfs: mounted
+[   11.888156] Freeing unused kernel memory: 1728K
+
+Welcome to [1mLinux-Kernel-Functional-Testing 2.5+linaro[0m!
+
+[   13.104394] random: systemd: uninitialized urandom read (16 bytes read)
+[   13.733656] random: systemd: uninitialized urandom read (16 bytes read)
+[[0;32m  OK  [0m] Reached target Swap.
+[   13.755259] random: systemd: uninitialized urandom read (16 bytes read)
+[[0;32m  OK  [0m] Created slice System Slice.
+[[0;32m  OK  [0m] Listening on udev Control Socket.
+[[0;32m  OK  [0m] Listening on Journal Socket (/dev/log).
+[[0;32m  OK  [0m] Created slice system-getty.slice.
+[[0;32m  OK  [0m] Listening on /dev/initctl Compatibility Named Pipe.
+[[0;32m  OK  [0m] Listening on Journal Socket.
+         Mounting Temporary Directory (/tmp)...
+         Mounting POSIX Message Queue File System...
+[[0;32m  OK  [0m] Listening on Syslog Socket.
+         Mounting Kernel Debug File System...
+         Mounting Huge Pages File System...
+[[0;32m  OK  [0m] Created slice system-serial\x2dgetty.slice.
+[[0;32m  OK  [0m] Started Dispatch Password Requests to Console Directory Watch.
+[[0;32m  OK  [0m] Listening on Network Service Netlink Socket.
+         Starting Create list of required st…ce nodes for the current kernel...
+[[0;32m  OK  [0m] Started Forward Password Requests to Wall Directory Watch.
+[[0;32m  OK  [0m] Reached target Paths.
+         Starting Load Kernel Modules...
+         Starting Remount Root and Kernel File Systems...
+[[0;32m  OK  [0m] Listening on udev Kernel Socket.
+         Starting udev Coldplug all Devices...
+[[0;32m  OK  [0m] Created slice User and Session Slice.
+[[0;32m  OK  [0m] Reached target Slices.
+[[0;32m  OK  [0m] Reached target Remote File Systems.
+[[0;32m  OK  [0m] Listening on Journal Audit Socket.
+[   14.241530] fuse init (API version 7.26)
+         Starting Journal Service...
+[[0;32m  OK  [0m] Mounted Temporary Directory (/tmp).
+[[0;32m  OK  [0m] Mounted POSIX Message Queue File System.
+[[0;32m  OK  [0m] Mounted Kernel Debug File System.
+[[0;32m  OK  [0m] Mounted Huge Pages File System.
+[[0;32m  OK  [0m] Started Create list of required sta…vice nodes for the current kernel.
+[[0;32m  OK  [0m] Started Load Kernel Modules.
+[[0;32m  OK  [0m] Started Remount Root and Kernel File Systems.
+         Starting Rebuild Hardware Database...
+         Starting Create System Users...
+         Mounting Kernel Configuration File System...
+         Starting Apply Kernel Variables...
+         Mounting FUSE Control File System...
+[[0;32m  OK  [0m] Mounted Kernel Configuration File System.
+[[0;32m  OK  [0m] Mounted FUSE Control File System.
+[[0;32m  OK  [0m] Started Apply Kernel Variables.
+[[0;32m  OK  [0m] Started Journal Service.
+         Starting Flush Journal to Persistent Storage...
+[[0;32m  OK  [0m] Started Flush Journal to Persistent Storage.
+[[0;32m  OK  [0m] Started Create System Users.
+         Starting Create Static Device Nodes in /dev...
+[[0;32m  OK  [0m] Started udev Coldplug all Devices.
+[[0;32m  OK  [0m] Started Create Static Device Nodes in /dev.
+[[0;32m  OK  [0m] Reached target Local File Systems (Pre).
+         Mounting /var/volatile...
+[[0;32m  OK  [0m] Reached target Containers.
+[[0;32m  OK  [0m] Mounted /var/volatile.
+         Starting Load/Save Random Seed...
+[[0;32m  OK  [0m] Reached target Local File Systems.
+         Starting Rebuild Dynamic Linker Cache...
+         Starting Rebuild Journal Catalog...
+         Starting Create Volatile Files and Directories...
+[[0;32m  OK  [0m] Started Load/Save Random Seed.
+[[0;32m  OK  [0m] Started Rebuild Journal Catalog.
+[[0;32m  OK  [0m] Started Create Volatile Files and Directories.
+         Starting Run pending postinsts...
+         Starting Opkg first boot configure...
+         Starting Network Time Synchronization...
+         Starting Update UTMP about System Boot/Shutdown...
+[[0;32m  OK  [0m] Started Update UTMP about System Boot/Shutdown.
+[[0;32m  OK  [0m] Started Network Time Synchronization.
+[[0;32m  OK  [0m] Reached target System Time Synchronized.
+[[0;32m  OK  [0m] Started Rebuild Hardware Database.
+         Starting udev Kernel Device Manager...
+[[0;32m  OK  [0m] Started Opkg first boot configure.
+[[0;32m  OK  [0m] Started Run pending postinsts.
+[[0;32m  OK  [0m] Started udev Kernel Device Manager.
+         Starting Network Service...
+[   20.041046] sky2 0000:08:00.0 enp8s0: renamed from eth0
+[[0;32m  OK  [0m] Started Network Service.
+[[0;32m  OK  [0m] Found device /dev/ttyAMA0.
+[[0;32m  OK  [0m] Started Rebuild Dynamic Linker Cache.
+[   21.120666] random: crng init done
+[   21.124061] random: 7 urandom warning(s) missed due to ratelimiting
+         Starting Update is Completed...
+         Starting Network Name Resolution...
+[[0;32m  OK  [0m] Started Update is Completed.
+[[0;32m  OK  [0m] Reached target System Initialization.
+[[0;32m  OK  [0m] Listening on RPCbind Server Activation Socket.
+[[0;32m  OK  [0m] Listening on Avahi mDNS/DNS-SD Stack Activation Socket.
+[[0;32m  OK  [0m] Listening on D-Bus System Message Bus Socket.
+[[0;32m  OK  [0m] Started Daily Cleanup of Temporary Directories.
+         Starting sshd.socket.
+[[0;32m  OK  [0m] Started Daily rotation of log files.
+[[0;32m  OK  [0m] Reached target Timers.
+[[0;32m  OK  [0m] Listening on sshd.socket.
+[[0;32m  OK  [0m] Reached target Sockets.
+[[0;32m  OK  [0m] Reached target Basic System.
+         Starting Login Service...
+[[0;32m  OK  [0m] Started TEE Supplicant.
+         Starting Entropy Daemon based on the HAVEGE algorithm...
+[[0;32m  OK  [0m] Started D-Bus System Message Bus.
+[[0;32m  OK  [0m] Started Login Service.
+         Starting Network Manager...
+[[0;32m  OK  [0m] Started Kernel Logging Service.
+[[0;32m  OK  [0m] Started System Logging Service.
+[[0;32m  OK  [0m] Started Periodic Command Scheduler.
+         Starting Resize root filesystem to fit available disk space...
+[[0;32m  OK  [0m] Started Job spooling tools.
+         Starting Avahi mDNS/DNS-SD Stack...
+[[0;32m  OK  [0m] Started Network Name Resolution.
+[[0;32m  OK  [0m] Started Entropy Daemon based on the HAVEGE algorithm.
+[[0;32m  OK  [0m] Reached target Host and Network Name Lookups.
+[[0;32m  OK  [0m] Started Avahi mDNS/DNS-SD Stack.
+         Starting Hostname Service...
+[[0;32m  OK  [0m] Started Network Manager.
+[[0;32m  OK  [0m] Started Hostname Service.
+[[0;32m  OK  [0m] Started Resize root filesystem to fit available disk space.
+         Starting Network Manager Script Dispatcher Service...
+[[0;32m  OK  [0m] Reached target Network.
+         Starting DNS forwarder and DHCP server...
+         Starting Permit User Sessions...
+[[0;32m  OK  [0m] Started Network Manager Script Dispatcher Service.
+[[0;32m  OK  [0m] Started Permit User Sessions.
+[[0;32m  OK  [0m] Started DNS forwarder and DHCP server.
+[[0;32m  OK  [0m] Started Serial Getty on ttyAMA0.
+[[0;32m  OK  [0m] Started Getty on tty1.
+[[0;32m  OK  [0m] Reached target Login Prompts.
+[[0;32m  OK  [0m] Reached target Multi-User System.
+         Starting Update UTMP about System Runlevel Changes...
+[   24.890485] IPv6: ADDRCONF(NETDEV_UP): enp8s0: link is not ready
+[   24.899991] sky2 0000:08:00.0 enp8s0: enabling interface
+[   24.905893] IPv6: ADDRCONF(NETDEV_UP): enp8s0: link is not ready
+[[0;32m  OK  [0m] Started Update UTMP about System Runlevel Changes.
+
+Linux-Kernel-Functional-Testing 2.5+linaro juno ttyAMA0
+
+juno login: root
+root
+[   26.738428] audit: type=1006 audit(1574425251.148:2): pid=2596 uid=0 old-auid=4294967295 auid=0 tty=(none) old-ses=4294967295 ses=1 res=1
+7[r[999;999H[6n[   27.774954] sky2 0000:08:00.0 enp8s0: Link is up at 1000 Mbps, full duplex, flow control rx
+[   27.783360] IPv6: ADDRCONF(NETDEV_CHANGE): enp8s0: link becomes ready
+root@juno:~# 
+
+root@juno:~# #
+#
+root@juno:~# export SHELL=/bin/sh
+export SHELL=/bin/sh
+root@juno:~# . /lava-1019767/environment
+. /lava-1019767/environment
+root@juno:~# /lava-1019767/bin/lava-test-runner /lava-1019767/0
+/lava-1019767/bin/lava-test-runner /lava-1019767/0
++ export TESTRUN_ID=0_prep-inline
++ TESTRUN_ID=0_prep-inline
++ cd /lava-1019767/0/tests/0_prep-inline
+++ cat uuid
++ UUID=1019767_1.4.2.4.1
++ set +x
+<LAVA_SIGNAL_STARTRUN 0_prep-inline 1019767_1.4.2.4.1>
+++ lava-target-storage SATA
++ export STORAGE_DEV=/dev/disk/by-id/ata-SanDisk_SSD_PLUS_120GB_190703A00248
++ STORAGE_DEV=/dev/disk/by-id/ata-SanDisk_SSD_PLUS_120GB_190703A00248
++ test -n /dev/disk/by-id/ata-SanDisk_SSD_PLUS_120GB_190703A00248
++ echo y
++ mkfs -t ext4 /dev/disk/by-id/ata-SanDisk_SSD_PLUS_120GB_190703A00248
+mke2fs 1.43.8 (1-Jan-2018)
+Discarding device blocks:     4096/29306880 4722688/2930688012062720/2930688018878464/2930688026218496/29306880                 done                            
+Creating filesystem with 29306880 4k blocks and 7331840 inodes
+Filesystem UUID: 9ef64d8d-a23c-4284-93f0-70b53a9c5504
+Superblock backups stored on blocks: 
+	32768, 98304, 163840, 229376, 294912, 819200, 884736, 1605632, 2654208, 
+	4096000, 7962624, 11239424, 20480000, 23887872
+
+Allocating group tables:   0/895       done                            
+Writing inode tables:   0/895       done                            
+Creating journal (131072 blocks): done
+Writing superblocks and filesystem accounting information:   0/895       done
+
++ mkdir -p /scratch
++ mount /dev/disk/by-id/ata-SanDisk_SSD_PLUS_120GB_190703A00248 /scratch
+[   44.400280] EXT4-fs (sda): mounted filesystem with ordered data mode. Opts: (null)
++ echo mounted
+mounted
++ df -h
+Filesystem                                                                    Size  Used Avail Use% Mounted on
+10.66.16.123:/var/lib/lava/dispatcher/tmp/1019767/extract-nfsrootfs-3fstuc8a  667G   25G  643G   4% /
+devtmpfs                                                                      3.9G     0  3.9G   0% /dev
+tmpfs                                                                         3.9G     0  3.9G   0% /dev/shm
+tmpfs                                                                         3.9G  8.4M  3.9G   1% /run
+tmpfs                                                                         3.9G     0  3.9G   0% /sys/fs/cgroup
+tmpfs                                                                         3.9G     0  3.9G   0% /tmp
+tmpfs                                                                         3.9G   20K  3.9G   1% /var/volatile
+tmpfs                                                                         796M     0  796M   0% /run/user/0
+/dev/sda                                                                      110G   60M  104G   1% /scratch
++ mount
+10.66.16.123:/var/lib/lava/dispatcher/tmp/1019767/extract-nfsrootfs-3fstuc8a on / type nfs (rw,relatime,vers=3,rsize=4096,wsize=4096,namlen=255,hard,nolock,proto=tcp,timeo=600,retrans=2,sec=sys,mountaddr=10.66.16.123,mountvers=3,mountproto=tcp,local_lock=all,addr=10.66.16.123)
+devtmpfs on /dev type devtmpfs (rw,relatime,size=4061836k,nr_inodes=1015459,mode=755)
+sysfs on /sys type sysfs (rw,nosuid,nodev,noexec,relatime)
+proc on /proc type proc (rw,relatime)
+tmpfs on /dev/shm type tmpfs (rw,nosuid,nodev)
+devpts on /dev/pts type devpts (rw,relatime,gid=5,mode=620,ptmxmode=000)
+tmpfs on /run type tmpfs (rw,nosuid,nodev,mode=755)
+tmpfs on /sys/fs/cgroup type tmpfs (ro,nosuid,nodev,noexec,mode=755)
+cgroup on /sys/fs/cgroup/unified type cgroup2 (rw,nosuid,nodev,noexec,relatime,nsdelegate)
+cgroup on /sys/fs/cgroup/systemd type cgroup (rw,nosuid,nodev,noexec,relatime,xattr,name=systemd)
+pstore on /sys/fs/pstore type pstore (rw,nosuid,nodev,noexec,relatime)
+cgroup on /sys/fs/cgroup/cpuset type cgroup (rw,nosuid,nodev,noexec,relatime,cpuset)
+cgroup on /sys/fs/cgroup/devices type cgroup (rw,nosuid,nodev,noexec,relatime,devices)
+cgroup on /sys/fs/cgroup/blkio type cgroup (rw,nosuid,nodev,noexec,relatime,blkio)
+cgroup on /sys/fs/cgroup/memory type cgroup (rw,nosuid,nodev,noexec,relatime,memory)
+cgroup on /sys/fs/cgroup/perf_event type cgroup (rw,nosuid,nodev,noexec,relatime,perf_event)
+cgroup on /sys/fs/cgroup/pids type cgroup (rw,nosuid,nodev,noexec,relatime,pids)
+cgroup on /sys/fs/cgroup/cpu,cpuacct type cgroup (rw,nosuid,nodev,noexec,relatime,cpu,cpuacct)
+cgroup on /sys/fs/cgroup/hugetlb type cgroup (rw,nosuid,nodev,noexec,relatime,hugetlb)
+tmpfs on /tmp type tmpfs (rw,nosuid,nodev)
+mqueue on /dev/mqueue type mqueue (rw,relatime)
+debugfs on /sys/kernel/debug type debugfs (rw,relatime)
+hugetlbfs on /dev/hugepages type hugetlbfs (rw,relatime,pagesize=2M)
+configfs on /sys/kernel/config type configfs (rw,relatime)
+fusectl on /sys/fs/fuse/connections type fusectl (rw,relatime)
+tmpfs on /var/volatile type tmpfs (rw,relatime)
+tmpfs on /run/user/0 type tmpfs (rw,nosuid,nodev,relatime,size=814176k,mode=700)
+/dev/sda on /scratch type ext4 (rw,relatime,data=ordered)
++ set +x
+<LAVA_SIGNAL_ENDRUN 0_prep-inline 1019767_1.4.2.4.1>
++ export TESTRUN_ID=1_timesync-off
++ TESTRUN_ID=1_timesync-off
++ cd /lava-1019767/0/tests/1_timesync-off
+++ cat uuid
++ UUID=1019767_1.4.2.4.5
++ set +x
+<LAVA_SIGNAL_STARTRUN 1_timesync-off 1019767_1.4.2.4.5>
++ systemctl stop systemd-timesyncd
++ set +x
+<LAVA_SIGNAL_ENDRUN 1_timesync-off 1019767_1.4.2.4.5>
++ export TESTRUN_ID=2_kselftest
++ TESTRUN_ID=2_kselftest
++ cd /lava-1019767/0/tests/2_kselftest
+++ cat uuid
++ UUID=1019767_1.4.2.4.9
++ set +x
+<LAVA_SIGNAL_STARTRUN 2_kselftest 1019767_1.4.2.4.9>
++ cd ./automated/linux/kselftest/
++ ./kselftest.sh -t kselftest_armhf.tar.gz -s false -u '' -L '' -S skipfile-lkft.yaml -b juno-r2 -g 4.14 -e production -p /opt/kselftests/mainline/
+INFO: Generating a skipfile based on /lava-1019767/0/tests/2_kselftest/automated/linux/kselftest/skipfile-lkft.yaml
+INFO: Using the following generated skipfile contents (until EOF):
+breakpoint_test_arm64
+bridge_brouter.sh
+ftracetest
+mq_perf_tests
+nft_flowtable.sh
+nft_trans_stress.sh
+run_param_test.sh
+step_after_suspend_test
+INFO: EOF
+kselftests found on rootfs
+========================================
+skiplist:
+selftests: tmpskipdir: breakpoint_test_arm64
+selftests: tmpskipdir: bridge_brouter.sh
+selftests: tmpskipdir: ftracetest
+selftests: tmpskipdir: mq_perf_tests
+selftests: tmpskipdir: nft_flowtable.sh
+selftests: tmpskipdir: nft_trans_stress.sh
+selftests: tmpskipdir: run_param_test.sh
+selftests: tmpskipdir: step_after_suspend_test
+
+========================================
+[   45.288600] kselftest: Running tests in android
+[   45.834753] kselftest: Running tests in bpf
+[   46.037573] audit: type=1701 audit(1574425270.387:3): auid=4294967295 uid=0 gid=0 ses=4294967295 pid=2736 comm=\"test_verifier\" exe=\"/opt/kselftests/mainline/bpf/test_verifier\" sig=6 res=1
+[   46.154055] audit: type=1701 audit(1574425270.503:4): auid=4294967295 uid=0 gid=0 ses=4294967295 pid=2767 comm=\"test_tag\" exe=\"/opt/kselftests/mainline/bpf/test_tag\" sig=6 res=1
+[   47.126085] audit: type=1701 audit(1574425271.474:5): auid=4294967295 uid=0 gid=0 ses=4294967295 pid=2792 comm=\"test_lru_map\" exe=\"/opt/kselftests/mainline/bpf/test_lru_map\" sig=6 res=1
+[   53.630296] audit: type=1701 audit(1574425277.974:6): auid=4294967295 uid=0 gid=0 ses=4294967295 pid=2807 comm=\"test_lpm_map\" exe=\"/opt/kselftests/mainline/bpf/test_lpm_map\" sig=6 res=1
+[   53.760656] audit: type=1701 audit(1574425278.106:7): auid=4294967295 uid=0 gid=0 ses=4294967295 pid=2819 comm=\"test_progs\" exe=\"/opt/kselftests/mainline/bpf/test_progs\" sig=6 res=1
+TAP version 13
+13: _ TAP
+1..1
+: _ 1..1
+# selftests android run.sh
+android: run.sh_ #
+# ion_test.sh No /dev/ion device found
+No: /dev/ion_device #
+# ion_test.sh May be CONFIG_ION is not set
+May: be_CONFIG_ION #
+[SKIP] 1 selftests android run.sh # SKIP
+selftests: android_run.sh [SKIP]
+TAP version 13
+13: _ TAP
+1..50
+: _ 1..50
+# selftests bpf test_verifier
+bpf: test_verifier_ #
+./kselftest/runner.sh line 28  2736 Aborted                 (core dumped) ./$BASENAME_TEST 2>&1
+28: 2736_Aborted ./kselftest/runner.sh
+# test_verifier test_verifier.c405 update_map Assertion `!bpf_map_update_elem(fd, &index, &value, 0)' failed.
+test_verifier.c405: update_map_Assertion #
+[FAIL] 1 selftests bpf test_verifier
+selftests: bpf_test_verifier [FAIL]
+# selftests bpf test_tag
+bpf: test_tag_ #
+./kselftest/runner.sh line 28  2767 Aborted                 (core dumped) ./$BASENAME_TEST 2>&1
+28: 2767_Aborted ./kselftest/runner.sh
+# test_tag test_tag.c62 bpf_try_load_prog Assertion `fd_prog > 0' failed.
+test_tag.c62: bpf_try_load_prog_Assertion #
+[FAIL] 2 selftests bpf test_tag
+selftests: bpf_test_tag [FAIL]
+# selftests bpf test_maps
+bpf: test_maps_ #
+# helper_fill_hashmap(261)FAILfailed to create hashmap err Invalid argument, flags 0x40
+to: create_hashmap #
+[FAIL] 3 selftests bpf test_maps
+selftests: bpf_test_maps [FAIL]
+# selftests bpf test_lru_map
+bpf: test_lru_map_ #
+./kselftest/runner.sh line 28  2792 Aborted                 (core dumped) ./$BASENAME_TEST 2>&1
+28: 2792_Aborted ./kselftest/runner.sh
+# nr_cpus6
+: _ #
+# 
+: _ #
+# test_lru_sanity0 (map_type9 map_flags0x0) test_lru_map test_lru_map.c221 test_lru_sanity0 Assertion `!bpf_map_lookup_elem_with_ref_bit(lru_map_fd, key, value)' failed.
+(map_type9: map_flags0x0)_test_lru_map #
+[FAIL] 4 selftests bpf test_lru_map
+selftests: bpf_test_lru_map [FAIL]
+# selftests bpf test_lpm_map
+bpf: test_lpm_map_ #
+# test_lpm_map test_lpm_map.c289 test_lpm_map Assertion `!r' failed.
+test_lpm_map.c289: test_lpm_map_Assertion #
+./kselftest/runner.sh line 28  2807 Aborted                 (core dumped) ./$BASENAME_TEST 2>&1
+28: 2807_Aborted ./kselftest/runner.sh
+[FAIL] 5 selftests bpf test_lpm_map
+selftests: bpf_test_lpm_map [FAIL]
+# selftests bpf test_progs
+bpf: test_progs_ #
+./kselftest/runner.sh line 28  2819 Aborted                 (core dumped) ./$BASENAME_TEST 2>&1
+28: 2819_Aborted ./kselftest/runner.sh
+# libbpf BTF is required, but is missing or corrupted.
+BTF: is_required, #
+# libbpf BTF is required, but is missing or corrupted.
+BTF: is_required, #
+# test_progs prog_tests/bpf_obj_id.c53 test_bpf_obj_id Assertion `!err' failed.
+prog_tests/bpf_obj_id.c53: test_bpf_obj_id_Assertion #
+[FAIL] 6 selftests bpf test_progs
+selftests: bpf_test_progs [FAIL]
+# selftests bpf test_align
+bpf: test_align_ #
+# Test   0 mov ... Failed to find match 1 R3_w=inv2
+0: mov_... #
+# 0 R1=ctx(id=0,off=0,imm=0) R10=fp0
+R1=ctx(id=0,off=0,imm=0): R10=fp0_ #
+# 0 (b7) r3 = 2
+(b7): r3_= #
+# 1 R1=ctx(id=0,off=0,imm=0) R3=inv2 R10=fp0
+R1=ctx(id=0,off=0,imm=0): R3=inv2_R10=fp0 #
+# 1 (b7) r3 = 4
+(b7): r3_= #
+# 2 R1=ctx(id=0,off=0,imm=0) R3=inv4 R10=fp0
+R1=ctx(id=0,off=0,imm=0): R3=inv4_R10=fp0 #
+# 2 (b7) r3 = 8
+(b7): r3_= #
+# 3 R1=ctx(id=0,off=0,imm=0) R3=inv8 R10=fp0
+R1=ctx(id=0,off=0,imm=0): R3=inv8_R10=fp0 #
+# 3 (b7) r3 = 16
+(b7): r3_= #
+# 4 R1=ctx(id=0,off=0,imm=0) R3=inv16 R10=fp0
+R1=ctx(id=0,off=0,imm=0): R3=inv16_R10=fp0 #
+# 4 (b7) r3 = 32
+(b7): r3_= #
+# 5 R1=ctx(id=0,off=0,imm=0) R3=inv32 R10=fp0
+R1=ctx(id=0,off=0,imm=0): R3=inv32_R10=fp0 #
+# 5 (b7) r0 = 0
+(b7): r0_= #
+# 6 R0=inv0 R1=ctx(id=0,off=0,imm=0) R3=inv32 R10=fp0
+R0=inv0: R1=ctx(id=0,off=0,imm=0)_R3=inv32 #
+# 6 (95) exit
+(95): exit_ #
+# processed 7 insns, stack depth 0
+7: insns,_stack #
+# FAIL
+: _ #
+# Test   1 shift ... Failed to find match 1 R3_w=inv1
+1: shift_... #
+# 0 R1=ctx(id=0,off=0,imm=0) R10=fp0
+R1=ctx(id=0,off=0,imm=0): R10=fp0_ #
+# 0 (b7) r3 = 1
+(b7): r3_= #
+# 1 R1=ctx(id=0,off=0,imm=0) R3=inv1 R10=fp0
+R1=ctx(id=0,off=0,imm=0): R3=inv1_R10=fp0 #
+# 1 (67) r3 <<= 1
+(67): r3_<<= #
+# 2 R1=ctx(id=0,off=0,imm=0) R3=inv2 R10=fp0
+R1=ctx(id=0,off=0,imm=0): R3=inv2_R10=fp0 #
+# 2 (67) r3 <<= 1
+(67): r3_<<= #
+# 3 R1=ctx(id=0,off=0,imm=0) R3=inv4 R10=fp0
+R1=ctx(id=0,off=0,imm=0): R3=inv4_R10=fp0 #
+# 3 (67) r3 <<= 1
+(67): r3_<<= #
+# 4 R1=ctx(id=0,off=0,imm=0) R3=inv8 R10=fp0
+R1=ctx(id=0,off=0,imm=0): R3=inv8_R10=fp0 #
+# 4 (67) r3 <<= 1
+(67): r3_<<= #
+# 5 R1=ctx(id=0,off=0,imm=0) R3=inv16 R10=fp0
+R1=ctx(id=0,off=0,imm=0): R3=inv16_R10=fp0 #
+# 5 (77) r3 >>= 4
+(77): r3_>>= #
+# 6 R1=ctx(id=0,off=0,imm=0) R3=inv1 R10=fp0
+R1=ctx(id=0,off=0,imm=0): R3=inv1_R10=fp0 #
+# 6 (b7) r4 = 32
+(b7): r4_= #
+# 7 R1=ctx(id=0,off=0,imm=0) R3=inv1 R4=inv32 R10=fp0
+R1=ctx(id=0,off=0,imm=0): R3=inv1_R4=inv32 #
+# 7 (77) r4 >>= 1
+(77): r4_>>= #
+# 8 R1=ctx(id=0,off=0,imm=0) R3=inv1 R4=inv16 R10=fp0
+R1=ctx(id=0,off=0,imm=0): R3=inv1_R4=inv16 #
+# 8 (77) r4 >>= 1
+(77): r4_>>= #
+# 9 R1=ctx(id=0,off=0,imm=0) R3=inv1 R4=inv8 R10=fp0
+R1=ctx(id=0,off=0,imm=0): R3=inv1_R4=inv8 #
+# 9 (77) r4 >>= 1
+(77): r4_>>= #
+# 10 R1=ctx(id=0,off=0,imm=0) R3=inv1 R4=inv4 R10=fp0
+R1=ctx(id=0,off=0,imm=0): R3=inv1_R4=inv4 #
+# 10 (77) r4 >>= 1
+(77): r4_>>= #
+# 11 R1=ctx(id=0,off=0,imm=0) R3=inv1 R4=inv2 R10=fp0
+R1=ctx(id=0,off=0,imm=0): R3=inv1_R4=inv2 #
+# 11 (b7) r0 = 0
+(b7): r0_= #
+# 12 R0=inv0 R1=ctx(id=0,off=0,imm=0) R3=inv1 R4=inv2 R10=fp0
+R0=inv0: R1=ctx(id=0,off=0,imm=0)_R3=inv1 #
+# 12 (95) exit
+(95): exit_ #
+# processed 13 insns, stack depth 0
+13: insns,_stack #
+# FAIL
+: _ #
+# Test   2 addsub ... Failed to find match 1 R3_w=inv4
+2: addsub_... #
+# 0 R1=ctx(id=0,off=0,imm=0) R10=fp0
+R1=ctx(id=0,off=0,imm=0): R10=fp0_ #
+# 0 (b7) r3 = 4
+(b7): r3_= #
+# 1 R1=ctx(id=0,off=0,imm=0) R3=inv4 R10=fp0
+R1=ctx(id=0,off=0,imm=0): R3=inv4_R10=fp0 #
+# 1 (07) r3 += 4
+(07): r3_+= #
+# 2 R1=ctx(id=0,off=0,imm=0) R3=inv8 R10=fp0
+R1=ctx(id=0,off=0,imm=0): R3=inv8_R10=fp0 #
+# 2 (07) r3 += 2
+(07): r3_+= #
+# 3 R1=ctx(id=0,off=0,imm=0) R3=inv10 R10=fp0
+R1=ctx(id=0,off=0,imm=0): R3=inv10_R10=fp0 #
+# 3 (b7) r4 = 8
+(b7): r4_= #
+# 4 R1=ctx(id=0,off=0,imm=0) R3=inv10 R4=inv8 R10=fp0
+R1=ctx(id=0,off=0,imm=0): R3=inv10_R4=inv8 #
+# 4 (07) r4 += 4
+(07): r4_+= #
+# 5 R1=ctx(id=0,off=0,imm=0) R3=inv10 R4=inv12 R10=fp0
+R1=ctx(id=0,off=0,imm=0): R3=inv10_R4=inv12 #
+# 5 (07) r4 += 2
+(07): r4_+= #
+# 6 R1=ctx(id=0,off=0,imm=0) R3=inv10 R4=inv14 R10=fp0
+R1=ctx(id=0,off=0,imm=0): R3=inv10_R4=inv14 #
+# 6 (b7) r0 = 0
+(b7): r0_= #
+# 7 R0=inv0 R1=ctx(id=0,off=0,imm=0) R3=inv10 R4=inv14 R10=fp0
+R0=inv0: R1=ctx(id=0,off=0,imm=0)_R3=inv10 #
+# 7 (95) exit
+(95): exit_ #
+# processed 8 insns, stack depth 0
+8: insns,_stack #
+# FAIL
+: _ #
+# Test   3 mul ... Failed to find match 1 R3_w=inv7
+3: mul_... #
+# 0 R1=ctx(id=0,off=0,imm=0) R10=fp0
+R1=ctx(id=0,off=0,imm=0): R10=fp0_ #
+# 0 (b7) r3 = 7
+(b7): r3_= #
+# 1 R1=ctx(id=0,off=0,imm=0) R3=inv7 R10=fp0
+R1=ctx(id=0,off=0,imm=0): R3=inv7_R10=fp0 #
+# 1 (27) r3 *= 1
+(27): r3_*= #
+# 2 R1=ctx(id=0,off=0,imm=0) R3=inv7 R10=fp0
+R1=ctx(id=0,off=0,imm=0): R3=inv7_R10=fp0 #
+# 2 (27) r3 *= 2
+(27): r3_*= #
+# 3 R1=ctx(id=0,off=0,imm=0) R3=inv14 R10=fp0
+R1=ctx(id=0,off=0,imm=0): R3=inv14_R10=fp0 #
+# 3 (27) r3 *= 4
+(27): r3_*= #
+# 4 R1=ctx(id=0,off=0,imm=0) R3=inv56 R10=fp0
+R1=ctx(id=0,off=0,imm=0): R3=inv56_R10=fp0 #
+# 4 (b7) r0 = 0
+(b7): r0_= #
+# 5 R0=inv0 R1=ctx(id=0,off=0,imm=0) R3=inv56 R10=fp0
+R0=inv0: R1=ctx(id=0,off=0,imm=0)_R3=inv56 #
+# 5 (95) exit
+(95): exit_ #
+# processed 6 insns, stack depth 0
+6: insns,_stack #
+# FAIL
+: _ #
+# Test   4 unknown shift ... Failed to find match 7 R0_w=pkt(id=0,off=8,r=8,imm=0)
+4: unknown_shift #
+# 0 R1=ctx(id=0,off=0,imm=0) R10=fp0
+R1=ctx(id=0,off=0,imm=0): R10=fp0_ #
+# 0 (61) r2 = *(u32 *)(r1 +76)
+(61): r2_= #
+# 1 R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=0,imm=0) R10=fp0
+R1=ctx(id=0,off=0,imm=0): R2=pkt(id=0,off=0,r=0,imm=0)_R10=fp0 #
+# 1 (61) r3 = *(u32 *)(r1 +80)
+(61): r3_= #
+# 2 R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=0,imm=0) R3=pkt_end(id=0,off=0,imm=0) R10=fp0
+R1=ctx(id=0,off=0,imm=0): R2=pkt(id=0,off=0,r=0,imm=0)_R3=pkt_end(id=0,off=0,imm=0) #
+# 2 (bf) r0 = r2
+(bf): r0_= #
+# 3 R0=pkt(id=0,off=0,r=0,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=0,imm=0) R3=pkt_end(id=0,off=0,imm=0) R10=fp0
+R0=pkt(id=0,off=0,r=0,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=0,imm=0) #
+# 3 (07) r0 += 8
+(07): r0_+= #
+# 4 R0=pkt(id=0,off=8,r=0,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=0,imm=0) R3=pkt_end(id=0,off=0,imm=0) R10=fp0
+R0=pkt(id=0,off=8,r=0,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=0,imm=0) #
+# 4 (3d) if r3 >= r0 goto pc+1
+(3d): if_r3 #
+#  R0=pkt(id=0,off=8,r=0,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=0,imm=0) R3=pkt_end(id=0,off=0,imm=0) R10=fp0
+R1=ctx(id=0,off=0,imm=0): R2=pkt(id=0,off=0,r=0,imm=0)_R3=pkt_end(id=0,off=0,imm=0) #
+# 5 R0=pkt(id=0,off=8,r=0,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=0,imm=0) R3=pkt_end(id=0,off=0,imm=0) R10=fp0
+R0=pkt(id=0,off=8,r=0,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=0,imm=0) #
+# 5 (95) exit
+(95): exit_ #
+# 6 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 6 (71) r3 = *(u8 *)(r2 +0)
+(71): r3_= #
+# 7 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=inv(id=0,umax_value=255,var_off=(0x0; 0xff)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 7 (67) r3 <<= 1
+(67): r3_<<= #
+# 8 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=inv(id=0,umax_value=510,var_off=(0x0; 0x1fe)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 8 (67) r3 <<= 1
+(67): r3_<<= #
+# 9 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=inv(id=0,umax_value=1020,var_off=(0x0; 0x3fc)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 9 (67) r3 <<= 1
+(67): r3_<<= #
+# 10 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=inv(id=0,umax_value=2040,var_off=(0x0; 0x7f8)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 10 (67) r3 <<= 1
+(67): r3_<<= #
+# 11 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=inv(id=0,umax_value=4080,var_off=(0x0; 0xff0)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 11 (61) r2 = *(u32 *)(r1 +76)
+(61): r2_= #
+# 12 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=0,imm=0) R3=inv(id=0,umax_value=4080,var_off=(0x0; 0xff0)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=0,imm=0) #
+# 12 (61) r3 = *(u32 *)(r1 +80)
+(61): r3_= #
+# 13 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=0,imm=0) R3=pkt_end(id=0,off=0,imm=0) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=0,imm=0) #
+# 13 (bf) r0 = r2
+(bf): r0_= #
+# 14 R0=pkt(id=0,off=0,r=0,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=0,imm=0) R3=pkt_end(id=0,off=0,imm=0) R10=fp0
+R0=pkt(id=0,off=0,r=0,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=0,imm=0) #
+# 14 (07) r0 += 8
+(07): r0_+= #
+# 15 R0=pkt(id=0,off=8,r=0,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=0,imm=0) R3=pkt_end(id=0,off=0,imm=0) R10=fp0
+R0=pkt(id=0,off=8,r=0,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=0,imm=0) #
+# 15 (3d) if r3 >= r0 goto pc+1
+(3d): if_r3 #
+#  R0=pkt(id=0,off=8,r=0,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=0,imm=0) R3=pkt_end(id=0,off=0,imm=0) R10=fp0
+R1=ctx(id=0,off=0,imm=0): R2=pkt(id=0,off=0,r=0,imm=0)_R3=pkt_end(id=0,off=0,imm=0) #
+# 16 R0=pkt(id=0,off=8,r=0,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=0,imm=0) R3=pkt_end(id=0,off=0,imm=0) R10=fp0
+R0=pkt(id=0,off=8,r=0,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=0,imm=0) #
+# 16 (95) exit
+(95): exit_ #
+# 17 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 17 (71) r4 = *(u8 *)(r2 +0)
+(71): r4_= #
+# 18 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=inv(id=0,umax_value=255,var_off=(0x0; 0xff)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 18 (67) r4 <<= 5
+(67): r4_<<= #
+# 19 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=inv(id=0,umax_value=8160,var_off=(0x0; 0x1fe0)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 19 (77) r4 >>= 1
+(77): r4_>>= #
+# 20 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=inv(id=0,umax_value=4080,var_off=(0x0; 0xff0)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 20 (77) r4 >>= 1
+(77): r4_>>= #
+# 21 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=inv(id=0,umax_value=2040,var_off=(0x0; 0x7f8)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 21 (77) r4 >>= 1
+(77): r4_>>= #
+# 22 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=inv(id=0,umax_value=1020,var_off=(0x0; 0x3fc)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 22 (77) r4 >>= 1
+(77): r4_>>= #
+# 23 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=inv(id=0,umax_value=510,var_off=(0x0; 0x1fe)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 23 (b7) r0 = 0
+(b7): r0_= #
+# 24 R0=inv0 R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=inv(id=0,umax_value=510,var_off=(0x0; 0x1fe)) R10=fp0
+R0=inv0: R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 24 (95) exit
+(95): exit_ #
+# processed 25 insns, stack depth 0
+25: insns,_stack #
+# FAIL
+: _ #
+# Test   5 unknown mul ... Failed to find match 7 R3_w=inv(id=0,umax_value=255,var_off=(0x0; 0xff))
+5: unknown_mul #
+# 0 R1=ctx(id=0,off=0,imm=0) R10=fp0
+R1=ctx(id=0,off=0,imm=0): R10=fp0_ #
+# 0 (61) r2 = *(u32 *)(r1 +76)
+(61): r2_= #
+# 1 R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=0,imm=0) R10=fp0
+R1=ctx(id=0,off=0,imm=0): R2=pkt(id=0,off=0,r=0,imm=0)_R10=fp0 #
+# 1 (61) r3 = *(u32 *)(r1 +80)
+(61): r3_= #
+# 2 R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=0,imm=0) R3=pkt_end(id=0,off=0,imm=0) R10=fp0
+R1=ctx(id=0,off=0,imm=0): R2=pkt(id=0,off=0,r=0,imm=0)_R3=pkt_end(id=0,off=0,imm=0) #
+# 2 (bf) r0 = r2
+(bf): r0_= #
+# 3 R0=pkt(id=0,off=0,r=0,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=0,imm=0) R3=pkt_end(id=0,off=0,imm=0) R10=fp0
+R0=pkt(id=0,off=0,r=0,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=0,imm=0) #
+# 3 (07) r0 += 8
+(07): r0_+= #
+# 4 R0=pkt(id=0,off=8,r=0,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=0,imm=0) R3=pkt_end(id=0,off=0,imm=0) R10=fp0
+R0=pkt(id=0,off=8,r=0,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=0,imm=0) #
+# 4 (3d) if r3 >= r0 goto pc+1
+(3d): if_r3 #
+#  R0=pkt(id=0,off=8,r=0,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=0,imm=0) R3=pkt_end(id=0,off=0,imm=0) R10=fp0
+R1=ctx(id=0,off=0,imm=0): R2=pkt(id=0,off=0,r=0,imm=0)_R3=pkt_end(id=0,off=0,imm=0) #
+# 5 R0=pkt(id=0,off=8,r=0,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=0,imm=0) R3=pkt_end(id=0,off=0,imm=0) R10=fp0
+R0=pkt(id=0,off=8,r=0,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=0,imm=0) #
+# 5 (95) exit
+(95): exit_ #
+# 6 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 6 (71) r3 = *(u8 *)(r2 +0)
+(71): r3_= #
+# 7 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=inv(id=0,umax_value=255,var_off=(0x0; 0xff)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 7 (bf) r4 = r3
+(bf): r4_= #
+# 8 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=inv(id=0,umax_value=255,var_off=(0x0; 0xff)) R4=inv(id=0,umax_value=255,var_off=(0x0; 0xff)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 8 (27) r4 *= 1
+(27): r4_*= #
+# 9 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=inv(id=0,umax_value=255,var_off=(0x0; 0xff)) R4=inv(id=0,umax_value=255,var_off=(0x0; 0xff)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 9 (bf) r4 = r3
+(bf): r4_= #
+# 10 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=inv(id=0,umax_value=255,var_off=(0x0; 0xff)) R4=inv(id=0,umax_value=255,var_off=(0x0; 0xff)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 10 (27) r4 *= 2
+(27): r4_*= #
+# 11 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=inv(id=0,umax_value=255,var_off=(0x0; 0xff)) R4=inv(id=0,umax_value=510,var_off=(0x0; 0x1fe)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 11 (bf) r4 = r3
+(bf): r4_= #
+# 12 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=inv(id=0,umax_value=255,var_off=(0x0; 0xff)) R4=inv(id=0,umax_value=255,var_off=(0x0; 0xff)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 12 (27) r4 *= 4
+(27): r4_*= #
+# 13 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=inv(id=0,umax_value=255,var_off=(0x0; 0xff)) R4=inv(id=0,umax_value=1020,var_off=(0x0; 0x3fc)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 13 (bf) r4 = r3
+(bf): r4_= #
+# 14 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=inv(id=0,umax_value=255,var_off=(0x0; 0xff)) R4=inv(id=0,umax_value=255,var_off=(0x0; 0xff)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 14 (27) r4 *= 8
+(27): r4_*= #
+# 15 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=inv(id=0,umax_value=255,var_off=(0x0; 0xff)) R4=inv(id=0,umax_value=2040,var_off=(0x0; 0x7f8)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 15 (27) r4 *= 2
+(27): r4_*= #
+# 16 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=inv(id=0,umax_value=255,var_off=(0x0; 0xff)) R4=inv(id=0,umax_value=4080,var_off=(0x0; 0xff0)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 16 (b7) r0 = 0
+(b7): r0_= #
+# 17 R0=inv0 R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=inv(id=0,umax_value=255,var_off=(0x0; 0xff)) R4=inv(id=0,umax_value=4080,var_off=(0x0; 0xff0)) R10=fp0
+R0=inv0: R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 17 (95) exit
+(95): exit_ #
+# processed 18 insns, stack depth 0
+18: insns,_stack #
+# FAIL
+: _ #
+# Test   6 packet const offset ... Failed to find match 4 R5_w=pkt(id=0,off=0,r=0,imm=0)
+6: packet_const #
+# 0 R1=ctx(id=0,off=0,imm=0) R10=fp0
+R1=ctx(id=0,off=0,imm=0): R10=fp0_ #
+# 0 (61) r2 = *(u32 *)(r1 +76)
+(61): r2_= #
+# 1 R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=0,imm=0) R10=fp0
+R1=ctx(id=0,off=0,imm=0): R2=pkt(id=0,off=0,r=0,imm=0)_R10=fp0 #
+# 1 (61) r3 = *(u32 *)(r1 +80)
+(61): r3_= #
+# 2 R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=0,imm=0) R3=pkt_end(id=0,off=0,imm=0) R10=fp0
+R1=ctx(id=0,off=0,imm=0): R2=pkt(id=0,off=0,r=0,imm=0)_R3=pkt_end(id=0,off=0,imm=0) #
+# 2 (bf) r5 = r2
+(bf): r5_= #
+# 3 R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=0,imm=0) R3=pkt_end(id=0,off=0,imm=0) R5=pkt(id=0,off=0,r=0,imm=0) R10=fp0
+R1=ctx(id=0,off=0,imm=0): R2=pkt(id=0,off=0,r=0,imm=0)_R3=pkt_end(id=0,off=0,imm=0) #
+# 3 (b7) r0 = 0
+(b7): r0_= #
+# 4 R0=inv0 R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=0,imm=0) R3=pkt_end(id=0,off=0,imm=0) R5=pkt(id=0,off=0,r=0,imm=0) R10=fp0
+R0=inv0: R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=0,imm=0) #
+# 4 (07) r5 += 14
+(07): r5_+= #
+# 5 R0=inv0 R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=0,imm=0) R3=pkt_end(id=0,off=0,imm=0) R5=pkt(id=0,off=14,r=0,imm=0) R10=fp0
+R0=inv0: R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=0,imm=0) #
+# 5 (bf) r4 = r5
+(bf): r4_= #
+# 6 R0=inv0 R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=0,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=pkt(id=0,off=14,r=0,imm=0) R5=pkt(id=0,off=14,r=0,imm=0) R10=fp0
+R0=inv0: R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=0,imm=0) #
+# 6 (07) r4 += 4
+(07): r4_+= #
+# 7 R0=inv0 R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=0,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=pkt(id=0,off=18,r=0,imm=0) R5=pkt(id=0,off=14,r=0,imm=0) R10=fp0
+R0=inv0: R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=0,imm=0) #
+# 7 (3d) if r3 >= r4 goto pc+1
+(3d): if_r3 #
+#  R0=inv0 R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=0,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=pkt(id=0,off=18,r=0,imm=0) R5=pkt(id=0,off=14,r=0,imm=0) R10=fp0
+R1=ctx(id=0,off=0,imm=0): R2=pkt(id=0,off=0,r=0,imm=0)_R3=pkt_end(id=0,off=0,imm=0) #
+# 8 R0=inv0 R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=0,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=pkt(id=0,off=18,r=0,imm=0) R5=pkt(id=0,off=14,r=0,imm=0) R10=fp0
+R0=inv0: R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=0,imm=0) #
+# 8 (95) exit
+(95): exit_ #
+# 9 R0=inv0 R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=18,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=pkt(id=0,off=18,r=18,imm=0) R5=pkt(id=0,off=14,r=18,imm=0) R10=fp0
+R0=inv0: R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=18,imm=0) #
+# 9 (71) r4 = *(u8 *)(r5 +0)
+(71): r4_= #
+# 10 R0=inv0 R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=18,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=inv(id=0,umax_value=255,var_off=(0x0; 0xff)) R5=pkt(id=0,off=14,r=18,imm=0) R10=fp0
+R0=inv0: R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=18,imm=0) #
+# 10 (71) r4 = *(u8 *)(r5 +1)
+(71): r4_= #
+# 11 R0=inv0 R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=18,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=inv(id=0,umax_value=255,var_off=(0x0; 0xff)) R5=pkt(id=0,off=14,r=18,imm=0) R10=fp0
+R0=inv0: R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=18,imm=0) #
+# 11 (71) r4 = *(u8 *)(r5 +2)
+(71): r4_= #
+# 12 R0=inv0 R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=18,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=inv(id=0,umax_value=255,var_off=(0x0; 0xff)) R5=pkt(id=0,off=14,r=18,imm=0) R10=fp0
+R0=inv0: R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=18,imm=0) #
+# 12 (71) r4 = *(u8 *)(r5 +3)
+(71): r4_= #
+# 13 R0=inv0 R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=18,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=inv(id=0,umax_value=255,var_off=(0x0; 0xff)) R5=pkt(id=0,off=14,r=18,imm=0) R10=fp0
+R0=inv0: R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=18,imm=0) #
+# 13 (69) r4 = *(u16 *)(r5 +0)
+(69): r4_= #
+# 14 R0=inv0 R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=18,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=inv(id=0,umax_value=65535,var_off=(0x0; 0xffff)) R5=pkt(id=0,off=14,r=18,imm=0) R10=fp0
+R0=inv0: R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=18,imm=0) #
+# 14 (69) r4 = *(u16 *)(r5 +2)
+(69): r4_= #
+# 15 R0=inv0 R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=18,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=inv(id=0,umax_value=65535,var_off=(0x0; 0xffff)) R5=pkt(id=0,off=14,r=18,imm=0) R10=fp0
+R0=inv0: R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=18,imm=0) #
+# 15 (61) r4 = *(u32 *)(r5 +0)
+(61): r4_= #
+# 16 R0=inv0 R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=18,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=inv(id=0,umax_value=4294967295,var_off=(0x0; 0xffffffff)) R5=pkt(id=0,off=14,r=18,imm=0) R10=fp0
+R0=inv0: R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=18,imm=0) #
+# 16 (b7) r0 = 0
+(b7): r0_= #
+# 17 R0=inv0 R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=18,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=inv(id=0,umax_value=4294967295,var_off=(0x0; 0xffffffff)) R5=pkt(id=0,off=14,r=18,imm=0) R10=fp0
+R0=inv0: R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=18,imm=0) #
+# 17 (95) exit
+(95): exit_ #
+# processed 18 insns, stack depth 0
+18: insns,_stack #
+# FAIL
+: _ #
+# Test   7 packet variable offset ... Failed to find match 8 R2_w=pkt(id=0,off=0,r=8,imm=0)
+7: packet_variable #
+# 0 R1=ctx(id=0,off=0,imm=0) R10=fp0
+R1=ctx(id=0,off=0,imm=0): R10=fp0_ #
+# 0 (61) r2 = *(u32 *)(r1 +76)
+(61): r2_= #
+# 1 R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=0,imm=0) R10=fp0
+R1=ctx(id=0,off=0,imm=0): R2=pkt(id=0,off=0,r=0,imm=0)_R10=fp0 #
+# 1 (61) r3 = *(u32 *)(r1 +80)
+(61): r3_= #
+# 2 R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=0,imm=0) R3=pkt_end(id=0,off=0,imm=0) R10=fp0
+R1=ctx(id=0,off=0,imm=0): R2=pkt(id=0,off=0,r=0,imm=0)_R3=pkt_end(id=0,off=0,imm=0) #
+# 2 (bf) r0 = r2
+(bf): r0_= #
+# 3 R0=pkt(id=0,off=0,r=0,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=0,imm=0) R3=pkt_end(id=0,off=0,imm=0) R10=fp0
+R0=pkt(id=0,off=0,r=0,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=0,imm=0) #
+# 3 (07) r0 += 8
+(07): r0_+= #
+# 4 R0=pkt(id=0,off=8,r=0,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=0,imm=0) R3=pkt_end(id=0,off=0,imm=0) R10=fp0
+R0=pkt(id=0,off=8,r=0,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=0,imm=0) #
+# 4 (3d) if r3 >= r0 goto pc+1
+(3d): if_r3 #
+#  R0=pkt(id=0,off=8,r=0,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=0,imm=0) R3=pkt_end(id=0,off=0,imm=0) R10=fp0
+R1=ctx(id=0,off=0,imm=0): R2=pkt(id=0,off=0,r=0,imm=0)_R3=pkt_end(id=0,off=0,imm=0) #
+# 5 R0=pkt(id=0,off=8,r=0,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=0,imm=0) R3=pkt_end(id=0,off=0,imm=0) R10=fp0
+R0=pkt(id=0,off=8,r=0,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=0,imm=0) #
+# 5 (95) exit
+(95): exit_ #
+# 6 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 6 (71) r6 = *(u8 *)(r2 +0)
+(71): r6_= #
+# 7 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R6=inv(id=0,umax_value=255,var_off=(0x0; 0xff)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 7 (67) r6 <<= 2
+(67): r6_<<= #
+# 8 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R6=inv(id=0,umax_value=1020,var_off=(0x0; 0x3fc)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 8 (bf) r5 = r2
+(bf): r5_= #
+# 9 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R5=pkt(id=0,off=0,r=8,imm=0) R6=inv(id=0,umax_value=1020,var_off=(0x0; 0x3fc)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 9 (07) r5 += 14
+(07): r5_+= #
+# 10 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R5=pkt(id=0,off=14,r=8,imm=0) R6=inv(id=0,umax_value=1020,var_off=(0x0; 0x3fc)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 10 (0f) r5 += r6
+(0f): r5_+= #
+# 11 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R5=pkt(id=1,off=14,r=0,umax_value=1020,var_off=(0x0; 0x3fc)) R6=inv(id=0,umax_value=1020,var_off=(0x0; 0x3fc)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 11 (bf) r4 = r5
+(bf): r4_= #
+# 12 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=pkt(id=1,off=14,r=0,umax_value=1020,var_off=(0x0; 0x3fc)) R5=pkt(id=1,off=14,r=0,umax_value=1020,var_off=(0x0; 0x3fc)) R6=inv(id=0,umax_value=1020,var_off=(0x0; 0x3fc)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 12 (07) r4 += 4
+(07): r4_+= #
+# 13 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=pkt(id=1,off=18,r=0,umax_value=1020,var_off=(0x0; 0x3fc)) R5=pkt(id=1,off=14,r=0,umax_value=1020,var_off=(0x0; 0x3fc)) R6=inv(id=0,umax_value=1020,var_off=(0x0; 0x3fc)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 13 (3d) if r3 >= r4 goto pc+1
+(3d): if_r3 #
+#  R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=pkt(id=1,off=18,r=0,umax_value=1020,var_off=(0x0; 0x3fc)) R5=pkt(id=1,off=14,r=0,umax_value=1020,var_off=(0x0; 0x3fc)) R6=inv(id=0,umax_value=1020,var_off=(0x0; 0x3fc)) R10=fp0
+R1=ctx(id=0,off=0,imm=0): R2=pkt(id=0,off=0,r=8,imm=0)_R3=pkt_end(id=0,off=0,imm=0) #
+# 14 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=pkt(id=1,off=18,r=0,umax_value=1020,var_off=(0x0; 0x3fc)) R5=pkt(id=1,off=14,r=0,umax_value=1020,var_off=(0x0; 0x3fc)) R6=inv(id=0,umax_value=1020,var_off=(0x0; 0x3fc)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 14 (95) exit
+(95): exit_ #
+# 15 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=pkt(id=1,off=18,r=18,umax_value=1020,var_off=(0x0; 0x3fc)) R5=pkt(id=1,off=14,r=18,umax_value=1020,var_off=(0x0; 0x3fc)) R6=inv(id=0,umax_value=1020,var_off=(0x0; 0x3fc)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 15 (61) r4 = *(u32 *)(r5 +0)
+(61): r4_= #
+# 16 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=inv(id=0,umax_value=4294967295,var_off=(0x0; 0xffffffff)) R5=pkt(id=1,off=14,r=18,umax_value=1020,var_off=(0x0; 0x3fc)) R6=inv(id=0,umax_value=1020,var_off=(0x0; 0x3fc)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 16 (bf) r5 = r2
+(bf): r5_= #
+# 17 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=inv(id=0,umax_value=4294967295,var_off=(0x0; 0xffffffff)) R5=pkt(id=0,off=0,r=8,imm=0) R6=inv(id=0,umax_value=1020,var_off=(0x0; 0x3fc)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 17 (0f) r5 += r6
+(0f): r5_+= #
+# 18 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=inv(id=0,umax_value=4294967295,var_off=(0x0; 0xffffffff)) R5=pkt(id=2,off=0,r=0,umax_value=1020,var_off=(0x0; 0x3fc)) R6=inv(id=0,umax_value=1020,var_off=(0x0; 0x3fc)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 18 (07) r5 += 14
+(07): r5_+= #
+# 19 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=inv(id=0,umax_value=4294967295,var_off=(0x0; 0xffffffff)) R5=pkt(id=2,off=14,r=0,umax_value=1020,var_off=(0x0; 0x3fc)) R6=inv(id=0,umax_value=1020,var_off=(0x0; 0x3fc)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 19 (bf) r4 = r5
+(bf): r4_= #
+# 20 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=pkt(id=2,off=14,r=0,umax_value=1020,var_off=(0x0; 0x3fc)) R5=pkt(id=2,off=14,r=0,umax_value=1020,var_off=(0x0; 0x3fc)) R6=inv(id=0,umax_value=1020,var_off=(0x0; 0x3fc)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 20 (07) r4 += 4
+(07): r4_+= #
+# 21 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=pkt(id=2,off=18,r=0,umax_value=1020,var_off=(0x0; 0x3fc)) R5=pkt(id=2,off=14,r=0,umax_value=1020,var_off=(0x0; 0x3fc)) R6=inv(id=0,umax_value=1020,var_off=(0x0; 0x3fc)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 21 (3d) if r3 >= r4 goto pc+1
+(3d): if_r3 #
+#  R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=pkt(id=2,off=18,r=0,umax_value=1020,var_off=(0x0; 0x3fc)) R5=pkt(id=2,off=14,r=0,umax_value=1020,var_off=(0x0; 0x3fc)) R6=inv(id=0,umax_value=1020,var_off=(0x0; 0x3fc)) R10=fp0
+R1=ctx(id=0,off=0,imm=0): R2=pkt(id=0,off=0,r=8,imm=0)_R3=pkt_end(id=0,off=0,imm=0) #
+# 22 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=pkt(id=2,off=18,r=0,umax_value=1020,var_off=(0x0; 0x3fc)) R5=pkt(id=2,off=14,r=0,umax_value=1020,var_off=(0x0; 0x3fc)) R6=inv(id=0,umax_value=1020,var_off=(0x0; 0x3fc)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 22 (95) exit
+(95): exit_ #
+# 23 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=pkt(id=2,off=18,r=18,umax_value=1020,var_off=(0x0; 0x3fc)) R5=pkt(id=2,off=14,r=18,umax_value=1020,var_off=(0x0; 0x3fc)) R6=inv(id=0,umax_value=1020,var_off=(0x0; 0x3fc)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 23 (61) r4 = *(u32 *)(r5 +0)
+(61): r4_= #
+# 24 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=inv(id=0,umax_value=4294967295,var_off=(0x0; 0xffffffff)) R5=pkt(id=2,off=14,r=18,umax_value=1020,var_off=(0x0; 0x3fc)) R6=inv(id=0,umax_value=1020,var_off=(0x0; 0x3fc)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 24 (bf) r5 = r2
+(bf): r5_= #
+# 25 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=inv(id=0,umax_value=4294967295,var_off=(0x0; 0xffffffff)) R5=pkt(id=0,off=0,r=8,imm=0) R6=inv(id=0,umax_value=1020,var_off=(0x0; 0x3fc)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 25 (07) r5 += 14
+(07): r5_+= #
+# 26 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=inv(id=0,umax_value=4294967295,var_off=(0x0; 0xffffffff)) R5=pkt(id=0,off=14,r=8,imm=0) R6=inv(id=0,umax_value=1020,var_off=(0x0; 0x3fc)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 26 (0f) r5 += r6
+(0f): r5_+= #
+# 27 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=inv(id=0,umax_value=4294967295,var_off=(0x0; 0xffffffff)) R5=pkt(id=3,off=14,r=0,umax_value=1020,var_off=(0x0; 0x3fc)) R6=inv(id=0,umax_value=1020,var_off=(0x0; 0x3fc)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 27 (07) r5 += 4
+(07): r5_+= #
+# 28 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=inv(id=0,umax_value=4294967295,var_off=(0x0; 0xffffffff)) R5=pkt(id=3,off=18,r=0,umax_value=1020,var_off=(0x0; 0x3fc)) R6=inv(id=0,umax_value=1020,var_off=(0x0; 0x3fc)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 28 (0f) r5 += r6
+(0f): r5_+= #
+# 29 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=inv(id=0,umax_value=4294967295,var_off=(0x0; 0xffffffff)) R5=pkt(id=4,off=18,r=0,umax_value=2040,var_off=(0x0; 0x7fc)) R6=inv(id=0,umax_value=1020,var_off=(0x0; 0x3fc)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 29 (bf) r4 = r5
+(bf): r4_= #
+# 30 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=pkt(id=4,off=18,r=0,umax_value=2040,var_off=(0x0; 0x7fc)) R5=pkt(id=4,off=18,r=0,umax_value=2040,var_off=(0x0; 0x7fc)) R6=inv(id=0,umax_value=1020,var_off=(0x0; 0x3fc)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 30 (07) r4 += 4
+(07): r4_+= #
+# 31 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=pkt(id=4,off=22,r=0,umax_value=2040,var_off=(0x0; 0x7fc)) R5=pkt(id=4,off=18,r=0,umax_value=2040,var_off=(0x0; 0x7fc)) R6=inv(id=0,umax_value=1020,var_off=(0x0; 0x3fc)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 31 (3d) if r3 >= r4 goto pc+1
+(3d): if_r3 #
+#  R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=pkt(id=4,off=22,r=0,umax_value=2040,var_off=(0x0; 0x7fc)) R5=pkt(id=4,off=18,r=0,umax_value=2040,var_off=(0x0; 0x7fc)) R6=inv(id=0,umax_value=1020,var_off=(0x0; 0x3fc)) R10=fp0
+R1=ctx(id=0,off=0,imm=0): R2=pkt(id=0,off=0,r=8,imm=0)_R3=pkt_end(id=0,off=0,imm=0) #
+# 32 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=pkt(id=4,off=22,r=0,umax_value=2040,var_off=(0x0; 0x7fc)) R5=pkt(id=4,off=18,r=0,umax_value=2040,var_off=(0x0; 0x7fc)) R6=inv(id=0,umax_value=1020,var_off=(0x0; 0x3fc)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 32 (95) exit
+(95): exit_ #
+# 33 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=pkt(id=4,off=22,r=22,umax_value=2040,var_off=(0x0; 0x7fc)) R5=pkt(id=4,off=18,r=22,umax_value=2040,var_off=(0x0; 0x7fc)) R6=inv(id=0,umax_value=1020,var_off=(0x0; 0x3fc)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 33 (61) r4 = *(u32 *)(r5 +0)
+(61): r4_= #
+# 34 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=inv(id=0,umax_value=4294967295,var_off=(0x0; 0xffffffff)) R5=pkt(id=4,off=18,r=22,umax_value=2040,var_off=(0x0; 0x7fc)) R6=inv(id=0,umax_value=1020,var_off=(0x0; 0x3fc)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 34 (b7) r0 = 0
+(b7): r0_= #
+# 35 R0=inv0 R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=inv(id=0,umax_value=4294967295,var_off=(0x0; 0xffffffff)) R5=pkt(id=4,off=18,r=22,umax_value=2040,var_off=(0x0; 0x7fc)) R6=inv(id=0,umax_value=1020,var_off=(0x0; 0x3fc)) R10=fp0
+R0=inv0: R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 35 (95) exit
+(95): exit_ #
+# processed 36 insns, stack depth 0
+36: insns,_stack #
+# FAIL
+: _ #
+# Test   8 packet variable offset 2 ... Failed to find match 8 R2_w=pkt(id=0,off=0,r=8,imm=0)
+8: packet_variable #
+# 0 R1=ctx(id=0,off=0,imm=0) R10=fp0
+R1=ctx(id=0,off=0,imm=0): R10=fp0_ #
+# 0 (61) r2 = *(u32 *)(r1 +76)
+(61): r2_= #
+# 1 R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=0,imm=0) R10=fp0
+R1=ctx(id=0,off=0,imm=0): R2=pkt(id=0,off=0,r=0,imm=0)_R10=fp0 #
+# 1 (61) r3 = *(u32 *)(r1 +80)
+(61): r3_= #
+# 2 R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=0,imm=0) R3=pkt_end(id=0,off=0,imm=0) R10=fp0
+R1=ctx(id=0,off=0,imm=0): R2=pkt(id=0,off=0,r=0,imm=0)_R3=pkt_end(id=0,off=0,imm=0) #
+# 2 (bf) r0 = r2
+(bf): r0_= #
+# 3 R0=pkt(id=0,off=0,r=0,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=0,imm=0) R3=pkt_end(id=0,off=0,imm=0) R10=fp0
+R0=pkt(id=0,off=0,r=0,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=0,imm=0) #
+# 3 (07) r0 += 8
+(07): r0_+= #
+# 4 R0=pkt(id=0,off=8,r=0,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=0,imm=0) R3=pkt_end(id=0,off=0,imm=0) R10=fp0
+R0=pkt(id=0,off=8,r=0,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=0,imm=0) #
+# 4 (3d) if r3 >= r0 goto pc+1
+(3d): if_r3 #
+#  R0=pkt(id=0,off=8,r=0,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=0,imm=0) R3=pkt_end(id=0,off=0,imm=0) R10=fp0
+R1=ctx(id=0,off=0,imm=0): R2=pkt(id=0,off=0,r=0,imm=0)_R3=pkt_end(id=0,off=0,imm=0) #
+# 5 R0=pkt(id=0,off=8,r=0,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=0,imm=0) R3=pkt_end(id=0,off=0,imm=0) R10=fp0
+R0=pkt(id=0,off=8,r=0,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=0,imm=0) #
+# 5 (95) exit
+(95): exit_ #
+# 6 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 6 (71) r6 = *(u8 *)(r2 +0)
+(71): r6_= #
+# 7 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R6=inv(id=0,umax_value=255,var_off=(0x0; 0xff)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 7 (67) r6 <<= 2
+(67): r6_<<= #
+# 8 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R6=inv(id=0,umax_value=1020,var_off=(0x0; 0x3fc)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 8 (07) r6 += 14
+(07): r6_+= #
+# 9 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R6=inv(id=0,umin_value=14,umax_value=1034,var_off=(0x2; 0x7fc)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 9 (bf) r5 = r2
+(bf): r5_= #
+# 10 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R5=pkt(id=0,off=0,r=8,imm=0) R6=inv(id=0,umin_value=14,umax_value=1034,var_off=(0x2; 0x7fc)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 10 (0f) r5 += r6
+(0f): r5_+= #
+# 11 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R5=pkt(id=1,off=0,r=0,umin_value=14,umax_value=1034,var_off=(0x2; 0x7fc)) R6=inv(id=0,umin_value=14,umax_value=1034,var_off=(0x2; 0x7fc)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 11 (bf) r4 = r5
+(bf): r4_= #
+# 12 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=pkt(id=1,off=0,r=0,umin_value=14,umax_value=1034,var_off=(0x2; 0x7fc)) R5=pkt(id=1,off=0,r=0,umin_value=14,umax_value=1034,var_off=(0x2; 0x7fc)) R6=inv(id=0,umin_value=14,umax_value=1034,var_off=(0x2; 0x7fc)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 12 (07) r4 += 4
+(07): r4_+= #
+# 13 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=pkt(id=1,off=4,r=0,umin_value=14,umax_value=1034,var_off=(0x2; 0x7fc)) R5=pkt(id=1,off=0,r=0,umin_value=14,umax_value=1034,var_off=(0x2; 0x7fc)) R6=inv(id=0,umin_value=14,umax_value=1034,var_off=(0x2; 0x7fc)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 13 (3d) if r3 >= r4 goto pc+1
+(3d): if_r3 #
+#  R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=pkt(id=1,off=4,r=0,umin_value=14,umax_value=1034,var_off=(0x2; 0x7fc)) R5=pkt(id=1,off=0,r=0,umin_value=14,umax_value=1034,var_off=(0x2; 0x7fc)) R6=inv(id=0,umin_value=14,umax_value=1034,var_off=(0x2; 0x7fc)) R10=fp0
+R1=ctx(id=0,off=0,imm=0): R2=pkt(id=0,off=0,r=8,imm=0)_R3=pkt_end(id=0,off=0,imm=0) #
+# 14 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=pkt(id=1,off=4,r=0,umin_value=14,umax_value=1034,var_off=(0x2; 0x7fc)) R5=pkt(id=1,off=0,r=0,umin_value=14,umax_value=1034,var_off=(0x2; 0x7fc)) R6=inv(id=0,umin_value=14,umax_value=1034,var_off=(0x2; 0x7fc)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 14 (95) exit
+(95): exit_ #
+# 15 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=pkt(id=1,off=4,r=4,umin_value=14,umax_value=1034,var_off=(0x2; 0x7fc)) R5=pkt(id=1,off=0,r=4,umin_value=14,umax_value=1034,var_off=(0x2; 0x7fc)) R6=inv(id=0,umin_value=14,umax_value=1034,var_off=(0x2; 0x7fc)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 15 (61) r6 = *(u32 *)(r5 +0)
+(61): r6_= #
+# 16 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=pkt(id=1,off=4,r=4,umin_value=14,umax_value=1034,var_off=(0x2; 0x7fc)) R5=pkt(id=1,off=0,r=4,umin_value=14,umax_value=1034,var_off=(0x2; 0x7fc)) R6=inv(id=0,umax_value=4294967295,var_off=(0x0; 0xffffffff)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 16 (57) r6 &= 255
+(57): r6_&= #
+# 17 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=pkt(id=1,off=4,r=4,umin_value=14,umax_value=1034,var_off=(0x2; 0x7fc)) R5=pkt(id=1,off=0,r=4,umin_value=14,umax_value=1034,var_off=(0x2; 0x7fc)) R6=inv(id=0,umax_value=255,var_off=(0x0; 0xff)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 17 (67) r6 <<= 2
+(67): r6_<<= #
+# 18 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=pkt(id=1,off=4,r=4,umin_value=14,umax_value=1034,var_off=(0x2; 0x7fc)) R5=pkt(id=1,off=0,r=4,umin_value=14,umax_value=1034,var_off=(0x2; 0x7fc)) R6=inv(id=0,umax_value=1020,var_off=(0x0; 0x3fc)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 18 (0f) r5 += r6
+(0f): r5_+= #
+# 19 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=pkt(id=1,off=4,r=4,umin_value=14,umax_value=1034,var_off=(0x2; 0x7fc)) R5=pkt(id=2,off=0,r=0,umin_value=14,umax_value=2054,var_off=(0x2; 0xffc)) R6=inv(id=0,umax_value=1020,var_off=(0x0; 0x3fc)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 19 (bf) r4 = r5
+(bf): r4_= #
+# 20 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=pkt(id=2,off=0,r=0,umin_value=14,umax_value=2054,var_off=(0x2; 0xffc)) R5=pkt(id=2,off=0,r=0,umin_value=14,umax_value=2054,var_off=(0x2; 0xffc)) R6=inv(id=0,umax_value=1020,var_off=(0x0; 0x3fc)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 20 (07) r4 += 4
+(07): r4_+= #
+# 21 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=pkt(id=2,off=4,r=0,umin_value=14,umax_value=2054,var_off=(0x2; 0xffc)) R5=pkt(id=2,off=0,r=0,umin_value=14,umax_value=2054,var_off=(0x2; 0xffc)) R6=inv(id=0,umax_value=1020,var_off=(0x0; 0x3fc)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 21 (3d) if r3 >= r4 goto pc+1
+(3d): if_r3 #
+#  R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=pkt(id=2,off=4,r=0,umin_value=14,umax_value=2054,var_off=(0x2; 0xffc)) R5=pkt(id=2,off=0,r=0,umin_value=14,umax_value=2054,var_off=(0x2; 0xffc)) R6=inv(id=0,umax_value=1020,var_off=(0x0; 0x3fc)) R10=fp0
+R1=ctx(id=0,off=0,imm=0): R2=pkt(id=0,off=0,r=8,imm=0)_R3=pkt_end(id=0,off=0,imm=0) #
+# 22 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=pkt(id=2,off=4,r=0,umin_value=14,umax_value=2054,var_off=(0x2; 0xffc)) R5=pkt(id=2,off=0,r=0,umin_value=14,umax_value=2054,var_off=(0x2; 0xffc)) R6=inv(id=0,umax_value=1020,var_off=(0x0; 0x3fc)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 22 (95) exit
+(95): exit_ #
+# 23 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=pkt(id=2,off=4,r=4,umin_value=14,umax_value=2054,var_off=(0x2; 0xffc)) R5=pkt(id=2,off=0,r=4,umin_value=14,umax_value=2054,var_off=(0x2; 0xffc)) R6=inv(id=0,umax_value=1020,var_off=(0x0; 0x3fc)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 23 (61) r6 = *(u32 *)(r5 +0)
+(61): r6_= #
+# 24 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=pkt(id=2,off=4,r=4,umin_value=14,umax_value=2054,var_off=(0x2; 0xffc)) R5=pkt(id=2,off=0,r=4,umin_value=14,umax_value=2054,var_off=(0x2; 0xffc)) R6=inv(id=0,umax_value=4294967295,var_off=(0x0; 0xffffffff)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 24 (b7) r0 = 0
+(b7): r0_= #
+# 25 R0=inv0 R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=pkt(id=2,off=4,r=4,umin_value=14,umax_value=2054,var_off=(0x2; 0xffc)) R5=pkt(id=2,off=0,r=4,umin_value=14,umax_value=2054,var_off=(0x2; 0xffc)) R6=inv(id=0,umax_value=4294967295,var_off=(0x0; 0xffffffff)) R10=fp0
+R0=inv0: R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 25 (95) exit
+(95): exit_ #
+# processed 26 insns, stack depth 0
+26: insns,_stack #
+# FAIL
+: _ #
+# Test   9 dubious pointer arithmetic ... Failed to find match 4 R5_w=pkt_end(id=0,off=0,imm=0)
+9: dubious_pointer #
+# 0 R1=ctx(id=0,off=0,imm=0) R10=fp0
+R1=ctx(id=0,off=0,imm=0): R10=fp0_ #
+# 0 (61) r2 = *(u32 *)(r1 +76)
+(61): r2_= #
+# 1 R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=0,imm=0) R10=fp0
+R1=ctx(id=0,off=0,imm=0): R2=pkt(id=0,off=0,r=0,imm=0)_R10=fp0 #
+# 1 (61) r3 = *(u32 *)(r1 +80)
+(61): r3_= #
+# 2 R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=0,imm=0) R3=pkt_end(id=0,off=0,imm=0) R10=fp0
+R1=ctx(id=0,off=0,imm=0): R2=pkt(id=0,off=0,r=0,imm=0)_R3=pkt_end(id=0,off=0,imm=0) #
+# 2 (b7) r0 = 0
+(b7): r0_= #
+# 3 R0=inv0 R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=0,imm=0) R3=pkt_end(id=0,off=0,imm=0) R10=fp0
+R0=inv0: R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=0,imm=0) #
+# 3 (bf) r5 = r3
+(bf): r5_= #
+# 4 R0=inv0 R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=0,imm=0) R3=pkt_end(id=0,off=0,imm=0) R5=pkt_end(id=0,off=0,imm=0) R10=fp0
+R0=inv0: R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=0,imm=0) #
+# 4 (1f) r5 -= r2
+(1f): r5_-= #
+# 5 R0=inv0 R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=0,imm=0) R3=pkt_end(id=0,off=0,imm=0) R5=inv(id=0) R10=fp0
+R0=inv0: R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=0,imm=0) #
+# 5 (67) r5 <<= 2
+(67): r5_<<= #
+# 6 R0=inv0 R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=0,imm=0) R3=pkt_end(id=0,off=0,imm=0) R5=inv(id=0,smax_value=9223372036854775804,umax_value=18446744073709551612,var_off=(0x0; 0xfffffffffffffffc)) R10=fp0
+R0=inv0: R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=0,imm=0) #
+# 6 (07) r5 += 14
+(07): r5_+= #
+# 7 R0=inv0 R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=0,imm=0) R3=pkt_end(id=0,off=0,imm=0) R5=inv(id=0,var_off=(0x2; 0xfffffffffffffffc)) R10=fp0
+R0=inv0: R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=0,imm=0) #
+# 7 (75) if r5 s>= 0x0 goto pc+1
+(75): if_r5 #
+#  R0=inv0 R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=0,imm=0) R3=pkt_end(id=0,off=0,imm=0) R5=inv(id=0,umin_value=9223372036854775810,umax_value=18446744073709551614,var_off=(0x8000000000000002; 0x7ffffffffffffffc)) R10=fp0
+R1=ctx(id=0,off=0,imm=0): R2=pkt(id=0,off=0,r=0,imm=0)_R3=pkt_end(id=0,off=0,imm=0) #
+# 8 R0=inv0 R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=0,imm=0) R3=pkt_end(id=0,off=0,imm=0) R5=inv(id=0,umin_value=9223372036854775810,umax_value=18446744073709551614,var_off=(0x8000000000000002; 0x7ffffffffffffffc)) R10=fp0
+R0=inv0: R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=0,imm=0) #
+# 8 (95) exit
+(95): exit_ #
+# 9 R0=inv0 R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=0,imm=0) R3=pkt_end(id=0,off=0,imm=0) R5=inv(id=0,umin_value=2,umax_value=9223372036854775806,var_off=(0x2; 0x7ffffffffffffffc)) R10=fp0
+R0=inv0: R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=0,imm=0) #
+# 9 (bf) r6 = r2
+(bf): r6_= #
+# 10 R0=inv0 R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=0,imm=0) R3=pkt_end(id=0,off=0,imm=0) R5=inv(id=0,umin_value=2,umax_value=9223372036854775806,var_off=(0x2; 0x7ffffffffffffffc)) R6=pkt(id=0,off=0,r=0,imm=0) R10=fp0
+R0=inv0: R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=0,imm=0) #
+# 10 (0f) r6 += r5
+(0f): r6_+= #
+# 11 R0=inv0 R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=0,imm=0) R3=pkt_end(id=0,off=0,imm=0) R5=inv(id=0,umin_value=2,umax_value=9223372036854775806,var_off=(0x2; 0x7ffffffffffffffc)) R6=pkt(id=1,off=0,r=0,umin_value=2,umax_value=9223372036854775806,var_off=(0x2; 0x7ffffffffffffffc)) R10=fp0
+R0=inv0: R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=0,imm=0) #
+# 11 (bf) r4 = r6
+(bf): r4_= #
+# 12 R0=inv0 R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=0,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=pkt(id=1,off=0,r=0,umin_value=2,umax_value=9223372036854775806,var_off=(0x2; 0x7ffffffffffffffc)) R5=inv(id=0,umin_value=2,umax_value=9223372036854775806,var_off=(0x2; 0x7ffffffffffffffc)) R6=pkt(id=1,off=0,r=0,umin_value=2,umax_value=9223372036854775806,var_off=(0x2; 0x7ffffffffffffffc)) R10=fp0
+R0=inv0: R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=0,imm=0) #
+# 12 (07) r4 += 4
+(07): r4_+= #
+# 13 R0=inv0 R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=0,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=pkt(id=1,off=4,r=0,umin_value=2,umax_value=9223372036854775806,var_off=(0x2; 0x7ffffffffffffffc)) R5=inv(id=0,umin_value=2,umax_value=9223372036854775806,var_off=(0x2; 0x7ffffffffffffffc)) R6=pkt(id=1,off=0,r=0,umin_value=2,umax_value=9223372036854775806,var_off=(0x2; 0x7ffffffffffffffc)) R10=fp0
+R0=inv0: R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=0,imm=0) #
+# 13 (3d) if r3 >= r4 goto pc+1
+(3d): if_r3 #
+#  R0=inv0 R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=0,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=pkt(id=1,off=4,r=0,umin_value=2,umax_value=9223372036854775806,var_off=(0x2; 0x7ffffffffffffffc)) R5=inv(id=0,umin_value=2,umax_value=9223372036854775806,var_off=(0x2; 0x7ffffffffffffffc)) R6=pkt(id=1,off=0,r=0,umin_value=2,umax_value=9223372036854775806,var_off=(0x2; 0x7ffffffffffffffc)) R10=fp0
+R1=ctx(id=0,off=0,imm=0): R2=pkt(id=0,off=0,r=0,imm=0)_R3=pkt_end(id=0,off=0,imm=0) #
+# 14 R0=inv0 R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=0,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=pkt(id=1,off=4,r=0,umin_value=2,umax_value=9223372036854775806,var_off=(0x2; 0x7ffffffffffffffc)) R5=inv(id=0,umin_value=2,umax_value=9223372036854775806,var_off=(0x2; 0x7ffffffffffffffc)) R6=pkt(id=1,off=0,r=0,umin_value=2,umax_value=9223372036854775806,var_off=(0x2; 0x7ffffffffffffffc)) R10=fp0
+R0=inv0: R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=0,imm=0) #
+# 14 (95) exit
+(95): exit_ #
+# 15 R0=inv0 R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=0,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=pkt(id=1,off=4,r=0,umin_value=2,umax_value=9223372036854775806,var_off=(0x2; 0x7ffffffffffffffc)) R5=inv(id=0,umin_value=2,umax_value=9223372036854775806,var_off=(0x2; 0x7ffffffffffffffc)) R6=pkt(id=1,off=0,r=0,umin_value=2,umax_value=9223372036854775806,var_off=(0x2; 0x7ffffffffffffffc)) R10=fp0
+R0=inv0: R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=0,imm=0) #
+# 15 (61) r4 = *(u32 *)(r6 +0)
+(61): r4_= #
+# invalid access to packet, off=0 size=4, R6(id=1,off=0,r=0)
+access: to_packet, #
+# R6 offset is outside of the packet
+offset: is_outside #
+# FAIL
+: _ #
+# Test  10 variable subtraction ... Failed to find match 7 R2_w=pkt(id=0,off=0,r=8,imm=0)
+10: variable_subtraction #
+# 0 R1=ctx(id=0,off=0,imm=0) R10=fp0
+R1=ctx(id=0,off=0,imm=0): R10=fp0_ #
+# 0 (61) r2 = *(u32 *)(r1 +76)
+(61): r2_= #
+# 1 R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=0,imm=0) R10=fp0
+R1=ctx(id=0,off=0,imm=0): R2=pkt(id=0,off=0,r=0,imm=0)_R10=fp0 #
+# 1 (61) r3 = *(u32 *)(r1 +80)
+(61): r3_= #
+# 2 R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=0,imm=0) R3=pkt_end(id=0,off=0,imm=0) R10=fp0
+R1=ctx(id=0,off=0,imm=0): R2=pkt(id=0,off=0,r=0,imm=0)_R3=pkt_end(id=0,off=0,imm=0) #
+# 2 (bf) r0 = r2
+(bf): r0_= #
+# 3 R0=pkt(id=0,off=0,r=0,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=0,imm=0) R3=pkt_end(id=0,off=0,imm=0) R10=fp0
+R0=pkt(id=0,off=0,r=0,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=0,imm=0) #
+# 3 (07) r0 += 8
+(07): r0_+= #
+# 4 R0=pkt(id=0,off=8,r=0,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=0,imm=0) R3=pkt_end(id=0,off=0,imm=0) R10=fp0
+R0=pkt(id=0,off=8,r=0,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=0,imm=0) #
+# 4 (3d) if r3 >= r0 goto pc+1
+(3d): if_r3 #
+#  R0=pkt(id=0,off=8,r=0,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=0,imm=0) R3=pkt_end(id=0,off=0,imm=0) R10=fp0
+R1=ctx(id=0,off=0,imm=0): R2=pkt(id=0,off=0,r=0,imm=0)_R3=pkt_end(id=0,off=0,imm=0) #
+# 5 R0=pkt(id=0,off=8,r=0,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=0,imm=0) R3=pkt_end(id=0,off=0,imm=0) R10=fp0
+R0=pkt(id=0,off=8,r=0,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=0,imm=0) #
+# 5 (95) exit
+(95): exit_ #
+# 6 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 6 (71) r6 = *(u8 *)(r2 +0)
+(71): r6_= #
+# 7 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R6=inv(id=0,umax_value=255,var_off=(0x0; 0xff)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 7 (bf) r7 = r6
+(bf): r7_= #
+# 8 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R6=inv(id=0,umax_value=255,var_off=(0x0; 0xff)) R7=inv(id=0,umax_value=255,var_off=(0x0; 0xff)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 8 (67) r6 <<= 2
+(67): r6_<<= #
+# 9 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R6=inv(id=0,umax_value=1020,var_off=(0x0; 0x3fc)) R7=inv(id=0,umax_value=255,var_off=(0x0; 0xff)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 9 (07) r6 += 14
+(07): r6_+= #
+# 10 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R6=inv(id=0,umin_value=14,umax_value=1034,var_off=(0x2; 0x7fc)) R7=inv(id=0,umax_value=255,var_off=(0x0; 0xff)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 10 (67) r7 <<= 2
+(67): r7_<<= #
+# 11 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R6=inv(id=0,umin_value=14,umax_value=1034,var_off=(0x2; 0x7fc)) R7=inv(id=0,umax_value=1020,var_off=(0x0; 0x3fc)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 11 (1f) r6 -= r7
+(1f): r6_-= #
+# 12 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R6=inv(id=0,smin_value=-1006,smax_value=1034,var_off=(0x2; 0xfffffffffffffffc)) R7=inv(id=0,umax_value=1020,var_off=(0x0; 0x3fc)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 12 (75) if r6 s>= 0x0 goto pc+1
+(75): if_r6 #
+#  R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R6=inv(id=0,umin_value=18446744073709550610,umax_value=18446744073709551614,var_off=(0xfffffffffffffc02; 0x3fc)) R7=inv(id=0,umax_value=1020,var_off=(0x0; 0x3fc)) R10=fp0
+R1=ctx(id=0,off=0,imm=0): R2=pkt(id=0,off=0,r=8,imm=0)_R3=pkt_end(id=0,off=0,imm=0) #
+# 13 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R6=inv(id=0,umin_value=18446744073709550610,umax_value=18446744073709551614,var_off=(0xfffffffffffffc02; 0x3fc)) R7=inv(id=0,umax_value=1020,var_off=(0x0; 0x3fc)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 13 (95) exit
+(95): exit_ #
+# 14 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R6=inv(id=0,umin_value=2,umax_value=1034,var_off=(0x2; 0x7fc)) R7=inv(id=0,umax_value=1020,var_off=(0x0; 0x3fc)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 14 (bf) r5 = r2
+(bf): r5_= #
+# 15 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R5=pkt(id=0,off=0,r=8,imm=0) R6=inv(id=0,umin_value=2,umax_value=1034,var_off=(0x2; 0x7fc)) R7=inv(id=0,umax_value=1020,var_off=(0x0; 0x3fc)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 15 (0f) r5 += r6
+(0f): r5_+= #
+# 16 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R5=pkt(id=1,off=0,r=0,umin_value=2,umax_value=1034,var_off=(0x2; 0x7fc)) R6=inv(id=0,umin_value=2,umax_value=1034,var_off=(0x2; 0x7fc)) R7=inv(id=0,umax_value=1020,var_off=(0x0; 0x3fc)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 16 (bf) r4 = r5
+(bf): r4_= #
+# 17 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=pkt(id=1,off=0,r=0,umin_value=2,umax_value=1034,var_off=(0x2; 0x7fc)) R5=pkt(id=1,off=0,r=0,umin_value=2,umax_value=1034,var_off=(0x2; 0x7fc)) R6=inv(id=0,umin_value=2,umax_value=1034,var_off=(0x2; 0x7fc)) R7=inv(id=0,umax_value=1020,var_off=(0x0; 0x3fc)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 17 (07) r4 += 4
+(07): r4_+= #
+# 18 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=pkt(id=1,off=4,r=0,umin_value=2,umax_value=1034,var_off=(0x2; 0x7fc)) R5=pkt(id=1,off=0,r=0,umin_value=2,umax_value=1034,var_off=(0x2; 0x7fc)) R6=inv(id=0,umin_value=2,umax_value=1034,var_off=(0x2; 0x7fc)) R7=inv(id=0,umax_value=1020,var_off=(0x0; 0x3fc)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 18 (3d) if r3 >= r4 goto pc+1
+(3d): if_r3 #
+#  R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=pkt(id=1,off=4,r=0,umin_value=2,umax_value=1034,var_off=(0x2; 0x7fc)) R5=pkt(id=1,off=0,r=0,umin_value=2,umax_value=1034,var_off=(0x2; 0x7fc)) R6=inv(id=0,umin_value=2,umax_value=1034,var_off=(0x2; 0x7fc)) R7=inv(id=0,umax_value=1020,var_off=(0x0; 0x3fc)) R10=fp0
+R1=ctx(id=0,off=0,imm=0): R2=pkt(id=0,off=0,r=8,imm=0)_R3=pkt_end(id=0,off=0,imm=0) #
+# 19 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=pkt(id=1,off=4,r=0,umin_value=2,umax_value=1034,var_off=(0x2; 0x7fc)) R5=pkt(id=1,off=0,r=0,umin_value=2,umax_value=1034,var_off=(0x2; 0x7fc)) R6=inv(id=0,umin_value=2,umax_value=1034,var_off=(0x2; 0x7fc)) R7=inv(id=0,umax_value=1020,var_off=(0x0; 0x3fc)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 19 (95) exit
+(95): exit_ #
+# 20 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=pkt(id=1,off=4,r=4,umin_value=2,umax_value=1034,var_off=(0x2; 0x7fc)) R5=pkt(id=1,off=0,r=4,umin_value=2,umax_value=1034,var_off=(0x2; 0x7fc)) R6=inv(id=0,umin_value=2,umax_value=1034,var_off=(0x2; 0x7fc)) R7=inv(id=0,umax_value=1020,var_off=(0x0; 0x3fc)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 20 (61) r6 = *(u32 *)(r5 +0)
+(61): r6_= #
+# 21 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=pkt(id=1,off=4,r=4,umin_value=2,umax_value=1034,var_off=(0x2; 0x7fc)) R5=pkt(id=1,off=0,r=4,umin_value=2,umax_value=1034,var_off=(0x2; 0x7fc)) R6=inv(id=0,umax_value=4294967295,var_off=(0x0; 0xffffffff)) R7=inv(id=0,umax_value=1020,var_off=(0x0; 0x3fc)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 21 (95) exit
+(95): exit_ #
+# processed 22 insns, stack depth 0
+22: insns,_stack #
+# FAIL
+: _ #
+# Test  11 pointer variable subtraction ... Failed to find match 7 R2_w=pkt(id=0,off=0,r=8,imm=0)
+11: pointer_variable #
+# 0 R1=ctx(id=0,off=0,imm=0) R10=fp0
+R1=ctx(id=0,off=0,imm=0): R10=fp0_ #
+# 0 (61) r2 = *(u32 *)(r1 +76)
+(61): r2_= #
+# 1 R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=0,imm=0) R10=fp0
+R1=ctx(id=0,off=0,imm=0): R2=pkt(id=0,off=0,r=0,imm=0)_R10=fp0 #
+# 1 (61) r3 = *(u32 *)(r1 +80)
+(61): r3_= #
+# 2 R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=0,imm=0) R3=pkt_end(id=0,off=0,imm=0) R10=fp0
+R1=ctx(id=0,off=0,imm=0): R2=pkt(id=0,off=0,r=0,imm=0)_R3=pkt_end(id=0,off=0,imm=0) #
+# 2 (bf) r0 = r2
+(bf): r0_= #
+# 3 R0=pkt(id=0,off=0,r=0,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=0,imm=0) R3=pkt_end(id=0,off=0,imm=0) R10=fp0
+R0=pkt(id=0,off=0,r=0,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=0,imm=0) #
+# 3 (07) r0 += 8
+(07): r0_+= #
+# 4 R0=pkt(id=0,off=8,r=0,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=0,imm=0) R3=pkt_end(id=0,off=0,imm=0) R10=fp0
+R0=pkt(id=0,off=8,r=0,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=0,imm=0) #
+# 4 (3d) if r3 >= r0 goto pc+1
+(3d): if_r3 #
+#  R0=pkt(id=0,off=8,r=0,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=0,imm=0) R3=pkt_end(id=0,off=0,imm=0) R10=fp0
+R1=ctx(id=0,off=0,imm=0): R2=pkt(id=0,off=0,r=0,imm=0)_R3=pkt_end(id=0,off=0,imm=0) #
+# 5 R0=pkt(id=0,off=8,r=0,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=0,imm=0) R3=pkt_end(id=0,off=0,imm=0) R10=fp0
+R0=pkt(id=0,off=8,r=0,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=0,imm=0) #
+# 5 (95) exit
+(95): exit_ #
+# 6 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 6 (71) r6 = *(u8 *)(r2 +0)
+(71): r6_= #
+# 7 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R6=inv(id=0,umax_value=255,var_off=(0x0; 0xff)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 7 (bf) r7 = r6
+(bf): r7_= #
+# 8 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R6=inv(id=0,umax_value=255,var_off=(0x0; 0xff)) R7=inv(id=0,umax_value=255,var_off=(0x0; 0xff)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 8 (57) r6 &= 15
+(57): r6_&= #
+# 9 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R6=inv(id=0,umax_value=15,var_off=(0x0; 0xf)) R7=inv(id=0,umax_value=255,var_off=(0x0; 0xff)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 9 (67) r6 <<= 2
+(67): r6_<<= #
+# 10 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R6=inv(id=0,umax_value=60,var_off=(0x0; 0x3c)) R7=inv(id=0,umax_value=255,var_off=(0x0; 0xff)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 10 (07) r6 += 14
+(07): r6_+= #
+# 11 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R6=inv(id=0,umin_value=14,umax_value=74,var_off=(0x2; 0x7c)) R7=inv(id=0,umax_value=255,var_off=(0x0; 0xff)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 11 (bf) r5 = r2
+(bf): r5_= #
+# 12 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R5=pkt(id=0,off=0,r=8,imm=0) R6=inv(id=0,umin_value=14,umax_value=74,var_off=(0x2; 0x7c)) R7=inv(id=0,umax_value=255,var_off=(0x0; 0xff)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 12 (1f) r5 -= r6
+(1f): r5_-= #
+# 13 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R5=pkt(id=1,off=0,r=8,umin_value=18446744073709551542,umax_value=18446744073709551602,var_off=(0xffffffffffffff82; 0x7c)) R6=inv(id=0,umin_value=14,umax_value=74,var_off=(0x2; 0x7c)) R7=inv(id=0,umax_value=255,var_off=(0x0; 0xff)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 13 (67) r7 <<= 2
+(67): r7_<<= #
+# 14 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R5=pkt(id=1,off=0,r=8,umin_value=18446744073709551542,umax_value=18446744073709551602,var_off=(0xffffffffffffff82; 0x7c)) R6=inv(id=0,umin_value=14,umax_value=74,var_off=(0x2; 0x7c)) R7=inv(id=0,umax_value=1020,var_off=(0x0; 0x3fc)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 14 (07) r7 += 76
+(07): r7_+= #
+# 15 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R5=pkt(id=1,off=0,r=8,umin_value=18446744073709551542,umax_value=18446744073709551602,var_off=(0xffffffffffffff82; 0x7c)) R6=inv(id=0,umin_value=14,umax_value=74,var_off=(0x2; 0x7c)) R7=inv(id=0,umin_value=76,umax_value=1096,var_off=(0x0; 0x7fc)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 15 (0f) r5 += r7
+(0f): r5_+= #
+# 16 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R5=pkt(id=2,off=0,r=0,umin_value=2,umax_value=1082,var_off=(0x2; 0x7fc)) R6=inv(id=0,umin_value=14,umax_value=74,var_off=(0x2; 0x7c)) R7=inv(id=0,umin_value=76,umax_value=1096,var_off=(0x0; 0x7fc)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 16 (bf) r4 = r5
+(bf): r4_= #
+# 17 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=pkt(id=2,off=0,r=0,umin_value=2,umax_value=1082,var_off=(0x2; 0x7fc)) R5=pkt(id=2,off=0,r=0,umin_value=2,umax_value=1082,var_off=(0x2; 0x7fc)) R6=inv(id=0,umin_value=14,umax_value=74,var_off=(0x2; 0x7c)) R7=inv(id=0,umin_value=76,umax_value=1096,var_off=(0x0; 0x7fc)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 17 (07) r4 += 4
+(07): r4_+= #
+# 18 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=pkt(id=2,off=4,r=0,umin_value=2,umax_value=1082,var_off=(0x2; 0x7fc)) R5=pkt(id=2,off=0,r=0,umin_value=2,umax_value=1082,var_off=(0x2; 0x7fc)) R6=inv(id=0,umin_value=14,umax_value=74,var_off=(0x2; 0x7c)) R7=inv(id=0,umin_value=76,umax_value=1096,var_off=(0x0; 0x7fc)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 18 (3d) if r3 >= r4 goto pc+1
+(3d): if_r3 #
+#  R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=pkt(id=2,off=4,r=0,umin_value=2,umax_value=1082,var_off=(0x2; 0x7fc)) R5=pkt(id=2,off=0,r=0,umin_value=2,umax_value=1082,var_off=(0x2; 0x7fc)) R6=inv(id=0,umin_value=14,umax_value=74,var_off=(0x2; 0x7c)) R7=inv(id=0,umin_value=76,umax_value=1096,var_off=(0x0; 0x7fc)) R10=fp0
+R1=ctx(id=0,off=0,imm=0): R2=pkt(id=0,off=0,r=8,imm=0)_R3=pkt_end(id=0,off=0,imm=0) #
+# 19 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=pkt(id=2,off=4,r=0,umin_value=2,umax_value=1082,var_off=(0x2; 0x7fc)) R5=pkt(id=2,off=0,r=0,umin_value=2,umax_value=1082,var_off=(0x2; 0x7fc)) R6=inv(id=0,umin_value=14,umax_value=74,var_off=(0x2; 0x7c)) R7=inv(id=0,umin_value=76,umax_value=1096,var_off=(0x0; 0x7fc)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 19 (95) exit
+(95): exit_ #
+# 20 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=pkt(id=2,off=4,r=4,umin_value=2,umax_value=1082,var_off=(0x2; 0x7fc)) R5=pkt(id=2,off=0,r=4,umin_value=2,umax_value=1082,var_off=(0x2; 0x7fc)) R6=inv(id=0,umin_value=14,umax_value=74,var_off=(0x2; 0x7c)) R7=inv(id=0,umin_value=76,umax_value=1096,var_off=(0x0; 0x7fc)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 20 (61) r6 = *(u32 *)(r5 +0)
+(61): r6_= #
+# 21 R0=pkt(id=0,off=8,r=8,imm=0) R1=ctx(id=0,off=0,imm=0) R2=pkt(id=0,off=0,r=8,imm=0) R3=pkt_end(id=0,off=0,imm=0) R4=pkt(id=2,off=4,r=4,umin_value=2,umax_value=1082,var_off=(0x2; 0x7fc)) R5=pkt(id=2,off=0,r=4,umin_value=2,umax_value=1082,var_off=(0x2; 0x7fc)) R6=inv(id=0,umax_value=4294967295,var_off=(0x0; 0xffffffff)) R7=inv(id=0,umin_value=76,umax_value=1096,var_off=(0x0; 0x7fc)) R10=fp0
+R0=pkt(id=0,off=8,r=8,imm=0): R1=ctx(id=0,off=0,imm=0)_R2=pkt(id=0,off=0,r=8,imm=0) #
+# 21 (95) exit
+(95): exit_ #
+# processed 22 insns, stack depth 0
+22: insns,_stack #
+# FAIL
+: _ #
+# Results 0 pass 12 fail
+0: pass_12 #
+[FAIL] 7 selftests bpf test_align
+selftests: bpf_test_align [FAIL]
+# selftests bpf test_verifier_log
+bpf: test_verifier_log_ #
+# Test log_level 0...
+log_level: 0..._ #
+# Test log_size < 128...
+log_size: <_128... #
+# Test log_buff = NULL...
+log_buff: =_NULL... #
+# Test oversized buffer...
+oversized: buffer..._ #
+# Test exact buffer...
+exact: buffer..._ #
+# Test undersized buffers...
+undersized: buffers..._ #
+# test_verifier_log OK
+OK: _ #
+[PASS] 8 selftests bpf test_verifier_log
+selftests: bpf_test_verifier_log [PASS]
+# selftests bpf test_dev_cgroup
+bpf: test_dev_cgroup_ #
+# libbpf load bpf program failed Invalid argument
+load: bpf_program #
+# libbpf failed to load program 'cgroup/dev'
+failed: to_load #
+# libbpf failed to load object './dev_cgroup.o'
+failed: to_load #
+# Failed to load DEV_CGROUP program
+to: load_DEV_CGROUP #
+[FAIL] 9 selftests bpf test_dev_cgroup
+selftests: bpf_test_dev_cgroup [FAIL]
+# selftests bpf test_tcpbpf_user
+bpf: test_tcpbpf_user_ #
+# libbpf BTF is required, but is missing or corrupted.
+BTF: is_r[   60.605466] test_bpf: #0 TAX jited:0 309 309 303 PASS
+equired, #
+# FAILED load_bpf_file failed for test_tcpbpf_kern.o
+load_bpf_file: failed_for #
+[[   60.622656] test_bpf: #1 TXA jited:0 178 168 173 PASS
+FAIL] 10 selftests bpf test_tcpbpf_user
+selftes[   60.635920] test_bpf: #2 ADD_SUB_MUL_K jited:0 215 PASS
+ts: bpf_test_tcpbpf_user [FAIL]
+# selftests bpf test_sock
+bpf: test_sock_ #
+# Test case bind4[   60.645232] test_bpf: #3 DIV_MOD_KX jited:0 550 PASS
+ load with invalid access src_ip6 .. [PASS]
+case: bind4_load #
+# Test case bin[   60.658446] test_bpf: #4 AND_OR_LSH_K jited:0 241 237 PASS
+d4 load with invalid access mark .. [PASS]
+case[   60.670645] test_bpf: #5 LD_IMM_0 jited:0 174 PASS
+: bind4_load #
+# Test case bind6 load with invalid access src_ip4 .. [PASS]
+case: bind6_load #[   60.679506] test_bpf: #6 LD_IND jited:0 186 194 186 PASS
+
+# Test case sock_create load with invalid access src_port .. [PASS]
+case: soc[   60.693009] test_bpf: #7 LD_ABS jited:0 155 162 155 PASS
+k_create_load #
+# Test case sock_create load w/o expected_attach_type (compat m[   60.705137] test_bpf: #8 LD_ABS_LL jited:0 226 250 PASS
+ode) .. [FAIL]
+case: sock_create_load #
+# Test case sock_create load w/ expected_attach_type .. [FAIL]
+case: [   60.717180] test_bpf: #9 LD_IND_LL jited:0 251 243 248 PASS
+sock_create_load #
+# Test case attach type mismatch bind4 vs bind6 .. [FAIL]
+c[   60.732323] test_bpf: #10 LD_ABS_NET jited:0 213 252 PASS
+ase: attach_type #
+# Test case attach type mismatch bind6 vs bind4 .. [FAIL]
+case: attach_type #
+# Test case [   60.744531] test_bpf: #11 LD_IND_NET jited:0 232 249 245 PASS
+attach type mismatch default vs bind4 .. [PASS]
+case: attach_type #
+# Test case attach type mi[   60.759842] test_bpf: #12 LD_PKTTYPE jited:0 315 322 PASS
+smatch bind6 vs sock_create .. [FAIL]
+case: attach_type #
+# Te[   60.773432] test_bpf: #13 LD_MARK jited:0 131 139 PASS
+st case bind4 reject all .. [FAIL]
+case: bind4_reject #
+# Test[   60.784012] test_bpf: #14 LD_RXHASH jited:0 131 131 PASS
+ case bind6 reject all .. [FAIL]
+case: bind6_reject #
+# Test c[   60.794797] test_bpf: #15 LD_QUEUE jited:0 137 131 PASS
+ase bind6 deny specific IP & port .. [FAIL]
+case: bind6_deny #
+# Test case bind4 allow specifi[   60.805429] test_bpf: #16 LD_PROTOCOL jited:0 316 313 PASS
+c IP & port .. [FAIL]
+case: bind4_allow #
+# Test case bind4 al[   60.819105] test_bpf: #17 LD_VLAN_TAG jited:0 148 148 PASS
+low all .. [FAIL]
+case: bind4_allow #
+# Test case bind6 allow [   60.830029] test_bpf: #18 LD_VLAN_TAG_PRESENT jited:0 176 168 PASS
+all .. [FAIL]
+case: bind6_allow #
+# Summary 5 PASSED, 11 FAILE[   60.841641] test_bpf: #19 LD_IFINDEX jited:0 188 180 PASS
+D
+5: PASSED,_11 #
+[FAIL] 11 selftests bpf test_sock
+selftests[   60.852486] test_bpf: #20 LD_HATYPE jited:0 180 187 PASS
+: bpf_test_sock [FAIL]
+# selftests bpf test_btf
+bpf: test_btf_ #
+# BTF raw test[1] (struct test #1) do[   60.863229] test_bpf: #21 LD_CPU jited:0 342 350 PASS
+_test_raw3660FAIL btf_fd-1 test->btf_load_err0
+raw: test[1]_(struct #
+# BTF raw test[2] (struc[   60.877271] test_bpf: #22 LD_NLATTR jited:0 274 302 PASS
+t test #2) do_test_raw3660FAIL btf_fd-1 test->btf_load_err0
+raw: test[2]_(struct #
+# BTF raw test[3] (struct test #3 Invalid member offset) do_test_raw3662FAIL expected err_strInvalid member bits_offset
+raw: test[3]_(struct #
+# BTF raw test[4] (global data test #1) do_test_raw3660FAIL btf_fd-1 test->btf_load_err0
+[   60.890756] test_bpf: #23 LD_NLATTR_NEST jited:0 1051 1393 PASS
+raw: test[4]_(global #
+# BTF raw test[5] (global data test #2) do_test_raw3660FAIL btf_fd-1 test->btf_load_err0
+raw: test[5]_(global #
+# BTF raw test[6] (global data test #3) do_test_raw3660FAIL btf_fd-1 test->btf_load_err0
+raw: test[6]_(global #
+# BTF raw test[7] (global data test #4, unsupported linkage) do_test_raw3662FAIL expected err_strLinkage not supported
+raw: test[7][   60.924125] test_bpf: #24 LD_PAYLOAD_OFF jited:0 1322 1730 PASS
+_(global #
+# BTF raw test[8] (global data test #5, invalid var [   60.962994] test_bpf: #25 LD_ANC_XOR jited:0 167 160 PASS
+type) do_test_raw3662FAIL expected err_strInvalid type_id
+raw: test[8]_(global #
+# BTF raw test[9] (global data test #6, invalid var type (fwd type)) do_test_[   60.973924] test_bpf: #26 SPILL_FILL jited:0 369 365 365 PASS
+raw3662FAIL expected err_strInvalid type
+raw: test[9]_(global #
+# BTF raw test[10] (global dat[   60.993276] test_bpf: #27 JEQ jited:0 177 203 204 PASS
+a test #7, invalid var type (fwd type)) do_test_raw3662FAIL expected err_strInvalid type
+raw: t[   61.006608] test_bpf: #28 JGT jited:0 184 193 204 PASS
+est[10]_(global #
+# BTF raw test[11] (global data test #8, invalid var size) do_test_raw3662FAI[   61.019945] test_bpf: #29 JGE (jt 0), test 1 jited:0 177 203 193 PASS
+L expected err_strInvalid size
+raw: test[11]_(global #
+# BTF raw test[12] (global data test #9[   61.034564] test_bpf: #30 JGE (jt 0), test 2 jited:0 203 193 204 PASS
+, invalid var size) do_test_raw3662FAIL expected err_strInvalid size
+raw: test[12]_(global #
+# BTF raw test[13] (global data t[   61.049199] test_bpf: #31 JGE jited:0 234 280 300 PASS
+est #10, invalid var size) do_test_raw3662FAIL expected err_strInvalid size
+raw: test[13]_(global #
+# BTF raw test[14] (global data test #11, multiple section members) do_tes[   61.065274] test_bpf: #32 JSET jited:0 319 368 519 PASS
+t_raw3660FAIL btf_fd-1 test->btf_load_err0
+raw: test[14]_(global #
+# BTF raw test[15] (global data test #12, invalid offset) do_test_raw3662FAIL expected err_strInvalid offse[   61.085572] test_bpf: #33 tcpdump port 22 jited:0 155 482 560 PASS
+t+size
+raw: test[15]_(global #
+# BTF raw test[16] (global data test #13, invalid offset) do_test_raw3662FAIL expected err_strInvalid offset
+raw: test[16]_(global #
+# BTF raw test[17] (global data test #14, invalid offset[   61.106836] test_bpf: #34 tcpdump complex jited:0 163 449 1107 PASS
+) do_test_raw3662FAIL expected err_strInvalid offset
+raw: test[[   61.132272] test_bpf: #35 RET_A jited:0 127 127 PASS
+17]_(global #
+# BTF raw test[18] (global data t[   61.142727] test_bpf: #36 INT: ADD trivial jited:0 183 PASS
+est #15, not var kind) do_test_raw3662FAIL expec[   61.152331] test_bpf: #37 INT: MUL_X jited:0 163 PASS
+ted err_strNot a VAR kind member
+raw: test[18]_[   61.161462] test_bpf: #38 INT: MUL_X2 jited:0 191 PASS
+(global #
+# BTF raw test[19] (global data test [   61.170635] test_bpf: #39 INT: MUL32_X jited:0 190 PASS
+#16, invalid var referencing sec) do_test_raw3662FAIL expected err_strInvalid type_id
+raw: test[19]_(global #
+# BTF raw test[20] (global data test #17, invalid var referencing var) do_test_raw3662FAIL expected err_strInvalid type_id
+raw: test[20]_(global #
+# BTF raw test[21] (global data test #18, invalid var loop) do_test_raw3662FAIL expected err_strInvalid typ[   61.179923] test_bpf: #40 INT: ADD 64-bit jited:0 2883 PASS
+e_id
+raw: test[21]_(global #
+# BTF raw test[22] (global data test #19, invalid var referencing var) do_test_raw3662FAIL expected err_strInvalid type_id
+raw: test[22]_(global #
+# BTF raw test[23] (global data test #20, invalid ptr referencing var) do_test_raw3662FAIL expected err_strInvalid type_id
+raw: test[23]_(global #
+# BTF r[   61.217077] test_bpf: #41 INT: ADD 32-bit jited:0 2628 PASS
+aw test[24] (global data test #21, var included in struct) do_test_raw3662FAIL expected err_strInvalid member
+raw: test[24]_(global #
+# BTF raw test[25] (global data test #22, array of var) do_test_raw3662FAIL expected err_strInvalid elem
+raw: test[25]_(global #
+# BTF raw test[26] (size check test #1) do_test_raw36[   61.251482] test_bpf: #42 INT: SUB jited:0 2529 PASS
+62FAIL expected err_strMember exceeds struct_size
+raw: test[26]_(size #
+# BTF raw test[27] (size check test #2) do_test_raw3662FAIL expected e[   61.283906] test_bpf: #43 INT: XOR jited:0 1072 PASS
+rr_strMember exceeds struct_size
+raw: test[27]_(size #
+# BTF raw test[28] (size check test #3) do_test_raw3662FAIL expected err_strMember exceeds struct_size[   61.301195] test_bpf: #44 INT: MUL jited:0 1209 PASS
+raw: test[28]_(size #
+# BTF raw test[29] (size check test #4) do_test_raw3662FAIL expected err[   61.319859] test_bpf: #45 MOV REG64 jited:0 652 PASS
+_strMember exceeds struct_size
+raw: test[29]_(size #
+# BTF raw test[30] (void test #1) do_test_raw3660FA[   61.333019] test_bpf: #46 MOV REG32 jited:0 626 PASS
+IL btf_fd-1 test->btf_load_err0
+raw: test[30]_(void #
+# BTF raw test[31] (void test #2) do_tes[   61.347029] test_bpf: #47 LD IMM64 jited:0 638 PASS
+t_raw3662FAIL expected err_strInvalid member
+raw: test[31]_(voi[   61.360156] test_bpf: #48 INT: ALU MIX jited:0 250 PASS
+d #
+# BTF raw test[32] (void test #3) do_test_raw3660FAIL btf_fd-1 test->btf_load_err0
+raw: te[   61.370808] test_bpf: #49 INT: shifts by register jited:0 548 PASS
+st[32]_(void #
+# BTF raw test[33] (void test #4) do_test_raw3662FAIL expected e[   61.385155] test_bpf: #50 INT: DIV + ABS jited:0 231 256 PASS
+rr_strInvalid elem
+raw: test[33]_(void #
+# BTF raw test[34] (l[   61.397713] test_bpf: #51 INT: DIV by zero jited:0 131 129 PASS
+oop test #1) do_test_raw3662FAIL[   61.409067] test_bpf: #52 check: missing ret PASS
+ expected err_strLoop detected
+[   61.416487] test_bpf: #53 check: div_k_0 PASS
+raw: test[34]_(loop #
+# BTF raw[   61.423545] test_bpf: #54 check: unknown insn PASS
+ test[35] (loop test #2) do_test[   61.431021] test_bpf: #55 check: out of range spill/fill PASS
+_raw3662FAIL expected err_strLoop detected
+raw: test[35]_(loop [   61.439461] test_bpf: #56 JUMPS + HOLES jited:0 371 PASS
+#
+# BTF raw test[36] (loop test[   61.450187] test_bpf: #57 check: RET X PASS
+ #3) do_test_raw3662FAIL expecte[   61.457086] test_bpf: #58 check: LDX + RET X PASS
+d err_strLoop detected
+raw: test[36]_(loop #
+# BTF raw test[37] (loop test #4) do_test_raw3662FAIL expected err_strLoop detected
+raw: test[37]_(loop #
+# BTF raw test[38] (loop test #5) do_test_raw3662FAIL expected err_st[   61.464505] test_bpf: #59 M[]: alt STX + LDX jited:0 1636 PASS
+rLoop detected
+raw: test[38]_(loop #
+# BTF raw test[39] (loop test #6) do_test_raw3662FAIL expected err_strLoop detected
+raw: test[39]_(loop #
+# BTF raw test[40] (loop test[   61.489481] test_bpf: #60 M[]: full STX + full LDX jited:0 1328 PASS
+ #7) do_test_raw3662FAIL expecte[   61.510897] test_bpf: #61 check: SKF_AD_MAX PASS
+d err_strLoop detected
+raw: test[40]_(loop #
+#[   61.518241] test_bpf: #62 LD [SKF_AD_OFF-1] jited:0 157 PASS
+ BTF raw test[41] (loop test #8) do_test_raw3662FAIL expected er[   61.527933] test_bpf: #63 load 64-bit immediate jited:0 271 PASS
+r_strLoop detected
+raw: test[41]_(loop #
+# BTF raw test[42] (string section does not end with null) do_test_ra[   61.539447] test_bpf: #64 nmap reduced jited:0 749 PASS
+w3662FAIL expected err_strInvali[   61.554178] test_bpf: #65 ALU_MOV_X: dst = 2 jited:0 90 PASS
+d string section
+raw: test[42]_[   61.562539] test_bpf: #66 ALU_MOV_X: dst = 4294967295 jited:0 97 PASS
+(string #
+# BTF raw test[43] (e[   61.571630] test_bpf: #67 ALU64_MOV_X: dst = 2 jited:0 88 PASS
+mpty string section) do_test_raw[   61.580192] test_bpf: #68 ALU64_MOV_X: dst = 4294967295 jited:0 88 PASS
+3662FAIL expected err_strInvalid[   61.589473] test_bpf: #69 ALU_MOV_K: dst = 2 jited:0 70 PASS
+ string section
+raw: test[43]_([   61.597830] test_bpf: #70 ALU_MOV_K: dst = 4294967295 jited:0 70 PASS
+empty #
+# BTF raw test[44] (empty type section)[   61.606928] test_bpf: #71 ALU_MOV_K: 0x0000ffffffff0000 = 0x00000000ffffffff jited:0 154 PASS
+ do_test_raw3662FAIL expected er[   61.619462] test_bpf: #72 ALU64_MOV_K: dst = 2 jited:0 70 PASS
+r_strNo type found
+raw: test[44[   61.628027] test_bpf: #73 ALU64_MOV_K: dst = 2147483647 jited:0 70 PASS
+]_(empty #
+# BTF raw test[45] (btf_header test.[   61.637296] test_bpf: #74 ALU64_OR_K: dst = 0x0 jited:0 146 PASS
+ Longer hdr_len) do_test_raw3662FAIL expected er[   61.647377] test_bpf: #75 ALU64_MOV_K: dst = -1 jited:0 146 PASS
+r_strUnsupported btf_header
+raw[   61.657405] test_bpf: #76 ALU_ADD_X: 1 + 2 = 3 jited:0 105 PASS
+: test[45]_(btf_header #
+# BTF [   61.666030] test_bpf: #77 ALU_ADD_X: 1 + 4294967294 = 4294967295 jited:0 105 PASS
+raw test[46] (btf_header test. Gap between hdr a[   61.676200] test_bpf: #78 ALU_ADD_X: 2 + 4294967294 = 0 jited:0 147 PASS
+nd type) do_test_raw3662FAIL expected err_strUns[   61.686934] test_bpf: #79 ALU64_ADD_X: 1 + 2 = 3 jited:0 111 PASS
+upported section found
+raw: tes[   61.697047] test_bpf: #80 ALU64_ADD_X: 1 + 4294967294 = 4294967295 jited:0 105 PASS
+t[46]_(btf_header #
+# BTF raw test[47] (btf_hea[   61.707491] test_bpf: #81 ALU64_ADD_X: 2 + 4294967294 = 4294967296 jited:0 166 PASS
+der test. Gap between type and s[   61.719068] test_bpf: #82 ALU_ADD_K: 1 + 2 = 3 jited:0 97 PASS
+tr) do_test_raw3662FAIL expected[   61.727588] test_bpf: #83 ALU_ADD_K: 3 + 0 = 3 jited:0 88 PASS
+ err_strUnsupported section foun[   61.736149] test_bpf: #84 ALU_ADD_K: 1 + 4294967294 = 4294967295 jited:0 88 PASS
+d
+raw: test[47]_(btf_header #
+# BTF raw test[4[   61.746217] test_bpf: #85 ALU_ADD_K: 4294967294 + 2 = 0 jited:0 139 PASS
+8] (btf_header test. Overlap between type and st[   61.756917] test_bpf: #86 ALU_ADD_K: 0 + (-1) = 0x00000000ffffffff jited:0 148 PASS
+r) do_test_raw3662FAIL expected err_strSection o[   61.768670] test_bpf: #87 ALU_ADD_K: 0 + 0xffff = 0xffff jited:0 148 PASS
+verlap found
+raw: test[48]_(btf_header #
+# BTF[   61.779573] test_bpf: #88 ALU_ADD_K: 0 + 0x7fffffff = 0x7fffffff jited:0 148 PASS
+ raw test[49] (btf_header test. Larger BTF size)[   61.791011] test_bpf: #89 ALU_ADD_K: 0 + 0x80000000 = 0x80000000 jited:0 156 PASS
+ do_test_raw3662FAIL expected err_strUnsupported[   61.802505] test_bpf: #90 ALU_ADD_K: 0 + 0x80008000 = 0x80008000 jited:0 158 PASS
+ section found
+raw: test[49]_(b[   61.814031] test_bpf: #91 ALU64_ADD_K: 1 + 2 = 3 jited:0 88 PASS
+tf_header #
+# BTF raw test[50] [   61.822769] test_bpf: #92 ALU64_ADD_K: 3 + 0 = 3 jited:0 95 PASS
+(btf_header test. Smaller BTF si[   61.831423] test_bpf: #93 ALU64_ADD_K: 1 + 2147483646 = 2147483647 jited:0 96 PASS
+ze) do_test_raw3662FAIL expected err_strTotal se[   61.841662] test_bpf: #94 ALU64_ADD_K: 4294967294 + 2 = 4294967296 jited:0 147 PASS
+ction length too long
+raw: test[   61.853374] test_bpf: #95 ALU64_ADD_K: 2147483646 + -2147483647 = -1 jited:0 88 PASS
+[50]_(btf_header #
+# BTF raw test[51] (array te[   61.863807] test_bpf: #96 ALU64_ADD_K: 1 + 0 = 1 jited:0 148 PASS
+st. index_type/elem_type \"int\") do_test_raw3660F[   61.873947] test_bpf: #97 ALU64_ADD_K: 0 + (-1) = 0xffffffffffffffff jited:0 148 PASS
+AIL btf_fd-1 test->btf_load_err0
+raw: test[51]_[   61.885773] test_bpf: #98 ALU64_ADD_K: 0 + 0xffff = 0xffff jited:0 148 PASS
+(array #
+# BTF raw test[52] (array test. index_[   61.896823] test_bpf: #99 ALU64_ADD_K: 0 + 0x7fffffff = 0x7fffffff jited:0 148 PASS
+type/elem_type \"const int\") do_test_raw3660FAIL [   61.908519] test_bpf: #100 ALU64_ADD_K: 0 + 0x80000000 = 0xffffffff80000000 jited:0 148 PASS
+btf_fd-1 test->btf_load_err0
+raw: test[52]_(arr[   61.920995] test_bpf: #101 ALU_ADD_K: 0 + 0x80008000 = 0xffffffff80008000 jited:0 148 PASS
+ay #
+# BTF raw test[53] (array [   61.933285] test_bpf: #102 ALU_SUB_X: 3 - 1 = 2 jited:0 105 PASS
+test. index_type \"const int31\") [   61.941992] test_bpf: #103 ALU_SUB_X: 4294967295 - 4294967294 = 1 jited:0 105 PASS
+do_test_raw3662FAIL expected err[   61.952217] test_bpf: #104 ALU64_SUB_X: 3 - 1 = 2 jited:0 105 PASS
+_strInvalid index
+raw: test[53][   61.961088] test_bpf: #105 ALU64_SUB_X: 4294967295 - 4294967294 = 1 jited:0 105 PASS
+_(array #
+# BTF raw test[54] (a[   61.971531] test_bpf: #106 ALU_SUB_K: 3 - 1 = 2 jited:0 88 PASS
+rray test. elem_type \"const int3[   61.980054] test_bpf: #107 ALU_SUB_K: 3 - 0 = 3 jited:0 88 PASS
+1\") do_test_raw3662FAIL expected[   61.988701] test_bpf: #108 ALU_SUB_K: 4294967295 - 4294967294 = 1 jited:0 88 PASS
+ err_strInvalid array of int
+ra[   61.998834] test_bpf: #109 ALU64_SUB_K: 3 - 1 = 2 jited:0 96 PASS
+w: test[54]_(array #
+# BTF raw [   62.007603] test_bpf: #110 ALU64_SUB_K: 3 - 0 = 3 jited:0 88 PASS
+test[55] (array test. index_type[   62.016400] test_bpf: #111 ALU64_SUB_K: 4294967294 - 4294967295 = -1 jited:0 88 PASS
+ \"void\") do_test_raw3662FAIL exp[   62.026790] test_bpf: #112 ALU64_ADD_K: 2147483646 - 2147483647 = -1 jited:0 96 PASS
+ected err_strInvalid index
+raw:[   62.037168] test_bpf: #113 ALU_MUL_X: 2 * 3 = 6 jited:0 107 PASS
+ test[55]_(array #
+# BTF raw te[   62.045908] test_bpf: #114 ALU_MUL_X: 2 * 0x7FFFFFF8 = 0xFFFFFFF0 jited:0 107 PASS
+st[56] (array test. index_type \"const void\") do_[   62.056132] test_bpf: #115 ALU_MUL_X: -1 * -1 = 1 jited:0 107 PASS
+test_raw3662FAIL expected err_strInvalid index
+[   62.066380] test_bpf: #116 ALU64_MUL_X: 2 * 3 = 6 jited:0 108 PASS
+raw: test[56]_(array #
+# BTF ra[   62.076571] test_bpf: #117 ALU64_MUL_X: 1 * 2147483647 = 2147483647 jited:0 108 PASS
+w test[57] (array test. elem_typ[   62.087005] test_bpf: #118 ALU_MUL_K: 2 * 3 = 6 jited:0 98 PASS
+e \"const void\") do_test_raw3662F[   62.095580] test_bpf: #119 ALU_MUL_K: 3 * 1 = 3 jited:0 91 PASS
+AIL expected err_strInvalid elem
+raw: test[57]_[   62.104185] test_bpf: #120 ALU_MUL_K: 2 * 0x7FFFFFF8 = 0xFFFFFFF0 jited:0 91 PASS
+(array #
+# BTF raw test[58] (array test. elem_t[   62.115747] test_bpf: #121 ALU_MUL_K: 1 * (-1) = 0x00000000ffffffff jited:0 151 PASS
+ype \"const void *\") do_test_raw3[   62.127525] test_bpf: #122 ALU64_MUL_K: 2 * 3 = 6 jited:0 99 PASS
+660FAIL btf_fd-1 test->btf_load_[   62.136264] test_bpf: #123 ALU64_MUL_K: 3 * 1 = 3 jited:0 92 PASS
+err0
+raw: test[58]_(array #
+# [   62.145073] test_bpf: #124 ALU64_MUL_K: 1 * 2147483647 = 2147483647 jited:0 92 PASS
+BTF raw test[59] (array test. in[   62.155411] test_bpf: #125 ALU64_MUL_K: 1 * -2147483647 = -2147483647 jited:0 98 PASS
+dex_type \"const void *\") do_test_raw3662FAIL exp[   62.165873] test_bpf: #126 ALU64_MUL_K: 1 * (-1) = 0xffffffffffffffff jited:0 152 PASS
+ected err_strInvalid index
+raw: test[59]_(array[   62.177841] test_bpf: #127 ALU_DIV_X: 6 / 2 = 3 jited:0 133 PASS
+ #
+# BTF raw test[60] (array test. t->size != 0[   62.187930] test_bpf: #128 ALU_DIV_X: 4294967295 / 4294967295 = 1 jited:0 133 PASS
+\") do_test_raw3662FAIL expected err_strsize != 0[   62.199521] test_bpf: #129 ALU64_DIV_X: 6 / 2 = 3 jited:0 119 PASS
+raw: test[60]_(array #
+# BTF raw test[61][   62.209816] test_bpf: #130 ALU64_DIV_X: 2147483647 / 2147483647 = 1 jited:0 112 PASS
+ (int test. invalid int_data) do_test_raw3662FAI[   62.221262] test_bpf: #131 ALU64_DIV_X: 0xffffffffffffffff / (-1) = 0x0000000000000001 jited:0 173 PASS
+L expected err_strInvalid int_data
+raw: test[61[   62.234664] test_bpf: #132 ALU_DIV_K: 6 / 2 = 3 jited:0 110 PASS
+]_(int #
+# BTF raw test[62] (in[   62.244695] test_bpf: #133 ALU_DIV_K: 3 / 1 = 3 jited:0 103 PASS
+valid BTF_INFO) do_test_raw3662F[   62.253429] test_bpf: #134 ALU_DIV_K: 4294967295 / 4294967295 = 1 jited:0 103 PASS
+AIL expected err_strInvalid btf_info
+raw: test[[   62.263704] test_bpf: #135 ALU_DIV_K: 0xffffffffffffffff / (-1) = 0x1 jited:0 172 PASS
+62]_(invalid #
+# BTF raw test[6[   62.275602] test_bpf: #136 ALU64_DIV_K: 6 / 2 = 3 jited:0 91 PASS
+3] (fwd test. t->type != 0\") do_[   62.284349] test_bpf: #137 ALU64_DIV_K: 3 / 1 = 3 jited:0 91 PASS
+test_raw3662FAIL expected err_st[   62.293154] test_bpf: #138 ALU64_DIV_K: 2147483647 / 2147483647 = 1 jited:0 91 PASS
+rtype != 0
+raw: test[63]_(fwd #
+# BTF raw test[   62.303473] test_bpf: #139 ALU64_DIV_K: 0xffffffffffffffff / (-1) = 0x0000000000000001 jited:0 162 PASS
+[64] (typedef (invalid name, name_off = 0)) do_t[   62.316867] test_bpf: #140 ALU_MOD_X: 3 % 2 = 1 jited:0 136 PASS
+est_raw3662FAIL expected err_strInvalid name
+ra[   62.326975] test_bpf: #141 ALU_MOD_X: 4294967295 % 4294967293 = 2 jited:0 142 PASS
+w: test[64]_(typedef #
+# BTF raw test[65] (type[   62.338551] test_bpf: #142 ALU64_MOD_X: 3 % 2 = 1 jited:0 133 PASS
+def (invalid name, invalid identifier)) do_test_[   62.348794] test_bpf: #143 ALU64_MOD_X: 2147483647 % 2147483645 = 2 jited:0 126 PASS
+raw3662FAIL expected err_strInva[   62.360594] test_bpf: #144 ALU_MOD_K: 3 % 2 = 1 jited:0 106 PASS
+lid name
+raw: test[65]_(typedef[   62.369286] test_bpf: #145 ALU_MOD_K: 3 % 1 = 0 jited:0 PASS
+ #
+# BTF raw test[66] (ptr type[   62.377620] test_bpf: #146 ALU_MOD_K: 4294967295 % 4294967293 = 2 jited:0 106 PASS
+ (invalid name, name_off <> 0)) [   62.387880] test_bpf: #147 ALU64_MOD_K: 3 % 2 = 1 jited:0 105 PASS
+do_test_raw3662FAIL expected err[   62.396721] test_bpf: #148 ALU64_MOD_K: 3 % 1 = 0 jited:0 PASS
+_strInvalid name
+raw: test[66]_[   62.405235] test_bpf: #149 ALU64_MOD_K: 2147483647 % 2147483645 = 2 jited:0 105 PASS
+(ptr #
+# BTF raw test[67] (volatile type (inval[   62.415642] test_bpf: #150 ALU_AND_X: 3 & 2 = 2 jited:0 111 PASS
+id name, name_off <> 0)) do_test[   62.425676] test_bpf: #151 ALU_AND_X: 0xffffffff & 0xffffffff = 0xffffffff jited:0 105 PASS
+_raw3662FAIL expected err_strInv[   62.436741] test_bpf: #152 ALU64_AND_X: 3 & 2 = 2 jited:0 105 PASS
+alid name
+raw: test[67]_(volati[   62.445577] test_bpf: #153 ALU64_AND_X: 0xffffffff & 0xffffffff = 0xffffffff jited:0 105 PASS
+le #
+# BTF raw test[68] (const [   62.456785] test_bpf: #154 ALU_AND_K: 3 & 2 = 2 jited:0 88 PASS
+type (invalid name, name_off <> [   62.465362] test_bpf: #155 ALU_AND_K: 0xffffffff & 0xffffffff = 0xffffffff jited:0 88 PASS
+0)) do_test_raw3662FAIL expected[   62.476311] test_bpf: #156 ALU64_AND_K: 3 & 2 = 2 jited:0 88 PASS
+ err_strInvalid name
+raw: test[[   62.485065] test_bpf: #157 ALU64_AND_K: 0xffffffff & 0xffffffff = 0xffffffff jited:0 88 PASS
+68]_(const #
+# BTF raw test[69] (restrict type [   62.496182] test_bpf: #158 ALU64_AND_K: 0x0000ffffffff0000 & 0x0 = 0x0000ffff00000000 jited:0 148 PASS
+(invalid name, name_off <> 0)) do_test_raw3662FA[   62.509490] test_bpf: #159 ALU64_AND_K: 0x0000ffffffff0000 & -1 = 0x0000ffffffffffff jited:0 148 PASS
+IL expected err_strInvalid name
+raw: test[69]_([   62.522783] test_bpf: #160 ALU64_AND_K: 0xffffffffffffffff & -1 = 0xffffffffffffffff jited:0 155 PASS
+restrict #
+# BTF raw test[70] ([   62.535968] test_bpf: #161 ALU_OR_X: 1 | 2 = 3 jited:0 105 PASS
+fwd type (invalid name, name_off[   62.544590] test_bpf: #162 ALU_OR_X: 0x0 | 0xffffffff = 0xffffffff jited:0 105 PASS
+ = 0)) do_test_raw3662FAIL expected err_strInval[   62.554926] test_bpf: #163 ALU64_OR_X: 1 | 2 = 3 jited:0 111 PASS
+id name
+raw: test[70]_(fwd #
+#[   62.565047] test_bpf: #164 ALU64_OR_X: 0 | 0xffffffff = 0xffffffff jited:0 105 PASS
+ BTF raw test[71] (fwd type (inv[   62.575379] test_bpf: #165 ALU_OR_K: 1 | 2 = 3 jited:0 96 PASS
+alid name, invalid identifier)) [   62.583868] test_bpf: #166 ALU_OR_K: 0 & 0xffffffff = 0xffffffff jited:0 88 PASS
+do_test_raw3662FAIL expected err[   62.593978] test_bpf: #167 ALU64_OR_K: 1 | 2 = 3 jited:0 88 PASS
+_strInvalid name
+raw: test[71]_[   62.602650] test_bpf: #168 ALU64_OR_K: 0 & 0xffffffff = 0xffffffff jited:0 88 PASS
+(fwd #
+# BTF raw test[72] (array type (invalid [   62.612899] test_bpf: #169 ALU64_OR_K: 0x0000ffffffff0000 | 0x0 = 0x0000ffff00000000 jited:0 148 PASS
+name, name_off <> 0)) do_test_raw3662FAIL expect[   62.626138] test_bpf: #170 ALU64_OR_K: 0x0000ffffffff0000 | -1 = 0xffffffffffffffff jited:0 148 PASS
+ed err_strInvalid name
+raw: test[72]_(array #
+[   62.639311] test_bpf: #171 ALU64_OR_K: 0x000000000000000 | -1 = 0xffffffffffffffff jited:0 154 PASS
+# BTF raw test[73] (struct type [   62.652354] test_bpf: #172 ALU_XOR_X: 5 ^ 6 = 3 jited:0 105 PASS
+(name_off = 0)) do_test_raw3660F[   62.661066] test_bpf: #173 ALU_XOR_X: 0x1 ^ 0xffffffff = 0xfffffffe jited:0 105 PASS
+AIL btf_fd-1 test->btf_load_err0
+raw: test[73]_[   62.671483] test_bpf: #174 ALU64_XOR_X: 5 ^ 6 = 3 jited:0 111 PASS
+(struct #
+# BTF raw test[74] (s[   62.681682] test_bpf: #175 ALU64_XOR_X: 1 ^ 0xffffffff = 0xfffffffe jited:0 105 PASS
+truct type (invalid name, invali[   62.692113] test_bpf: #176 ALU_XOR_K: 5 ^ 6 = 3 jited:0 88 PASS
+d identifier)) do_test_raw3662FA[   62.700735] test_bpf: #177 ALU_XOR_K: 1 ^ 0xffffffff = 0xfffffffe jited:0 88 PASS
+IL expected err_strInvalid name[   62.710860] test_bpf: #178 ALU64_XOR_K: 5 ^ 6 = 3 jited:0 88 PASS
+raw: test[74]_(struct #
+# BTF [   62.719603] test_bpf: #179 ALU64_XOR_K: 1 & 0xffffffff = 0xfffffffe jited:0 96 PASS
+raw test[75] (struct member (name_off = 0)) do_t[   62.729926] test_bpf: #180 ALU64_XOR_K: 0x0000ffffffff0000 ^ 0x0 = 0x0000ffffffff0000 jited:0 148 PASS
+est_raw3660FAIL btf_fd-1 test->btf_load_err0
+ra[   62.743289] test_bpf: #181 ALU64_XOR_K: 0x0000ffffffff0000 ^ -1 = 0xffff00000000ffff jited:0 154 PASS
+w: test[75]_(struct #
+# BTF raw test[76] (struc[   62.756510] test_bpf: #182 ALU64_XOR_K: 0x000000000000000 ^ -1 = 0xffffffffffffffff jited:0 148 PASS
+t member (invalid name, invalid identifier)) do_[   62.769716] test_bpf: #183 ALU_LSH_X: 1 << 1 = 2 jited:0 107 PASS
+test_raw3662FAIL expected err_strInvalid name
+r[   62.779881] test_bpf: #184 ALU_LSH_X: 1 << 31 = 0x80000000 jited:0 107 PASS
+aw: test[76]_(struct #
+# BTF raw test[77] (enum[   62.790879] test_bpf: #185 ALU64_LSH_X: 1 << 1 = 2 jited:0 113 PASS
+ type (name_off = 0)) do_test_ra[   62.801154] test_bpf: #186 ALU64_LSH_X: 1 << 31 = 0x80000000 jited:0 107 PASS
+w3660FAIL btf_fd-1 test->btf_loa[   62.810990] test_bpf: #187 ALU_LSH_K: 1 << 1 = 2 jited:0 97 PASS
+d_err0
+raw: test[77]_(enum #
+#[   62.819640] test_bpf: #188 ALU_LSH_K: 1 << 31 = 0x80000000 jited:0 98 PASS
+ BTF raw test[78] (enum type (in[   62.829192] test_bpf: #189 ALU64_LSH_K: 1 << 1 = 2 jited:0 91 PASS
+valid name, invalid identifier))[   62.838098] test_bpf: #190 ALU64_LSH_K: 1 << 31 = 0x80000000 jited:0 91 PASS
+ do_test_raw3662FAIL expected er[   62.847801] test_bpf: #191 ALU_RSH_X: 2 >> 1 = 1 jited:0 107 PASS
+r_strInvalid name
+raw: test[78][   62.856551] test_bpf: #192 ALU_RSH_X: 0x80000000 >> 31 = 1 jited:0 107 PASS
+_(enum #
+# BTF raw test[79] (enum member (inval[   62.866229] test_bpf: #193 ALU64_RSH_X: 2 >> 1 = 1 jited:0 107 PASS
+id name, name_off = 0)) do_test_raw3662FAIL expe[   62.876540] test_bpf: #194 ALU64_RSH_X: 0x80000000 >> 31 = 1 jited:0 107 PASS
+cted err_strInvalid name
+raw: t[   62.887735] test_bpf: #195 ALU_RSH_K: 2 >> 1 = 1 jited:0 97 PASS
+est[79]_(enum #
+# BTF raw test[[   62.896393] test_bpf: #196 ALU_RSH_K: 0x80000000 >> 31 = 1 jited:0 91 PASS
+80] (enum member (invalid name, [   62.905979] test_bpf: #197 ALU64_RSH_K: 2 >> 1 = 1 jited:0 91 PASS
+invalid identifier)) do_test_raw[   62.914832] test_bpf: #198 ALU64_RSH_K: 0x80000000 >> 31 = 1 jited:0 91 PASS
+3662FAIL expected err_strInvalid name
+raw: test[   62.924540] test_bpf: #199 ALU_ARSH_X: 0xff00ff0000000000 >> 40 = 0xffffffffffff00ff jited:0 107 PASS
+[80]_(enum #
+# BTF raw test[81][   62.937798] test_bpf: #200 ALU_ARSH_K: 0xff00ff0000000000 >> 40 = 0xffffffffffff00ff jited:0 91 PASS
+ (arraymap invalid btf key (a bi[   62.949564] test_bpf: #201 ALU_NEG: -(3) = -3 jited:0 87 PASS
+t field)) do_test_raw3660FAIL bt[   62.958064] test_bpf: #202 ALU_NEG: -(-3) = 3 jited:0 87 PASS
+f_fd-1 test->btf_load_err0
+raw:[   62.966425] test_bpf: #203 ALU64_NEG: -(3) = -3 jited:0 88 PASS
+ test[81]_(arraymap #
+# BTF raw[   62.975046] test_bpf: #204 ALU64_NEG: -(-3) = 3 jited:0 95 PASS
+ test[82] (arraymap invalid btf [   62.983605] test_bpf: #205 ALU_END_FROM_BE 16: 0x0123456789abcdef -> 0xcdef jited:0 107 PASS
+key (!= 32 bits)) do_test_raw3660FAIL btf_fd-1 t[   62.994694] test_bpf: #206 ALU_END_FROM_BE 32: 0x0123456789abcdef -> 0x89abcdef jited:0 163 PASS
+est->btf_load_err0
+raw: test[82[   63.007517] test_bpf: #207 ALU_END_FROM_BE 64: 0x0123456789abcdef -> 0x89abcdef jited:0 102 PASS
+]_(arraymap #
+# BTF raw test[83[   63.018950] test_bpf: #208 ALU_END_FROM_LE 16: 0x0123456789abcdef -> 0xefcd jited:0 100 PASS
+] (arraymap invalid btf value (too small)) do_te[   63.030048] test_bpf: #209 ALU_END_FROM_LE 32: 0x0123456789abcdef -> 0xefcdab89 jited:0 151 PASS
+st_raw3660FAIL btf_fd-1 test->bt[   63.042911] test_bpf: #210 ALU_END_FROM_LE 64: 0x0123456789abcdef -> 0x67452301 jited:0 86 PASS
+f_load_err0
+raw: test[83]_(arraymap #
+# BTF ra[   63.054249] test_bpf: #211 ST_MEM_B: Store/Load byte: max negative jited:0 111 PASS
+w test[84] (arraymap invalid btf[   63.065967] test_bpf: #212 ST_MEM_B: Store/Load byte: max positive jited:0 111 PASS
+ value (too big)) do_test_raw3660FAIL btf_fd-1 t[   63.076277] test_bpf: #213 STX_MEM_B: Store/Load byte: max negative jited:0 128 PASS
+est->btf_load_err0
+raw: test[84[   63.088078] test_bpf: #214 ST_MEM_H: Store/Load half word: max negative jited:0 111 PASS
+]_(arraymap #
+# BTF raw test[85] (func proto (i[   63.098813] test_bpf: #215 ST_MEM_H: Store/Load half word: max positive jited:0 117 PASS
+nt (*)(int, unsigned int))) do_test_raw3660FAIL [   63.110904] test_bpf: #216 STX_MEM_H: Store/Load half word: max negative jited:0 136 PASS
+btf_fd-1 test->btf_load_err0
+raw: test[85]_(fun[   63.123120] test_bpf: #217 ST_MEM_W: Store/Load word: max negative jited:0 118 PASS
+c #
+# BTF raw test[86] (func proto (vararg)) do[   63.134817] test_bpf: #218 ST_MEM_W: Store/Load word: max positive jited:0 120 PASS
+_test_raw3660FAIL btf_fd-1 test->btf_load_err0
+[   63.146516] test_bpf: #219 STX_MEM_W: Store/Load word: max negative jited:0 128 PASS
+raw: test[86]_(func #
+# BTF raw test[87] (func [   63.158356] test_bpf: #220 ST_MEM_DW: Store/Load double word: max negative jited:0 111 PASS
+proto (vararg with name)) do_test_raw3662FAIL ex[   63.170718] test_bpf: #221 ST_MEM_DW: Store/Load double word: max negative 2 jited:0 179 PASS
+pected err_strInvalid arg#3
+raw: test[87]_(func[   63.183245] test_bpf: #222 ST_MEM_DW: Store/Load double word: max positive jited:0 120 PASS
+ #
+# BTF raw test[88] (func proto (arg after va[   63.195632] test_bpf: #223 STX_MEM_DW: Store/Load double word: max negative jited:0 138 PASS
+rarg)) do_test_raw3662FAIL expected err_strInval[   63.208108] test_bpf: #224 STX_XADD_W: Test: 0x12 + 0x10 = 0x22 jited:0 148 PASS
+id arg#2
+raw: test[88]_(func #[   63.219594] test_bpf: #225 STX_XADD_W: Test side-effects, r10: 0x12 + 0x10 = 0x22 jited:0 PASS
+# BTF raw test[89] (func proto (CONST=>TYPEDEF=[   63.230844] test_bpf: #226 STX_XADD_W: Test side-effects, r0: 0x12 + 0x10 = 0x22 jited:0 136 PASS
+>PTR=>FUNC_PROTO)) do_test_raw3660FAIL btf_fd-1 test->btf_load_err0
+raw: test[89]_(func #
+# BTF raw test[90] (func proto (TYPEDEF=>FUNC_PROTO)) do_test_raw3660FAIL btf_fd-1 test->btf_load_err0
+raw: test[90]_(func #
+# BTF raw test[91] (func proto (btf_resolve(arg))) do_test_raw3660FAIL btf_fd-1 test->btf_load_err0
+raw: test[91]_(func #
+# BTF raw test[92] (func proto (Not all arg has name)) do_test_raw3660FAIL btf_fd-1 test->btf_load_err0
+raw: test[92]_(func #
+# BTF raw test[93] (func proto (Bad arg name_off)) do_test_raw3662FAIL expected err_strInvalid arg#2
+raw: test[93]_(func #
+# BTF raw test[94] (func proto (Bad arg name)) do_test_raw3662FAIL expected err_strInvalid arg#2
+raw: test[94]_(func #
+# BTF raw test[95] (func proto (Invalid return type)) do_test_raw3662FAIL expected err_strInvalid return type
+raw: test[95]_(func #
+# BTF raw test[96] (func proto (with func name)) do_test_raw3662FAIL expected err_strInvalid name
+raw: test[96]_(func #
+# BTF raw test[97] (func proto (const void arg)) do_test_raw3662FAIL expected err_strInvalid arg#1
+raw: test[97]_(func #
+# BTF raw test[98] (func (void func(int a, unsigned int b))) do_test_raw3660FAIL btf_fd-1 test->btf_load_err0
+raw: test[98]_(func #
+# BTF raw test[99] (func (No func name)) do_test_raw3662FAIL expected err_strInvalid name
+raw: test[99]_(func #
+# BTF raw test[100] (func (Invalid func name)) do_test_raw3662FAIL expected err_strInvalid name
+raw: test[100]_(func #
+# BTF raw test[101] (func (Some arg has no name)) do_test_raw3662FAIL expected err_strInvalid arg#2
+raw: test[101]_(func #
+# BTF raw test[102] (func (Non zero vlen)) do_test_raw3662FAIL expected err_strvlen != 0
+raw: test[102]_(func #
+# BTF raw test[103] (func (Not referring to FUNC_PROTO)) do_test_raw3662FAIL expected err_strInvalid type_id
+raw: test[103]_(func #
+# BTF raw test[104] (invalid int kind_flag) do_test_raw3662FAIL expected err_strInvalid btf_info kind_flag
+raw: test[104]_(invalid #
+# BTF raw test[105] (invalid ptr kind_flag) do_test_raw3662FAIL expected err_strInvalid btf_info kind_flag
+raw: test[105]_(invalid #
+# BTF raw test[106] (invalid array kind_flag) do_test_raw3662FAIL expected err_strInvalid btf_info kind_flag
+raw: test[106]_(invalid #
+# BTF raw test[107] (invalid enum kind_flag) do_test_raw3662FAIL expected err_strInvalid btf_info kind_flag
+raw: test[107]_(invalid #
+# BTF raw test[108] (valid fwd kind_flag) do_test_raw3660FAIL btf_fd-1 test->btf_load_err0
+raw: test[108]_(valid #
+# BTF raw test[109] (invalid typedef kind_flag) do_test_raw3662FAIL expected err_strInvalid btf_info kind_flag
+raw: test[109]_(invalid #
+# BTF raw test[110] (invalid volatile kind_flag) do_test_raw3662FAIL expected err_strInvalid btf_info kind_flag
+raw: test[110]_(invalid #
+# BTF raw test[111] (invalid const kind_flag) do_test_raw3662FAIL expected err_strInvalid btf_info kind_flag
+raw: test[111]_(invalid #
+# BTF raw test[112] (invalid restrict kind_flag) do_test_raw3662FAIL expected err_strInvalid btf_info kind_flag
+raw: test[112]_(invalid #
+# BTF raw test[113] (invalid func kind_flag) do_test_raw3662FAIL expected err_strInvalid btf_info kind_flag
+raw: test[113]_(invalid #
+# BTF raw test[114] (invalid func_proto kind_flag) do_test_raw3662FAIL expected err_strInvalid btf_info kind_flag
+raw: test[114]_(invalid #
+# BTF raw test[115] (valid struct, kind_flag, bitfield_size = 0) do_test_raw3660FAIL btf_fd-1 test->btf_load_err0
+raw: test[115]_(valid #
+# BTF raw test[116] (valid struct, kind_flag, int member, bitfield_size != 0) do_test_raw3660FAIL btf_fd-1 test->btf_load_err0
+raw: test[116]_(valid #
+# BTF raw test[117] (valid union, kind_flag, int member, bitfield_size != 0) do_test_raw3660FAIL btf_fd-1 test->btf_load_err0
+raw: test[117]_(valid #
+# BTF raw test[118] (valid struct, kind_flag, enum member, bitfield_size != 0) do_test_raw3660FAIL btf_fd-1 test->btf_load_err0
+raw: test[118]_(valid #
+# BTF raw test[119] (valid union, kind_flag, enum member, bitfield_size != 0) do_test_raw3660FAIL btf_fd-1 test->btf_load_err0
+raw: test[119]_(valid #
+# BTF raw test[120] (valid struct, kind_flag, typedef member, bitfield_size != 0) do_test_raw3660FAIL btf_fd-1 test->btf_load_err0
+raw: test[120]_(valid #
+# BTF raw test[121] (valid union, kind_flag, typedef member, bitfield_size != 0) do_test_raw3660FAIL btf_fd-1 test->btf_load_err0
+raw: test[121]_(valid #
+# BTF raw test[122] (invalid struct, kind_flag, bitfield_size greater than struct size) do_test_raw3662FAIL expected err_strMember exceeds struct_size
+raw: test[122]_(invalid #
+# BTF raw test[123] (invalid struct, kind_flag, bitfield base_type int not regular) do_test_raw3662FAIL expected err_strInvalid member base type
+raw: test[123]_(invalid #
+# BTF raw test[124] (invalid struct, kind_flag, base_type int not regular) do_test_raw3662FAIL expected err_strInvalid member base type
+raw: test[124]_(invalid #
+# BTF raw test[125] (invalid union, kind_flag, bitfield_size greater than struct size) do_test_raw3662FAIL expected err_strMember exceeds struct_size
+raw: test[125]_(invalid #
+# BTF raw test[126] (invalid struct, kind_flag, int member, bitfield_size = 0, wrong byte alignment) do_test_raw3662FAIL expected err_strInvalid member offset
+raw: test[126]_(invalid #
+# BTF raw test[127] (invalid struct, kind_flag, enum member, bitfield_size = 0, wrong byte alignment) do_test_raw3662FAIL expected err_strInvalid member offset
+raw: test[127]_(invalid #
+# BTF raw test[128] (128-bit int) do_test_raw3660FAIL btf_fd-1 test->btf_load_err0
+raw: test[128]_(128-bit #
+# BTF raw test[129] (struct, 128-bit int member) do_test_raw3660FAIL btf_fd-1 test->btf_load_err0
+raw: test[129]_(struct, #
+# BTF raw test[130] (struct, 120-bit int member bitfield) do_test_raw3660FAIL btf_fd-1 test->btf_load_err0
+raw: test[130]_(struct, #
+# BTF raw test[131] (struct, kind_flag, 128-bit int member) do_test_raw3660FAIL btf_fd-1 test->btf_load_err0
+raw: test[131]_(struct, #
+# BTF raw test[132] (struct, kind_flag, 120-bit int member bitfield) do_test_raw3660FAIL btf_fd-1 test->btf_load_err0
+raw: test[132]_(struct, #
+# BTF raw test[133] (struct->ptr->typedef->array->int size resolution) do_test_raw3660FAIL btf_fd-1 test->btf_load_err0
+raw: test[133]_(struct->ptr->typedef->array->int #
+# BTF raw test[134] (struct->ptr->typedef->multi-array->int size resolution) do_test_raw3660FAIL btf_fd-1 test->btf_load_err0
+raw: test[134]_(struct->ptr->typedef->multi-array->int #
+# BTF raw test[135] (typedef/multi-arr mix size resolution) do_test_raw3660FAIL btf_fd-1 test->btf_load_err0
+raw: test[135]_(typedef/multi-arr #
+# BTF GET_INFO test[1] (== raw_btf_size+1) do_test_get_info4035FAIL errno22
+GET_INFO: test[1]_(== #
+# BTF GET_INFO test[2] (== raw_btf_size-3) do_test_get_info4035FAIL errno22
+GET_INFO: test[2]_(== #
+# BTF GET_INFO test[3] (Large bpf_btf_info) test_big_btf_info3813FAIL errno22
+GET_INFO: test[3]_(Large #
+# BTF GET_INFO test[4] (BTF ID) test_btf_id3901FAIL errno22
+GET_INFO: test[4]_(BTF #
+# BTF libbpf test[1] (test_btf_haskv.o) SKIP. No ELF .BTF found
+libbpf: test[1]_(test_btf_haskv.o) #
+# BTF libbpf test[2] (test_btf_newkv.o) SKIP. No ELF .BTF found
+libbpf: test[2]_(test_btf_newkv.o) #
+# BTF libbpf test[3] (test_btf_nokv.o) SKIP. No ELF .BTF found
+libbpf: test[3]_(test_btf_nokv.o) #
+# BTF prog info raw test[1] (func_type (main func + one sub)) do_test_info_raw6166FAIL invalid btf_fd errno22
+prog: info_raw #
+# BTF prog info raw test[2] (func_type (Incorrect func_info_rec_size)) do_test_info_raw6166FAIL invalid btf_fd errno22
+prog: info_raw #
+# BTF prog info raw test[3] (func_type (Incorrect func_info_cnt)) do_test_info_raw6166FAIL invalid btf_fd errno22
+prog: info_raw #
+# BTF prog info raw test[4] (func_type (Incorrect bpf_func_info.insn_off)) do_test_info_raw6166FAIL invalid btf_fd errno22
+prog: info_raw #
+# BTF prog info raw test[5] (line_info (No subprog)) do_test_info_raw6166FAIL invalid btf_fd errno22
+prog: info_raw #
+# BTF prog info raw test[6] (line_info (No subprog. insn_off >= prog->len)) do_test_info_raw6166FAIL invalid btf_fd errno22
+prog: info_raw #
+# BTF prog info raw test[7] (line_info (Zero bpf insn code)) do_test_info_raw6166FAIL invalid btf_fd errno22
+prog: info_raw #
+# BTF prog info raw test[8] (line_info (No subprog. zero tailing line_info) do_test_info_raw6166FAIL invalid btf_fd errno22
+prog: info_raw #
+# BTF prog info raw test[9] (line_info (No subprog. nonzero tailing line_info)) do_test_info_raw6166FAIL invalid btf_fd errno22
+prog: info_raw #
+# BTF prog info raw test[10] (line_info (subprog)) do_test_info_raw6166FAIL invalid btf_fd errno22
+prog: info_raw #
+# BTF prog info raw test[11] (line_info (subprog + func_info)) do_test_info_raw6166FAIL invalid btf_fd errno22
+prog: info_raw #
+# BTF prog info raw test[12] (line_info (subprog. missing 1st func line info)) do_test_info_raw6166FAIL invalid btf_fd errno22
+prog: info_raw #
+# BTF prog info raw test[13] (line_info (subprog. missing 2nd func line info)) do_test_info_raw6166FAIL invalid btf_fd errno22
+prog: info_raw #
+# BTF prog info raw test[14] (line_info (subprog. unordered insn offset)) do_test_info_raw6166FAIL invalid btf_fd errno22
+prog: info_raw #
+# BTF prog info raw test[15] (line_info (dead start)) do_test_info_raw6166FAIL invalid btf_fd errno22
+prog: info_raw #
+# BTF prog info raw test[16] (line_info (dead end)) do_test_info_raw6166FAIL invalid btf_fd errno22
+prog: info_raw #
+# BTF prog info raw test[17] (line_info (dead code + subprog + func_info)) do_test_info_raw6166FAIL invalid btf_fd errno22
+prog: info_raw #
+# BTF prog info raw test[18] (line_info (dead subprog)) do_test_info_raw6166FAIL invalid btf_fd errno22
+prog: info_raw #
+# BTF prog info raw test[19] (line_info (dead last subprog)) do_test_info_raw6166FAIL invalid btf_fd errno22
+prog: info_raw #
+# BTF prog info raw test[20] (line_info (dead subprog + dead start)) do_test_info_raw6166FAIL invalid btf_fd errno22
+prog: info_raw #
+# BTF prog info raw test[21] (line_info (dead subprog + dead start w/ move)) do_test_info_raw6166FAIL invalid btf_fd errno22
+prog: info_raw #
+# BTF prog info raw test[22] (line_info (dead end + subprog start w/ no linfo)) do_test_info_raw6166FAIL invalid btf_fd errno22
+prog: info_raw #
+# BTF dedup test[1] (dedup unused strings filtering)OK
+dedup: test[1]_(dedup #
+# BTF dedup test[2] (dedup strings deduplication)OK
+dedup: test[2]_(dedup #
+# BTF dedup test[3] (dedup struct example #1)OK
+dedup: test[3]_(dedup #
+# BTF dedup test[4] (dedup struct <-> fwd resolution w/ hash collision)OK
+dedup: test[4]_(dedup #
+# BTF dedup test[5] (dedup void equiv check)OK
+dedup: test[5]_(dedup #
+# BTF dedup test[6] (dedup all possible kinds (no duplicates))OK
+dedup: test[6]_(dedup #
+# BTF dedup test[7] (dedup no int duplicates)OK
+dedup: test[7]_(dedup #
+# BTF dedup test[8] (dedup enum fwd resolution)OK
+dedup: test[8]_(dedup #
+# BTF dedup test[9] (dedup datasec and vars pass-through)OK
+dedup: test[9]_(dedup #
+# PASS9 SKIP3 FAIL161
+SKIP3: FAIL161_ #
+[FAIL] 12 selftests bpf test_btf
+selftests: bpf_test_btf [FAIL]
+# selftests bpf test_sockmap
+bpf: test_sockmap_ #
+# libbpf BTF is required, but is missing or corrupted.
+BTF: is_required, #
+# ERROR (-1) load bpf failed
+(-1): load_bpf #
+# Unable to load eBPF objects in file 'test_sockmap_kern.o'  No such file or directory
+to: load_eBPF #
+[FAIL] 13 selftests bpf test_sockmap
+selftests: bpf_test_sockmap [FAIL]
+# selftests bpf get_cgroup_id_user
+bpf: get_cgroup_id_user_ #
+# libbpf BTF is required, but is missing or corrupted.
+BTF: is_required, #
+# mainPASSsetup_cgroup_environment
+: _ #
+# mainPASScreate_and_get_cgroup
+: _ #
+# mainPASSjoin_cgroup
+: _ #
+# mainFAILbpf_prog_load err -2 errno 22
+err: -2_errno #
+[FAIL] 14 selftests bpf get_cgroup_id_user
+selftests: bpf_get_cgroup_id_user [FAIL]
+# selftests bpf test_socket_cookie
+bpf: test_socket_cookie_ #
+# libbpf BTF is required, but is missing or corrupted.
+BTF: is_required, #
+# (test_socket_cookie.c149 errno Invalid argument) Failed to load ./socket_cookie_prog.o
+errno: Invalid_argument) #
+# FAILED
+: _ #
+[FAIL] 15 selftests bpf test_socket_cookie
+selftests: bpf_test_socket_cookie [FAIL]
+# selftests bpf test_cgroup_storage
+bpf: test_cgroup_storage_ #
+# Failed to create map Invalid argument
+to: create_map #
+[FAIL] 16 selftests bpf test_cgroup_storage
+selftests: bpf_test_cgroup_storage [FAIL]
+# selftests bpf test_select_reuseport
+bpf: test_select_reuseport_ #
+# create_maps(71)FAILcreating reuseport_array reuseport_array-1 errno22
+reuseport_array: reuseport_array-1_errno22 #
+[FAIL] 17 selftests bpf test_select_reuseport
+selftests: bpf_test_select_reuseport [FAIL]
+# selftests bpf test_section_names
+bpf: test_section_names_ #
+# libbpf failed to guess program type based on ELF section name 'InvAliD'
+failed: to_guess #
+# libbpf supported section(type) names are socket kprobe/ kretprobe/ classifier action tracepoint/ raw_tracepoint/ xdp perf_event lwt_in lwt_out lwt_xmit lwt_seg6local cgroup_skb/ingress cgroup_skb/egress cgroup/skb cgroup/sock cgroup/post_bind4 cgroup/post_bind6 cgroup/dev sockops sk_skb/stream_parser sk_skb/stream_verdict sk_skb sk_msg lirc_mode2 flow_dissector cgroup/bind4 cgroup/bind6 cgroup/connect4 cgroup/connect6 cgroup/sendmsg4 cgroup/sendmsg6 cgroup/recvmsg4 cgroup/recvmsg6 cgroup/sysctl cgroup/getsockopt cgroup/setsockopt
+supported: section(type)_names #
+# libbpf failed to guess attach type based on ELF section name 'InvAliD'
+failed: to_guess #
+# libbpf attachable section(type) names are cgroup_skb/ingress cgroup_skb/egress cgroup/sock cgroup/post_bind4 cgroup/post_bind6 cgroup/dev sockops sk_skb/stream_parser sk_skb/stream_verdict sk_msg lirc_mode2 flow_dissector cgroup/bind4 cgroup/bind6 cgroup/connect4 cgroup/connect6 cgroup/sendmsg4 cgroup/sendmsg6 cgroup/recvmsg4 cgroup/recvmsg6 cgroup/sysctl cgroup/getsockopt cgroup/setsockopt
+attachable: section(type)_names #
+# libbpf failed to guess program type based on ELF section name 'cgroup'
+failed: to_guess #
+# libbpf supported section(type) names are socket kprobe/ kretprobe/ classifier action tracepoint/ raw_tracepoint/ xdp perf_event lwt_in lwt_out lwt_xmit lwt_seg6local cgroup_skb/ingress cgroup_skb/egress cgroup/skb cgroup/sock cgroup/post_bind4 cgroup/post_bind6 cgroup/dev sockops sk_skb/stream_parser sk_skb/stream_verdict sk_skb sk_msg lirc_mode2 flow_dissector cgroup/bind4 cgroup/bind6 cgroup/connect4 cgroup/connect6 cgroup/sendmsg4 cgroup/sendmsg6 cgroup/recvmsg4 cgroup/recvmsg6 cgroup/sysctl cgroup/getsockopt cgroup/setsockopt
+supported: section(type)_names #
+# libbpf failed to guess attach type based on ELF section name 'cgroup'
+failed: to_guess #
+# libbpf attachable section(type) names are cgroup_skb/ingress cgroup_skb/egress cgroup/sock cgroup/post_bind4 cgroup/post_bind6 cgroup/dev sockops sk_skb/stream_parser sk_skb/stream_verdict sk_msg lirc_mode2 flow_dissector cgroup/bind4 cgroup/bind6 cgroup/connect4 cgroup/connect6 cgroup/sendmsg4 cgroup/sendmsg6 cgroup/recvmsg4 cgroup/recvmsg6 cgroup/sysctl cgroup/getsockopt cgroup/setsockopt
+attachable: section(type)_names #
+# Summary 40 PASSED, 0 FAILED
+40: PASSED,_0 #
+[PASS] 18 selftests bpf test_section_names
+selftests: bpf_test_section_names [PASS]
+# selftests bpf test_netcnt
+bpf: test_netcnt_ #
+# libbpf BTF is required, but is missing or corrupted.
+BTF: is_required, #
+# Failed to load bpf program
+to: load_bpf #
+[FAIL] 19 selftests bpf test_netcnt
+selftests: bpf_test_netcnt [FAIL]
+# selftests bpf test_tcpnotify_user
+bpf: test_tcpnotify_user_ #
+# libbpf BTF is required, but is missing or corrupted.
+BTF: is_required, #
+# FAILED load_bpf_file failed for test_tcpnotify_kern.o
+load_bpf_file: failed_for #
+[FAIL] 20 selftests bpf test_tcpnotify_user
+selftests: bpf_test_tcpnotify_user [FAIL]
+# selftests bpf test_sock_fields
+bpf: test_sock_fields_ #
+# libbpf BTF is required, but is missing or corrupted.
+BTF: is_required, #
+# main(439)FAILbpf_prog_load_xattr() err-2
+err-2: _ #
+[FAIL] 21 selftests bpf test_sock_fields
+selftests: bpf_test_sock_fields [FAIL]
+# selftests bpf test_sysctl
+bpf: test_sysctl_ #
+# (test_sysctl.c1402 errno Invalid argument) >>> Loading program error.
+errno: Invalid_argument) #
+# >>> Verifier output
+Verifier: output_ #
+# 
+: _ #
+# -------
+: _ #
+# 
+: _ #
+# (test_sysctl.c1402 errno Invalid argument) >>> Loading program error.
+errno: Invalid_argument) #
+# >>> Verifier output
+Verifier: output_ #
+# 
+: _ #
+# -------
+: _ #
+# 
+: _ #
+# (test_sysctl.c1402 errno Invalid argument) >>> Loading program error.
+errno: Invalid_argument) #
+# >>> Verifier output
+Verifier: output_ #
+# 
+: _ #
+# -------
+: _ #
+# 
+: _ #
+# (test_sysctl.c1402 errno Invalid argument) >>> Loading program error.
+errno: Invalid_argument) #
+# >>> Verifier output
+Verifier: output_ #
+# 
+: _ #
+# -------
+: _ #
+# 
+: _ #
+# (test_sysctl.c1402 errno Invalid argument) >>> Loading program error.
+errno: Invalid_argument) #
+# >>> Verifier output
+Verifier: output_ #
+# 
+: _ #
+# -------
+: _ #
+# 
+: _ #
+# (test_sysctl.c1402 errno Invalid argument) >>> Loading program error.
+errno: Invalid_argument) #
+# >>> Verifier output
+Verifier: output_ #
+# 
+: _ #
+# -------
+: _ #
+# 
+: _ #
+# (test_sysctl.c1402 errno Invalid argument) >>> Loading program error.
+errno: Invalid_argument) #
+# >>> Verifier output
+Verifier: output_ #
+# 
+: _ #
+# -------
+: _ #
+# 
+: _ #
+# (test_sysctl.c1402 errno Invalid argument) >>> Loading program error.
+errno: Invalid_argument) #
+# >>> Verifier output
+Verifier: output_ #
+# 
+: _ #
+# -------
+: _ #
+# 
+: _ #
+# (test_sysctl.c1402 errno Invalid argument) >>> Loading program error.
+errno: Invalid_argument) #
+# >>> Verifier output
+Verifier: output_ #
+# 
+: _ #
+# -------
+: _ #
+# 
+: _ #
+# (test_sysctl.c1402 errno Invalid argument) >>> Loading program error.
+errno: Invalid_argument) #
+# >>> Verifier output
+Verifier: output_ #
+# 
+: _ #
+# -------
+: _ #
+# 
+: _ #
+# (test_sysctl.c1402 errno Invalid argument) >>> Loading program error.[   63.243715] test_bpf: #227 STX_XADD_W: X + 1 + 1 + 1 + ... jited:0 155625 PASS
+errno: Invalid_argument) #
+# >>> Verifier outp[   64.810767] test_bpf: #228 STX_XADD_DW: Test: 0x12 + 0x10 = 0x22 jited:0 156 PASS
+ut
+Verifier: output_ #
+# 
+: _[   64.822299] test_bpf: #229 STX_XADD_DW: Test side-effects, r10: 0x12 + 0x10 = 0x22 jited:0 PASS
+ #
+# -------
+: _ #
+# 
+: _ #
+# (test_sysctl.[   64.833736] test_bpf: #230 STX_XADD_DW: Test side-effects, r0: 0x12 + 0x10 = 0x22 jited:0 127 PASS
+c1402 errno Invalid argument) >>> Loading program error.
+errno: Invalid_argument) #
+# >>> Verifier output
+Verifier: output_ #
+# 
+: _ #
+# -------
+: _ #
+# 
+: _ #
+# (test_sysctl.c1402 errno Invalid argument) >>> Loading program error.
+errno: Invalid_argument) #
+# >>> Verifier output
+Verifier: output_ #
+# 
+: _ #
+# -------
+: _ #
+# 
+: _ #
+# (test_sysctl.c1402 errno Invalid argument) >>> Loading program error.
+errno: Invalid_argument) #
+# >>> Verifier output
+Verifier: output_ #
+# 
+: _ #
+# -------
+: _ #
+# 
+: _ #
+# (test_sysctl.c1402 errno Invalid argument) >>> Loading program error.
+errno: Invalid_argument) #
+# >>> Verifier output
+Verifier: output_ #
+# 
+: _ #
+# -------
+: _ #
+# 
+: _ #
+# (test_sysctl.c1402 errno Invalid argument) >>> Loading program error.
+errno: Invalid_argument) #
+# >>> Verifier output
+Verifier: output_ #
+# 
+: _ #
+# -------
+: _ #
+# 
+: _ #
+# (test_sysctl.c1402 errno Invalid argument) >>> Loading program error.
+errno: Invalid_argument) #
+# >>> Verifier output
+Verifier: output_ #
+# 
+: _ #
+# -------
+: _ #
+# 
+: _ #
+# (test_sysctl.c1402 errno Invalid argument) >>> Loading program error.
+errno: Invalid_argument) #
+# >>> Verifier output
+Verifier: output_ #
+# 
+: _ #
+# -------
+: _ #
+# 
+: _ #
+# (test_sysctl.c1402 errno Invalid argument) >>> Loading program error.
+errno: Invalid_argument) #
+# >>> Verifier output
+Verifier: output_ #
+# 
+: _ #
+# -------
+: _ #
+# 
+: _ #
+# (test_sysctl.c1402 errno Invalid argument) >>> Loading program error.
+errno: Invalid_argument) #
+# >>> Verifier output
+Verifier: output_ #
+# 
+: _ #
+# -------
+: _ #
+# 
+: _ #
+# (test_sysctl.c1402 errno Invalid argument) >>> Loading program error.
+errno: Invalid_argument) #
+# >>> Verifier output
+Verifier: output_ #
+# 
+: _ #
+# -------
+: _ #
+# 
+: _ #
+# (test_sysctl.c1402 errno Invalid argument) >>> Loading program error.
+errno: Invalid_argument) #
+# >>> Verifier output
+Verifier: output_ #
+# 
+: _ #
+# -------
+: _ #
+# 
+: _ #
+# (test_sysctl.c1402 errno Invalid argument) >>> Loading program error.
+errno: Invalid_argument) #
+# >>> Verifier output
+Verifier: output_ #
+# 
+: _ #
+# -------
+: _ #
+# 
+: _ #
+# (test_sysctl.c1402 errno Invalid argument) >>> Loading program error.
+errno: Invalid_argument) #
+# >>> Verifier output
+Verifier: output_ #
+# 
+: _ #
+# -------
+: _ #
+# 
+: _ #
+# (test_sysctl.c1402 errno Invalid argument) >>> Loading program error.
+errno: Invalid_argument) #
+# >>> Verifier output
+Verifier: output_ #
+# 
+: _ #
+# -------
+: _ #
+# 
+: _ #
+# (test_sysctl.c1402 errno Invalid argument) >>> Loading program error.
+errno: Invalid_argument) #
+# >>> Verifier output
+Verifier: output_ #
+# 
+: _ #
+# -------
+: _ #
+# 
+: _ #
+# (test_sysctl.c1402 errno Invalid argument) >>> Loading program error.
+errno: Invalid_argument) #
+# >>> Verifier output
+Verifier: output_ #
+# 
+: _ #
+# -------
+: _ #
+# 
+: _ #
+# (test_sysctl.c1402 errno Invalid argument) >>> Loading program error.
+errno: Invalid_argument) #
+# >>> Verifier output
+Verifier: output_ #
+# 
+: _ #
+# -------
+: _ #
+# 
+: _ #
+# (test_sysctl.c1402 errno Invalid argument) >>> Loading program error.
+errno: Invalid_argument) #
+# >>> Verifier output
+Verifier: output_ #
+# 
+: _ #
+# -------
+: _ #
+# 
+: _ #
+# (test_sysctl.c1402 errno Invalid argument) >>> Loading program error.
+errno: Invalid_argument) #
+# >>> Verifier output
+Verifier: output_ #
+# 
+: _ #
+# -------
+: _ #
+# 
+: _ #
+# (test_sysctl.c1402 errno Invalid argument) >>> Loading program error.
+errno: Invalid_argument) #
+# >>> Verifier output
+Verifier: output_ #
+# 
+: _ #
+# -------
+: _ #
+# 
+: _ #
+# (test_sysctl.c1402 errno Invalid argument) >>> Loading program error.
+errno: Invalid_argument) #
+# >>> Verifier output
+Verifier: output_ #
+# 
+: _ #
+# -------
+: _ #
+# 
+: _ #
+# (test_sysctl.c1402 errno Invalid argument) >>> Loading program error.
+errno: Invalid_argument) #
+# >>> Verifier output
+Verifier: output_ #
+# 
+: _ #
+# -------
+: _ #
+# 
+: _ #
+# (test_sysctl.c1402 errno Invalid argument) >>> Loading program error.
+errno: Invalid_argument) #
+# >>> Verifier output
+Verifier: output_ #
+# 
+: _ #
+# -------
+: _ #
+# 
+: _ #
+# libbpf load bpf program failed Invalid argument
+load: bpf_program #
+# libbpf failed to load program 'cgroup/sysctl'
+failed: to_load #
+# libbpf failed to load object './test_sysctl_prog.o'
+failed: to_load #
+# (test_sysctl.c1421 errno Invalid argument) >>> Loading program (./test_sysctl_prog.o) error.
+errno: Invalid_argument) #
+# 
+: _ #
+# libbpf load bpf program failed Invalid argument
+load: bpf_program #
+# libbpf failed to load program 'cgroup/sysctl'
+failed: to_load #
+# libbpf failed to load object './test_sysctl_prog.o'
+failed: to_load #
+# (test_sysctl.c1421 errno Invalid argument) >>> Loading program (./test_sysctl_prog.o) error.
+errno: Invalid_argument) #
+# 
+: _ #
+# libbpf load bpf program failed Invalid argument
+load: bpf_program #
+# libbpf failed to load program 'cgroup/sysctl'
+failed: to_load #
+# libbpf failed to load object './test_sysctl_prog.o'
+failed: to_load #
+# (test_sysctl.c1421 errno Invalid argument) >>> Loading program (./test_sysctl_prog.o) error.
+errno: Invalid_argument) #
+# 
+: _ #
+# Test case sysctl wrong attach_type .. [FAIL]
+case: sysctl_wrong #
+# Test case sysctlread allow all .. [FAIL]
+case: sysctlread_allow #
+# Test case sysctlread deny all .. [FAIL]
+case: sysctlread_deny #
+# Test case ctxwrite sysctlread read ok .. [FAIL]
+case: ctxwrite_sysctlread #
+# Test case ctxwrite sysctlwrite read ok .. [FAIL]
+case: ctxwrite_sysctlwrite #
+# Test case ctxwrite sysctlread write reject .. [PASS]
+case: ctxwrite_sysctlread #
+# Test case ctxfile_pos sysctlread read ok .. [FAIL]
+case: ctxfile_pos_sysctlread #
+# Test case ctxfile_pos sysctlread read ok narrow .. [FAIL]
+case: ctxfile_pos_sysctlread #
+# Test case ctxfile_pos sysctlread write ok .. [FAIL]
+case: ctxfile_pos_sysctlread #
+# Test case sysctl_get_name sysctl_valuebase ok .. [FAIL]
+case: sysctl_get_name_sysctl_valuebase #
+# Test case sysctl_get_name sysctl_valuebase E2BIG truncated .. [FAIL]
+case: sysctl_get_name_sysctl_valuebase #
+# Test case sysctl_get_name sysctlfull ok .. [FAIL]
+case: sysctl_get_name_sysctlfull #
+# Test case sysctl_get_name sysctlfull E2BIG truncated .. [FAIL]
+case: sysctl_get_name_sysctlfull #
+# Test case sysctl_get_name sysctlfull E2BIG truncated small .. [FAIL]
+case: sysctl_get_name_sysctlfull #
+# Test case sysctl_get_current_value sysctlread ok, gt .. [FAIL]
+case: sysctl_get_current_value_sysctlread #
+# Test case sysctl_get_current_value sysctlread ok, eq .. [FAIL]
+case: sysctl_get_current_value_sysctlread #
+# Test case sysctl_get_current_value sysctlread E2BIG truncated .. [FAIL]
+case: sysctl_get_current_value_sysctlread #
+# Test case sysctl_get_current_value sysctlread EINVAL .. [FAIL]
+case: sysctl_get_current_value_sysctlread #
+# Test case sysctl_get_current_value sysctlwrite ok .. [FAIL]
+case: sysctl_get_current_value_sysctlwrite #
+# Test case sysctl_get_new_value sysctlread EINVAL .. [FAIL]
+case: sysctl_get_new_value_sysctlread #
+# Test case sysctl_get_new_value sysctlwrite ok .. [FAIL]
+case: sysctl_get_new_value_sysctlwrite #
+# Test case sysctl_get_new_value sysctlwrite ok long .. [FAIL]
+case: sysctl_get_new_value_sysctlwrite #
+# Test case sysctl_get_new_value sysctlwrite E2BIG .. [FAIL]
+case: sysctl_get_new_value_sysctlwrite #
+# Test case sysctl_set_new_value sysctlread EINVAL .. [FAIL]
+case: sysctl_set_new_value_sysctlread #
+# Test case sysctl_set_new_value sysctlwrite ok .. [FAIL]
+case: sysctl_set_new_value_sysctlwrite #
+# Test case bpf_strtoul one number string .. [FAIL]
+case: bpf_strtoul_one #
+# Test case bpf_strtoul multi number string .. [FAIL]
+case: bpf_strtoul_multi #
+# Test case bpf_strtoul buf_len = 0, reject .. [PASS]
+case: bpf_strtoul_buf_len #
+# Test case bpf_strtoul supported base, ok .. [FAIL]
+case: bpf_strtoul_supported #
+# Test case bpf_strtoul unsupported base, EINVAL .. [FAIL]
+case: bpf_strtoul_unsupported #
+# Test case bpf_strtoul buf with spaces only, EINVAL .. [FAIL]
+case: bpf_strtoul_buf #
+# Test case bpf_strtoul negative number, EINVAL .. [FAIL]
+case: bpf_strtoul_negative #
+# Test case bpf_strtol negative number, ok .. [FAIL]
+case: bpf_strtol_negative #
+# Test case bpf_strtol hex number, ok .. [FAIL]
+case: bpf_strtol_hex #
+# Test case bpf_strtol max long .. [FAIL]
+case: bpf_strtol_max #
+# Test case bpf_strtol overflow, ERANGE .. [FAIL]
+case: bpf_strtol_overflow, #
+# Test case C prog deny all writes .. [FAIL]
+case: C_prog #
+# Test case C prog deny access by name .. [FAIL]
+case: C_prog #
+[   64.846671] test_bpf: #231 STX_XADD_DW: X + 1 + 1 + 1 + ... jited:0 155654 PASS
+[   66.411414] test_bpf: #232 JMP_EXIT jited:0 70 PASS
+[   66.417498] test_bpf: #233 JMP_JA: Unconditional jump: if (true) return 1 jited:0 101 PASS
+[   66.426916] test_bpf: #234 JMP_JSLT_K: Signed jump: if (-2 < -1) return 1 jited:0 127 PASS
+[   66.436602] test_bpf: #235 JMP_JSLT_K: Signed jump: if (-1 < -1) return 0 jited:0 113 PASS
+[   66.446122] test_bpf: #236 JMP_JSGT_K: Signed jump: if (-1 > -2) return 1 jited:0 127 PASS
+[   66.455792] test_bpf: #237 JMP_JSGT_K: Signed jump: if (-1 > -1) return 0 jited:0 107 PASS
+[   66.465269] test_bpf: #238 JMP_JSLE_K: Signed jump: if (-2 <= -1) return 1 jited:0 127 PASS
+[   66.475041] test_bpf: #239 JMP_JSLE_K: Signed jump: if (-1 <= -1) return 1 jited:0 127 PASS
+[   66.484816] test_bpf: #240 JMP_JSLE_K: Signed jump: value walk 1 jited:0 247 PASS
+[   66.494901] test_bpf: #241 JMP_JSLE_K: Signed jump: value walk 2 jited:0 203 PASS
+[   66.504613] test_bpf: #242 JMP_JSGE_K: Signed jump: if (-1 >= -2) return 1 jited:0 138 PASS
+[   66.514462] test_bpf: #243 JMP_JSGE_K: Signed jump: if (-1 >= -1) return 1 jited:0 127 PASS
+[   66.524217] test_bpf: #244 JMP_JSGE_K: Signed jump: value walk 1 jited:0 249 PASS
+[   66.534298] test_bpf: #245 JMP_JSGE_K: Signed jump: value walk 2 jited:0 203 PASS
+[   66.543983] test_bpf: #246 JMP_JGT_K: if (3 > 2) return 1 jited:0 134 PASS
+[   66.552328] test_bpf: #247 JMP_JGT_K: Unsigned jump: if (-1 > 1) return 1 jited:0 135 PASS
+[   66.562066] test_bpf: #248 JMP_JLT_K: if (2 < 3) return 1 jited:0 127 PASS
+[   66.570355] test_bpf: #249 JMP_JGT_K: Unsigned jump: if (1 < -1) return 1 jited:0 127 PASS
+[   66.580040] test_bpf: #250 JMP_JGE_K: if (3 >= 2) return 1 jited:0 134 PASS
+[   66.588469] test_bpf: #251 JMP_JLE_K: if (2 <= 3) return 1 jited:0 135 PASS
+[   66.596899] test_bpf: #252 JMP_JGT_K: if (3 > 2) return 1 (jump backwards) jited:0 151 PASS
+[   66.606855] test_bpf: #253 JMP_JGE_K: if (3 >= 3) return 1 jited:0 127 PASS
+[   66.615245] test_bpf: #254 JMP_JGT_K: if (2 < 3) return 1 (jump backwards) jited:0 143 PASS
+[   66.625194] test_bpf: #255 JMP_JLE_K: if (3 <= 3) return 1 jited:0 127 PASS
+[   66.633601] test_bpf: #256 JMP_JNE_K: if (3 != 2) return 1 jited:0 127 PASS
+[   66.641981] test_bpf: #257 JMP_JEQ_K: if (3 == 3) return 1 jited:0 127 PASS
+[   66.650379] test_bpf: #258 JMP_JSET_K: if (0x3 & 0x2) return 1 jited:0 127 PASS
+[   66.659103] test_bpf: #259 JMP_JSET_K: if (0x3 & 0xffffffff) return 1 jited:0 127 PASS
+[   66.668445] test_bpf: #260 JMP_JSGT_X: Signed jump: if (-1 > -2) return 1 jited:0 152 PASS
+[   66.678359] test_bpf: #261 JMP_JSGT_X: Signed jump: if (-1 > -1) return 0 jited:0 123 PASS
+[   66.687992] test_bpf: #262 JMP_JSLT_X: Signed jump: if (-2 < -1) return 1 jited:0 154 PASS
+[   66.697894] test_bpf: #263 JMP_JSLT_X: Signed jump: if (-1 < -1) return 0 jited:0 123 PASS
+[   66.707543] test_bpf: #264 JMP_JSGE_X: Signed jump: if (-1 >= -2) return 1 jited:0 146 PASS
+[   66.717518] test_bpf: #265 JMP_JSGE_X: Signed jump: if (-1 >= -1) return 1 jited:0 146 PASS
+[   66.727482] test_bpf: #266 JMP_JSLE_X: Signed jump: if (-2 <= -1) return 1 jited:0 146 PASS
+[   66.737436] test_bpf: #267 JMP_JSLE_X: Signed jump: if (-1 <= -1) return 1 jited:0 146 PASS
+[   66.747400] test_bpf: #268 JMP_JGT_X: if (3 > 2) return 1 jited:0 146 PASS
+[   66.755910] test_bpf: #269 JMP_JGT_X: Unsigned jump: if (-1 > 1) return 1 jited:0 155 PASS
+[   66.765828] test_bpf: #270 JMP_JLT_X: if (2 < 3) return 1 jited:0 146 PASS
+[   66.774323] test_bpf: #271 JMP_JLT_X: Unsigned jump: if (1 < -1) return 1 jited:0 146 PASS
+[   66.784181] test_bpf: #272 JMP_JGE_X: if (3 >= 2) return 1 jited:0 154 PASS
+[   66.792793] test_bpf: #273 JMP_JGE_X: if (3 >= 3) return 1 jited:0 153 PASS
+[   66.801401] test_bpf: #274 JMP_JLE_X: if (2 <= 3) return 1 jited:0 146 PASS
+[   66.809983] test_bpf: #275 JMP_JLE_X: if (3 <= 3) return 1 jited:0 146 PASS
+[   66.818551] test_bpf: #276 JMP_JGE_X: ldimm64 test 1 jited:0 147 PASS
+[   66.826632] test_bpf: #277 JMP_JGE_X: ldimm64 test 2 jited:0 147 PASS
+[   66.834710] test_bpf: #278 JMP_JGE_X: ldimm64 test 3 jited:0 130 PASS
+[   66.842622] test_bpf: #279 JMP_JLE_X: ldimm64 test 1 jited:0 147 PASS
+[   66.850686] test_bpf: #280 JMP_JLE_X: ldimm64 test 2 jited:0 147 PASS
+[   66.858765] test_bpf: #281 JMP_JLE_X: ldimm64 test 3 jited:0 130 PASS
+[   66.866656] test_bpf: #282 JMP_JNE_X: if (3 != 2) return 1 jited:0 146 PASS
+[   66.875239] test_bpf: #283 JMP_JEQ_X: if (3 == 3) return 1 jited:0 146 PASS
+[   66.883810] test_bpf: #284 JMP_JSET_X: if (0x3 & 0x2) return 1 jited:0 155 PASS
+[   66.892781] test_bpf: #285 JMP_JSET_X: if (0x3 & 0xffffffff) return 1 jited:0 153 PASS
+[   66.902334] test_bpf: #286 JMP_JA: Jump, gap, jump, ... jited:0 157 PASS
+[   66.910773] test_bpf: #287 BPF_MAXINSNS: Maximum possible literals jited:0 133 PASS
+[   66.921370] test_bpf: #288 BPF_MAXINSNS: Single literal jited:0 125 PASS
+[   66.930728] test_bpf: #289 BPF_MAXINSNS: Run/add until end jited:0 72922 PASS
+[   67.668438] test_bpf: #290 BPF_MAXINSNS: Too many instructions PASS
+[   67.674741] test_bpf: #291 BPF_MAXINSNS: Very long jump jited:0 149 PASS
+[   67.684832] test_bpf: #292 BPF_MAXINSNS: Ctx heavy transformations jited:0 244896 244887 PASS
+[   72.594364] test_bpf: #293 BPF_MAXINSNS: Call heavy transformations jited:0 343199 343196 PASS
+[   79.470961] test_bpf: #294 BPF_MAXINSNS: Jump heavy test jited:0 151762 PASS
+[   80.998379] test_bpf: #295 BPF_MAXINSNS: Very long jump backwards jited:0 102 PASS
+[   81.007168] test_bpf: #296 BPF_MAXINSNS: Edge hopping nuthouse jited:0 67674 PASS
+[   81.691728] test_bpf: #297 BPF_MAXINSNS: Jump, gap, jump, ... jited:0 1179 PASS
+[   81.712004] test_bpf: #298 BPF_MAXINSNS: ld_abs+get_processor_id jited:0 224782 PASS
+[   83.969969] test_bpf: #299 BPF_MAXINSNS: ld_abs+vlan_push/pop jited:0 178245 PASS
+[   85.760971] test_bpf: #300 BPF_MAXINSNS: jump around ld_abs jited:0 133 PASS
+[   85.769535] test_bpf: #301 LD_IND byte frag jited:0 287 PASS
+[   85.778677] test_bpf: #302 LD_IND halfword frag jited:0 287 PASS
+[   85.787765] test_bpf: #303 LD_IND word frag jited:0 293 PASS
+[   85.796500] test_bpf: #304 LD_IND halfword mixed head/frag jited:0 330 PASS
+[   85.806884] test_bpf: #305 LD_IND word mixed head/frag jited:0 315 PASS
+[   85.816770] test_bpf: #306 LD_ABS byte frag jited:0 270 PASS
+[   85.825274] test_bpf: #307 LD_ABS halfword frag jited:0 270 PASS
+[   85.834120] test_bpf: #308 LD_ABS word frag jited:0 261 PASS
+[   85.842576] test_bpf: #309 LD_ABS halfword mixed head/frag jited:0 295 PASS
+[   85.852708] test_bpf: #310 LD_ABS word mixed head/frag jited:0 287 PASS
+[   85.862354] test_bpf: #311 LD_IND byte default X jited:0 143 PASS
+[   85.870045] test_bpf: #312 LD_IND byte positive offset jited:0 160 PASS
+[   85.878434] test_bpf: #313 LD_IND byte negative offset jited:0 160 PASS
+[   85.886805] test_bpf: #314 LD_IND halfword positive offset jited:0 165 PASS
+[   85.895588] test_bpf: #315 LD_IND halfword negative offset jited:0 165 PASS
+[   85.904360] test_bpf: #316 LD_IND halfword unaligned jited:0 174 PASS
+[   85.912673] test_bpf: #317 LD_IND word positive offset jited:0 170 PASS
+[   85.921121] test_bpf: #318 LD_IND word negative offset jited:0 170 PASS
+[   85.929565] test_bpf: #319 LD_IND word unaligned (addr & 3 == 2) jited:0 170 PASS
+[   85.938873] test_bpf: #320 LD_IND word unaligned (addr & 3 == 1) jited:0 163 PASS
+[   85.948159] test_bpf: #321 LD_IND word unaligned (addr & 3 == 3) jited:0 170 PASS
+[   85.957478] test_bpf: #322 LD_ABS byte jited:0 145 PASS
+[   85.964310] test_bpf: #323 LD_ABS halfword jited:0 148 PASS
+[   85.971511] test_bpf: #324 LD_ABS halfword unaligned jited:0 140 PASS
+[   85.979512] test_bpf: #325 LD_ABS word jited:0 137 PASS
+[   85.986306] test_bpf: #326 LD_ABS word unaligned (addr & 3 == 2) jited:0 137 PASS
+[   85.995315] test_bpf: #327 LD_ABS word unaligned (addr & 3 == 1) jited:0 137 PASS
+[   86.004371] test_bpf: #328 LD_ABS word unaligned (addr & 3 == 3) jited:0 145 PASS
+[   86.013445] test_bpf: #329 ADD default X jited:0 151 PASS
+[   86.020501] test_bpf: #330 ADD default A jited:0 135 PASS
+[   86.027398] test_bpf: #331 SUB default X jited:0 143 PASS
+[   86.034395] test_bpf: #332 SUB default A jited:0 127 PASS
+[   86.041250] test_bpf: #333 MUL default X jited:0 152 PASS
+[   86.048329] test_bpf: #334 MUL default A jited:0 138 PASS
+[   86.055248] test_bpf: #335 DIV default X jited:0 155 PASS
+[   86.062359] test_bpf: #336 DIV default A jited:0 142 PASS
+[   86.069361] test_bpf: #337 MOD default X jited:0 161 PASS
+[   86.076502] test_bpf: #338 MOD default A jited:0 154 PASS
+[   86.083569] test_bpf: #339 JMP EQ default A jited:0 145 PASS
+[   86.090856] test_bpf: #340 JMP EQ default X jited:0 161 PASS
+[   86.098289] test_bpf: Summary: 341 PASSED, 0 FAILED, [0/333 JIT'ed]
+[   86.257599] test_bpf: #0 TAX jited:1 79 78 78 PASS
+[   86.265408] test_bpf: #1 TXA jited:1 53 42 42 PASS
+[   86.272013] test_bpf: #2 ADD_SUB_MUL_K jited:1 41 PASS
+[   86.278009] test_bpf: #3 DIV_MOD_KX jited:1 95 PASS
+[   86.284233] test_bpf: #4 AND_OR_LSH_K jited:1 42 42 PASS
+[   86.290800] test_bpf: #5 LD_IMM_0 jited:1 38 PASS
+[   86.296329] test_bpf: #6 LD_IND jited:1 101 108 101 PASS
+[   86.305174] test_bpf: #7 LD_ABS jited:1 103 96 96 PASS
+[   86.313691] test_bpf: #8 LD_ABS_LL jited:1 150 155 PASS
+[   86.322417] test_bpf: #9 LD_IND_LL jited:1 101 101 109 PASS
+[   86.331518] test_bpf: #10 LD_ABS_NET jited:1 146 158 PASS
+[   86.340345] test_bpf: #11 LD_IND_NET jited:1 98 107 100 PASS
+[   86.349487] test_bpf: #12 LD_PKTTYPE jited:1 58 58 PASS
+[   86.356378] test_bpf: #13 LD_MARK jited:1 38 38 PASS
+[   86.362566] test_bpf: #14 LD_RXHASH jited:1 38 38 PASS
+[   86.368870] test_bpf: #15 LD_QUEUE jited:1 38 44 PASS
+[   86.375129] test_bpf: #16 LD_PROTOCOL jited:1 116 123 PASS
+[   86.383397] test_bpf: #17 LD_VLAN_TAG jited:1 41 41 PASS
+[   86.389948] test_bpf: #18 LD_VLAN_TAG_PRESENT jited:1 43 43 PASS
+[   86.397223] test_bpf: #19 LD_IFINDEX jited:1 51 45 PASS
+[   86.403810] test_bpf: #20 LD_HATYPE jited:1 45 45 PASS
+[   86.410257] test_bpf: #21 LD_CPU jited:1 73 73 PASS
+[   86.417024] test_bpf: #22 LD_NLATTR jited:1 76 106 PASS
+[   86.424478] test_bpf: #23 LD_NLATTR_NEST jited:1 304 641 PASS
+[   86.440100] test_bpf: #24 LD_PAYLOAD_OFF jited:1 885 1308 PASS
+[   86.468362] test_bpf: #25 LD_ANC_XOR jited:1 37 37 PASS
+[   86.474842] test_bpf: #26 SPILL_FILL jited:1 65 65 65 PASS
+[   86.482715] test_bpf: #27 JEQ jited:1 100 76 75 PASS
+[   86.490650] test_bpf: #28 JGT jited:1 100 76 75 PASS
+[   86.498557] test_bpf: #29 JGE (jt 0), test 1 jited:1 100 76 76 PASS
+[   86.507788] test_bpf: #30 JGE (jt 0), test 2 jited:1 76 76 83 PASS
+[   86.516733] test_bpf: #31 JGE jited:1 86 82 82 PASS
+[   86.524557] test_bpf: #32 JSET jited:1 94 90 118 PASS
+[   86.533107] test_bpf: #33 tcpdump port 22 jited:1 104 247 268 PASS
+[   86.546015] test_bpf: #34 tcpdump complex jited:1 98 265 438 PASS
+[   86.560660] test_bpf: #35 RET_A jited:1 36 36 PASS
+[   86.566674] test_bpf: #36 INT: ADD trivial jited:1 43 PASS
+[   86.573002] test_bpf: #37 INT: MUL_X jited:1 41 PASS
+[   86.578770] test_bpf: #38 INT: MUL_X2 jited:1 45 PASS
+[   86.584666] test_bpf: #39 INT: MUL32_X jited:1 43 PASS
+[   86.590629] test_bpf: #40 INT: ADD 64-bit jited:1 192 PASS
+[   86.598479] test_bpf: #41 INT: ADD 32-bit jited:1 177 PASS
+[   86.606226] test_bpf: #42 INT: SUB jited:1 157 PASS
+[   86.613123] test_bpf: #43 INT: XOR jited:1 101 PASS
+[   86.619390] test_bpf: #44 INT: MUL jited:1 208 PASS
+[   86.626799] test_bpf: #45 MOV REG64 jited:1 66 PASS
+[   86.632752] test_bpf: #46 MOV REG32 jited:1 66 PASS
+[   86.638672] test_bpf: #47 LD IMM64 jited:1 66 PASS
+[   86.644524] test_bpf: #48 INT: ALU MIX jited:1 56 PASS
+[   86.650599] test_bpf: #49 INT: shifts by register jited:1 65 PASS
+[   86.657741] test_bpf: #50 INT: DIV + ABS jited:1 133 138 PASS
+[   86.666629] test_bpf: #51 INT: DIV by zero jited:1 96 70 PASS
+[   86.674450] test_bpf: #52 check: missing ret PASS
+[   86.679438] test_bpf: #53 check: div_k_0 PASS
+[   86.683936] test_bpf: #54 check: unknown insn PASS
+[   86.688860] test_bpf: #55 check: out of range spill/fill PASS
+[   86.694740] test_bpf: #56 JUMPS + HOLES jited:1 91 PASS
+[   86.701316] test_bpf: #57 check: RET X PASS
+[   86.705899] test_bpf: #58 check: LDX + RET X PASS
+[   86.710739] test_bpf: #59 M[]: alt STX + LDX jited:1 196 PASS
+[   86.718763] test_bpf: #60 M[]: full STX + full LDX jited:1 176 PASS
+[   86.727318] test_bpf: #61 check: SKF_AD_MAX PASS
+[   86.732328] test_bpf: #62 LD [SKF_AD_OFF-1] jited:1 87 PASS
+[   86.739010] test_bpf: #63 load 64-bit immediate jited:1 51 PASS
+[   86.745923] test_bpf: #64 nmap reduced jited:1 261 PASS
+[   86.754204] test_bpf: #65 ALU_MOV_X: dst = 2 jited:1 35 PASS
+[   86.760620] test_bpf: #66 ALU_MOV_X: dst = 4294967295 jited:1 35 PASS
+[   86.767777] test_bpf: #67 ALU64_MOV_X: dst = 2 jited:1 35 PASS
+[   86.774357] test_bpf: #68 ALU64_MOV_X: dst = 4294967295 jited:1 35 PASS
+[   86.781726] test_bpf: #69 ALU_MOV_K: dst = 2 jited:1 35 PASS
+[   86.788151] test_bpf: #70 ALU_MOV_K: dst = 4294967295 jited:1 35 PASS
+[   86.795334] test_bpf: #71 ALU_MOV_K: 0x0000ffffffff0000 = 0x00000000ffffffff jited:1 40 PASS
+[   86.804516] test_bpf: #72 ALU64_MOV_K: dst = 2 jited:1 35 PASS
+[   86.811105] test_bpf: #73 ALU64_MOV_K: dst = 2147483647 jited:1 35 PASS
+[   86.818441] test_bpf: #74 ALU64_OR_K: dst = 0x0 jited:1 40 PASS
+[   86.825202] test_bpf: #75 ALU64_MOV_K: dst = -1 jited:1 49 PASS
+[   86.831957] test_bpf: #76 ALU_ADD_X: 1 + 2 = 3 jited:1 36 PASS
+[   86.838548] test_bpf: #77 ALU_ADD_X: 1 + 4294967294 = 4294967295 jited:1 36 PASS
+[   86.846646] test_bpf: #78 ALU_ADD_X: 2 + 4294967294 = 0 jited:1 38 PASS
+[   86.854046] test_bpf: #79 ALU64_ADD_X: 1 + 2 = 3 jited:1 36 PASS
+[   86.860784] test_bpf: #80 ALU64_ADD_X: 1 + 4294967294 = 4294967295 jited:1 36 PASS
+[   86.869089] test_bpf: #81 ALU64_ADD_X: 2 + 4294967294 = 4294967296 jited:1 40 PASS
+[   86.877462] test_bpf: #82 ALU_ADD_K: 1 + 2 = 3 jited:1 44 PASS
+[   86.884093] test_bpf: #83 ALU_ADD_K: 3 + 0 = 3 jited:1 36 PASS
+[   86.890663] test_bpf: #84 ALU_ADD_K: 1 + 4294967294 = 4294967295 jited:1 36 PASS
+[   86.898774] test_bpf: #85 ALU_ADD_K: 4294967294 + 2 = 0 jited:1 38 PASS
+[   86.906154] test_bpf: #86 ALU_ADD_K: 0 + (-1) = 0x00000000ffffffff jited:1 38 PASS
+[   86.914499] test_bpf: #87 ALU_ADD_K: 0 + 0xffff = 0xffff jited:1 38 PASS
+[   86.921993] test_bpf: #88 ALU_ADD_K: 0 + 0x7fffffff = 0x7fffffff jited:1 40 PASS
+[   86.930186] test_bpf: #89 ALU_ADD_K: 0 + 0x80000000 = 0x80000000 jited:1 40 PASS
+[   86.938348] test_bpf: #90 ALU_ADD_K: 0 + 0x80008000 = 0x80008000 jited:1 40 PASS
+[   86.946553] test_bpf: #91 ALU64_ADD_K: 1 + 2 = 3 jited:1 36 PASS
+[   86.953320] test_bpf: #92 ALU64_ADD_K: 3 + 0 = 3 jited:1 43 PASS
+[   86.960100] test_bpf: #93 ALU64_ADD_K: 1 + 2147483646 = 2147483647 jited:1 36 PASS
+[   86.968455] test_bpf: #94 ALU64_ADD_K: 4294967294 + 2 = 4294967296 jited:1 40 PASS
+[   86.976804] test_bpf: #95 ALU64_ADD_K: 2147483646 + -2147483647 = -1 jited:1 37 PASS
+[   86.985290] test_bpf: #96 ALU64_ADD_K: 1 + 0 = 1 jited:1 46 PASS
+[   86.992134] test_bpf: #97 ALU64_ADD_K: 0 + (-1) = 0xffffffffffffffff jited:1 41 PASS
+[   87.001738] test_bpf: #98 ALU64_ADD_K: 0 + 0xffff = 0xffff jited:1 45 PASS
+[   87.009274] test_bpf: #99 ALU64_ADD_K: 0 + 0x7fffffff = 0x7fffffff jited:1 40 PASS
+[   87.017428] test_bpf: #100 ALU64_ADD_K: 0 + 0x80000000 = 0xffffffff80000000 jited:1 50 PASS
+[   87.026426] test_bpf: #101 ALU_ADD_K: 0 + 0x80008000 = 0xffffffff80008000 jited:1 42 PASS
+[   87.035261] test_bpf: #102 ALU_SUB_X: 3 - 1 = 2 jited:1 36 PASS
+[   87.041748] test_bpf: #103 ALU_SUB_X: 4294967295 - 4294967294 = 1 jited:1 42 PASS
+[   87.049804] test_bpf: #104 ALU64_SUB_X: 3 - 1 = 2 jited:1 36 PASS
+[   87.056482] test_bpf: #105 ALU64_SUB_X: 4294967295 - 4294967294 = 1 jited:1 36 PASS
+[   87.064690] test_bpf: #106 ALU_SUB_K: 3 - 1 = 2 jited:1 36 PASS
+[   87.071170] test_bpf: #107 ALU_SUB_K: 3 - 0 = 3 jited:1 36 PASS
+[   87.077661] test_bpf: #108 ALU_SUB_K: 4294967295 - 4294967294 = 1 jited:1 42 PASS
+[   87.085725] test_bpf: #109 ALU64_SUB_K: 3 - 1 = 2 jited:1 43 PASS
+[   87.092428] test_bpf: #110 ALU64_SUB_K: 3 - 0 = 3 jited:1 36 PASS
+[   87.099080] test_bpf: #111 ALU64_SUB_K: 4294967294 - 4294967295 = -1 jited:1 36 PASS
+[   87.107389] test_bpf: #112 ALU64_ADD_K: 2147483646 - 2147483647 = -1 jited:1 37 PASS
+[   87.115690] test_bpf: #113 ALU_MUL_X: 2 * 3 = 6 jited:1 36 PASS
+[   87.122216] test_bpf: #114 ALU_MUL_X: 2 * 0x7FFFFFF8 = 0xFFFFFFF0 jited:1 37 PASS
+[   87.130253] test_bpf: #115 ALU_MUL_X: -1 * -1 = 1 jited:1 40 PASS
+[   87.136960] test_bpf: #116 ALU64_MUL_X: 2 * 3 = 6 jited:1 37 PASS
+[   87.143630] test_bpf: #117 ALU64_MUL_X: 1 * 2147483647 = 2147483647 jited:1 38 PASS
+[   87.151875] test_bpf: #118 ALU_MUL_K: 2 * 3 = 6 jited:1 36 PASS
+[   87.158353] test_bpf: #119 ALU_MUL_K: 3 * 1 = 3 jited:1 36 PASS
+[   87.164844] test_bpf: #120 ALU_MUL_K: 2 * 0x7FFFFFF8 = 0xFFFFFFF0 jited:1 37 PASS
+[   87.172883] test_bpf: #121 ALU_MUL_K: 1 * (-1) = 0x00000000ffffffff jited:1 41 PASS
+[   87.181154] test_bpf: #122 ALU64_MUL_K: 2 * 3 = 6 jited:1 37 PASS
+[   87.187818] test_bpf: #123 ALU64_MUL_K: 3 * 1 = 3 jited:1 37 PASS
+[   87.194503] test_bpf: #124 ALU64_MUL_K: 1 * 2147483647 = 2147483647 jited:1 38 PASS
+[   87.202727] test_bpf: #125 ALU64_MUL_K: 1 * -2147483647 = -2147483647 jited:1 38 PASS
+[   87.211145] test_bpf: #126 ALU64_MUL_K: 1 * (-1) = 0xffffffffffffffff jited:1 43 PASS
+[   87.219598] test_bpf: #127 ALU_DIV_X: 6 / 2 = 3 jited:1 36 PASS
+[   87.226102] test_bpf: #128 ALU_DIV_X: 4294967295 / 4294967295 = 1 jited:1 37 PASS
+[   87.234148] test_bpf: #129 ALU64_DIV_X: 6 / 2 = 3 jited:1 36 PASS
+[   87.240813] test_bpf: #130 ALU64_DIV_X: 2147483647 / 2147483647 = 1 jited:1 38 PASS
+[   87.249047] test_bpf: #131 ALU64_DIV_X: 0xffffffffffffffff / (-1) = 0x0000000000000001 jited:1 47 PASS
+[   87.259018] test_bpf: #132 ALU_DIV_K: 6 / 2 = 3 jited:1 36 PASS
+[   87.265502] test_bpf: #133 ALU_DIV_K: 3 / 1 = 3 jited:1 42 PASS
+[   87.272006] test_bpf: #134 ALU_DIV_K: 4294967295 / 4294967295 = 1 jited:1 37 PASS
+[   87.280049] test_bpf: #135 ALU_DIV_K: 0xffffffffffffffff / (-1) = 0x1 jited:1 43 PASS
+[   87.288521] test_bpf: #136 ALU64_DIV_K: 6 / 2 = 3 jited:1 36 PASS
+[   87.295179] test_bpf: #137 ALU64_DIV_K: 3 / 1 = 3 jited:1 36 PASS
+[   87.301846] test_bpf: #138 ALU64_DIV_K: 2147483647 / 2147483647 = 1 jited:1 38 PASS
+[   87.310096] test_bpf: #139 ALU64_DIV_K: 0xffffffffffffffff / (-1) = 0x0000000000000001 jited:1 43 PASS
+[   87.320028] test_bpf: #140 ALU_MOD_X: 3 % 2 = 1 jited:1 42 PASS
+[   87.326583] test_bpf: #141 ALU_MOD_X: 4294967295 % 4294967293 = 2 jited:1 43 PASS
+[   87.334712] test_bpf: #142 ALU64_MOD_X: 3 % 2 = 1 jited:1 43 PASS
+[   87.341441] test_bpf: #143 ALU64_MOD_X: 2147483647 % 2147483645 = 2 jited:1 52 PASS
+[   87.349778] test_bpf: #144 ALU_MOD_K: 3 % 2 = 1 jited:1 49 PASS
+[   87.356354] test_bpf: #145 ALU_MOD_K: 3 % 1 = 0 jited:1 PASS
+[   87.362192] test_bpf: #146 ALU_MOD_K: 4294967295 % 4294967293 = 2 jited:1 43 PASS
+[   87.370334] test_bpf: #147 ALU64_MOD_K: 3 % 2 = 1 jited:1 43 PASS
+[   87.377065] test_bpf: #148 ALU64_MOD_K: 3 % 1 = 0 jited:1 PASS
+[   87.383114] test_bpf: #149 ALU64_MOD_K: 2147483647 % 2147483645 = 2 jited:1 46 PASS
+[   87.391416] test_bpf: #150 ALU_AND_X: 3 & 2 = 2 jited:1 36 PASS
+[   87.397919] test_bpf: #151 ALU_AND_X: 0xffffffff & 0xffffffff = 0xffffffff jited:1 36 PASS
+[   87.406743] test_bpf: #152 ALU64_AND_X: 3 & 2 = 2 jited:1 36 PASS
+[   87.413415] test_bpf: #153 ALU64_AND_X: 0xffffffff & 0xffffffff = 0xffffffff jited:1 36 PASS
+[   87.422431] test_bpf: #154 ALU_AND_K: 3 & 2 = 2 jited:1 36 PASS
+[   87.428913] test_bpf: #155 ALU_AND_K: 0xffffffff & 0xffffffff = 0xffffffff jited:1 36 PASS
+[   87.437739] test_bpf: #156 ALU64_AND_K: 3 & 2 = 2 jited:1 42 PASS
+[   87.444461] test_bpf: #157 ALU64_AND_K: 0xffffffff & 0xffffffff = 0xffffffff jited:1 36 PASS
+[   87.453445] test_bpf: #158 ALU64_AND_K: 0x0000ffffffff0000 & 0x0 = 0x0000ffff00000000 jited:1 46 PASS
+[   87.463278] test_bpf: #159 ALU64_AND_K: 0x0000ffffffff0000 & -1 = 0x0000ffffffffffff jited:1 42 PASS
+[   87.473027] test_bpf: #160 ALU64_AND_K: 0xffffffffffffffff & -1 = 0xffffffffffffffff jited:1 45 PASS
+[   87.482789] test_bpf: #161 ALU_OR_X: 1 | 2 = 3 jited:1 36 PASS
+[   87.489203] test_bpf: #162 ALU_OR_X: 0x0 | 0xffffffff = 0xffffffff jited:1 36 PASS
+[   87.497321] test_bpf: #163 ALU64_OR_X: 1 | 2 = 3 jited:1 36 PASS
+[   87.503910] test_bpf: #164 ALU64_OR_X: 0 | 0xffffffff = 0xffffffff jited:1 36 PASS
+[   87.512029] test_bpf: #165 ALU_OR_K: 1 | 2 = 3 jited:1 36 PASS
+[   87.518448] test_bpf: #166 ALU_OR_K: 0 & 0xffffffff = 0xffffffff jited:1 36 PASS
+[   87.526398] test_bpf: #167 ALU64_OR_K: 1 | 2 = 3 jited:1 36 PASS
+[   87.532988] test_bpf: #168 ALU64_OR_K: 0 & 0xffffffff = 0xffffffff jited:1 36 PASS
+[   87.541107] test_bpf: #169 ALU64_OR_K: 0x0000ffffffff0000 | 0x0 = 0x0000ffff00000000 jited:1 42 PASS
+[   87.550867] test_bpf: #170 ALU64_OR_K: 0x0000ffffffff0000 | -1 = 0xffffffffffffffff jited:1 43 PASS
+[   87.560527] test_bpf: #171 ALU64_OR_K: 0x000000000000000 | -1 = 0xffffffffffffffff jited:1 41 PASS
+[   87.570097] test_bpf: #172 ALU_XOR_X: 5 ^ 6 = 3 jited:1 36 PASS
+[   87.576581] test_bpf: #173 ALU_XOR_X: 0x1 ^ 0xffffffff = 0xfffffffe jited:1 36 PASS
+[   87.584797] test_bpf: #174 ALU64_XOR_X: 5 ^ 6 = 3 jited:1 36 PASS
+[   87.591454] test_bpf: #175 ALU64_XOR_X: 1 ^ 0xffffffff = 0xfffffffe jited:1 36 PASS
+[   87.599684] test_bpf: #176 ALU_XOR_K: 5 ^ 6 = 3 jited:1 36 PASS
+[   87.606178] test_bpf: #177 ALU_XOR_K: 1 ^ 0xffffffff = 0xfffffffe jited:1 36 PASS
+[   87.614235] test_bpf: #178 ALU64_XOR_K: 5 ^ 6 = 3 jited:1 36 PASS
+[   87.620898] test_bpf: #179 ALU64_XOR_K: 1 & 0xffffffff = 0xfffffffe jited:1 36 PASS
+[   87.629120] test_bpf: #180 ALU64_XOR_K: 0x0000ffffffff0000 ^ 0x0 = 0x0000ffffffff0000 jited:1 42 PASS
+[   87.638975] test_bpf: #181 ALU64_XOR_K: 0x0000ffffffff0000 ^ -1 = 0xffff00000000ffff jited:1 41 PASS
+[   87.648722] test_bpf: #182 ALU64_XOR_K: 0x000000000000000 ^ -1 = 0xffffffffffffffff jited:1 41 PASS
+[   87.658361] test_bpf: #183 ALU_LSH_X: 1 << 1 = 2 jited:1 36 PASS
+[   87.664959] test_bpf: #184 ALU_LSH_X: 1 << 31 = 0x80000000 jited:1 36 PASS
+[   87.672390] test_bpf: #185 ALU64_LSH_X: 1 << 1 = 2 jited:1 36 PASS
+[   87.679160] test_bpf: #186 ALU64_LSH_X: 1 << 31 = 0x80000000 jited:1 36 PASS
+[   87.686767] test_bpf: #187 ALU_LSH_K: 1 << 1 = 2 jited:1 35 PASS
+[   87.693331] test_bpf: #188 ALU_LSH_K: 1 << 31 = 0x80000000 jited:1 35 PASS
+[   87.701601] test_bpf: #189 ALU64_LSH_K: 1 << 1 = 2 jited:1 41 PASS
+[   87.708370] test_bpf: #190 ALU64_LSH_K: 1 << 31 = 0x80000000 jited:1 35 PASS
+[   87.715965] test_bpf: #191 ALU_RSH_X: 2 >> 1 = 1 jited:1 36 PASS
+[   87.722558] test_bpf: #192 ALU_RSH_X: 0x80000000 >> 31 = 1 jited:1 37 PASS
+[   87.730032] test_bpf: #193 ALU64_RSH_X: 2 >> 1 = 1 jited:1 36 PASS
+[   87.736790] test_bpf: #194 ALU64_RSH_X: 0x80000000 >> 31 = 1 jited:1 37 PASS
+[   87.744408] test_bpf: #195 ALU_RSH_K: 2 >> 1 = 1 jited:1 35 PASS
+[   87.750992] test_bpf: #196 ALU_RSH_K: 0x80000000 >> 31 = 1 jited:1 37 PASS
+[   87.758469] test_bpf: #197 ALU64_RSH_K: 2 >> 1 = 1 jited:1 35 PASS
+[   87.765215] test_bpf: #198 ALU64_RSH_K: 0x80000000 >> 31 = 1 jited:1 37 PASS
+[   87.772833] test_bpf: #199 ALU_ARSH_X: 0xff00ff0000000000 >> 40 = 0xffffffffffff00ff jited:1 38 PASS
+[   87.782553] test_bpf: #200 ALU_ARSH_K: 0xff00ff0000000000 >> 40 = 0xffffffffffff00ff jited:1 38 PASS
+[   87.792258] test_bpf: #201 ALU_NEG: -(3) = -3 jited:1 35 PASS
+[   87.798592] test_bpf: #202 ALU_NEG: -(-3) = 3 jited:1 35 PASS
+[   87.804899] test_bpf: #203 ALU64_NEG: -(3) = -3 jited:1 35 PASS
+[   87.811387] test_bpf: #204 ALU64_NEG: -(-3) = 3 jited:1 38 PASS
+[   87.817902] test_bpf: #205 ALU_END_FROM_BE 16: 0x0123456789abcdef -> 0xcdef jited:1 42 PASS
+[   87.826884] test_bpf: #206 ALU_END_FROM_BE 32: 0x0123456789abcdef -> 0x89abcdef jited:1 45 PASS
+[   87.836233] test_bpf: #207 ALU_END_FROM_BE 64: 0x0123456789abcdef -> 0x89abcdef jited:1 40 PASS
+[   87.845520] test_bpf: #208 ALU_END_FROM_LE 16: 0x0123456789abcdef -> 0xefcd jited:1 47 PASS
+[   87.854500] test_bpf: #209 ALU_END_FROM_LE 32: 0x0123456789abcdef -> 0xefcdab89 jited:1 45 PASS
+[   87.863850] test_bpf: #210 ALU_END_FROM_LE 64: 0x0123456789abcdef -> 0x67452301 jited:1 37 PASS
+[   87.873103] test_bpf: #211 ST_MEM_B: Store/Load byte: max negative jited:1 41 PASS
+[   87.881300] test_bpf: #212 ST_MEM_B: Store/Load byte: max positive jited:1 41 PASS
+[   87.889482] test_bpf: #213 STX_MEM_B: Store/Load byte: max negative jited:1 41 PASS
+[   87.897808] test_bpf: #214 ST_MEM_H: Store/Load half word: max negative jited:1 48 PASS
+[   87.906459] test_bpf: #215 ST_MEM_H: Store/Load half word: max positive jited:1 41 PASS
+[   87.915079] test_bpf: #216 STX_MEM_H: Store/Load half word: max negative jited:1 41 PASS
+[   87.923770] test_bpf: #217 ST_MEM_W: Store/Load word: max negative jited:1 41 PASS
+[   87.931967] test_bpf: #218 ST_MEM_W: Store/Load word: max positive jited:1 41 PASS
+[   87.940148] test_bpf: #219 STX_MEM_W: Store/Load word: max negative jited:1 42 PASS
+[   87.948451] test_bpf: #220 ST_MEM_DW: Store/Load double word: max negative jited:1 41 PASS
+[   87.957377] test_bpf: #221 ST_MEM_DW: Store/Load double word: max negative 2 jited:1 48 PASS
+[   87.966545] test_bpf: #222 ST_MEM_DW: Store/Load double word: max positive jited:1 41 PASS
+[   87.975436] test_bpf: #223 STX_MEM_DW: Store/Load double word: max negative jited:1 43 PASS
+[   87.984421] test_bpf: #224 STX_XADD_W: Test: 0x12 + 0x10 = 0x22 jited:1 58 PASS
+[   87.992543] test_bpf: #225 STX_XADD_W: Test side-effects, r10: 0x12 + 0x10 = 0x22 jited:1 PASS
+[   88.001329] test_bpf: #226 STX_XADD_W: Test side-effects, r0: 0x12 + 0x10 = 0x22 jited:1 56 PASS
+[   88.010906] test_bpf: #227 STX_XADD_W: X + 1 + 1 + 1 + ... jited:1 72471 PASS
+[   88.752571] test_bpf: #228 STX_XADD_DW: Test: 0x12 + 0x10 = 0x22 jited:1 58 PASS
+[   88.760811] test_bpf: #229 STX_XADD_DW: Test side-effects, r10: 0x12 + 0x10 = 0x22 jited:1 PASS
+[   88.769693] test_bpf: #230 STX_XADD_DW: Test side-effects, r0: 0x12 + 0x10 = 0x22 jited:1 64 PASS
+[   88.779366] test_bpf: #231 STX_XADD_DW: X + 1 + 1 + 1 + ... jited:1 72473 PASS
+[   89.521164] test_bpf: #232 JMP_EXIT jited:1 35 PASS
+[   89.526669] test_bpf: #233 JMP_JA: Unconditional jump: if (true) return 1 jited:1 36 PASS
+[   89.535410] test_bpf: #234 JMP_JSLT_K: Signed jump: if (-2 < -1) return 1 jited:1 40 PASS
+[   89.544211] test_bpf: #235 JMP_JSLT_K: Signed jump: if (-1 < -1) return 0 jited:1 40 PASS
+[   89.552983] test_bpf: #236 JMP_JSGT_K: Signed jump: if (-1 > -2) return 1 jited:1 40 PASS
+[   89.561776] test_bpf: #237 JMP_JSGT_K: Signed jump: if (-1 > -1) return 0 jited:1 40 PASS
+[   89.570603] test_bpf: #238 JMP_JSLE_K: Signed jump: if (-2 <= -1) return 1 jited:1 40 PASS
+[   89.579457] test_bpf: #239 JMP_JSLE_K: Signed jump: if (-1 <= -1) return 1 jited:1 40 PASS
+[   89.588329] test_bpf: #240 JMP_JSLE_K: Signed jump: value walk 1 jited:1 47 PASS
+[   89.596406] test_bpf: #241 JMP_JSLE_K: Signed jump: value walk 2 jited:1 45 PASS
+[   89.604472] test_bpf: #242 JMP_JSGE_K: Signed jump: if (-1 >= -2) return 1 jited:1 40 PASS
+[   89.613328] test_bpf: #243 JMP_JSGE_K: Signed jump: if (-1 >= -1) return 1 jited:1 40 PASS
+[   89.622206] test_bpf: #244 JMP_JSGE_K: Signed jump: value walk 1 jited:1 56 PASS
+[   89.630436] test_bpf: #245 JMP_JSGE_K: Signed jump: value walk 2 jited:1 46 PASS
+[   89.638514] test_bpf: #246 JMP_JGT_K: if (3 > 2) return 1 jited:1 37 PASS
+[   89.645912] test_bpf: #247 JMP_JGT_K: Unsigned jump: if (-1 > 1) return 1 jited:1 46 PASS
+[   89.654722] test_bpf: #248 JMP_JLT_K: if (2 < 3) return 1 jited:1 37 PASS
+[   89.662110] test_bpf: #249 JMP_JGT_K: Unsigned jump: if (1 < -1) return 1 jited:1 44 PASS
+[   89.670906] test_bpf: #250 JMP_JGE_K: if (3 >= 2) return 1 jited:1 37 PASS
+[   89.678409] test_bpf: #251 JMP_JLE_K: if (2 <= 3) return 1 jited:1 37 PASS
+[   89.685870] test_bpf: #252 JMP_JGT_K: if (3 > 2) return 1 (jump backwards) jited:1 46 PASS
+[   89.694766] test_bpf: #253 JMP_JGE_K: if (3 >= 3) return 1 jited:1 37 PASS
+[   89.702245] test_bpf: #254 JMP_JGT_K: if (2 < 3) return 1 (jump backwards) jited:1 38 PASS
+[   89.711115] test_bpf: #255 JMP_JLE_K: if (3 <= 3) return 1 jited:1 37 PASS
+[   89.718584] test_bpf: #256 JMP_JNE_K: if (3 != 2) return 1 jited:1 37 PASS
+[   89.726051] test_bpf: #257 JMP_JEQ_K: if (3 == 3) return 1 jited:1 43 PASS
+[   89.733538] test_bpf: #258 JMP_JSET_K: if (0x3 & 0x2) return 1 jited:1 37 PASS
+[   89.741346] test_bpf: #259 JMP_JSET_K: if (0x3 & 0xffffffff) return 1 jited:1 37 PASS
+[   89.749770] test_bpf: #260 JMP_JSGT_X: Signed jump: if (-1 > -2) return 1 jited:1 43 PASS
+[   89.758619] test_bpf: #261 JMP_JSGT_X: Signed jump: if (-1 > -1) return 0 jited:1 43 PASS
+[   89.767444] test_bpf: #262 JMP_JSLT_X: Signed jump: if (-2 < -1) return 1 jited:1 43 PASS
+[   89.776273] test_bpf: #263 JMP_JSLT_X: Signed jump: if (-1 < -1) return 0 jited:1 43 PASS
+[   89.785090] test_bpf: #264 JMP_JSGE_X: Signed jump: if (-1 >= -2) return 1 jited:1 43 PASS
+[   89.794018] test_bpf: #265 JMP_JSGE_X: Signed jump: if (-1 >= -1) return 1 jited:1 50 PASS
+[   89.802970] test_bpf: #266 JMP_JSLE_X: Signed jump: if (-2 <= -1) return 1 jited:1 43 PASS
+[   89.811876] test_bpf: #267 JMP_JSLE_X: Signed jump: if (-1 <= -1) return 1 jited:1 43 PASS
+[   89.820796] test_bpf: #268 JMP_JGT_X: if (3 > 2) return 1 jited:1 37 PASS
+[   89.828171] test_bpf: #269 JMP_JGT_X: Unsigned jump: if (-1 > 1) return 1 jited:1 40 PASS
+[   89.836964] test_bpf: #270 JMP_JLT_X: if (2 < 3) return 1 jited:1 37 PASS
+[   89.844340] test_bpf: #271 JMP_JLT_X: Unsigned jump: if (1 < -1) return 1 jited:1 40 PASS
+[   89.853133] test_bpf: #272 JMP_JGE_X: if (3 >= 2) return 1 jited:1 37 PASS
+[   89.860592] test_bpf: #273 JMP_JGE_X: if (3 >= 3) return 1 jited:1 37 PASS
+[   89.868066] test_bpf: #274 JMP_JLE_X: if (2 <= 3) return 1 jited:1 37 PASS
+[   89.875523] test_bpf: #275 JMP_JLE_X: if (3 <= 3) return 1 jited:1 37 PASS
+[   89.882998] test_bpf: #276 JMP_JGE_X: ldimm64 test 1 jited:1 40 PASS
+[   89.889971] test_bpf: #277 JMP_JGE_X: ldimm64 test 2 jited:1 46 PASS
+[   89.896973] test_bpf: #278 JMP_JGE_X: ldimm64 test 3 jited:1 37 PASS
+[   89.903921] test_bpf: #279 JMP_JLE_X: ldimm64 test 1 jited:1 40 PASS
+[   89.910915] test_bpf: #280 JMP_JLE_X: ldimm64 test 2 jited:1 40 PASS
+[   89.917882] test_bpf: #281 JMP_JLE_X: ldimm64 test 3 jited:1 37 PASS
+[   89.924855] test_bpf: #282 JMP_JNE_X: if (3 != 2) return 1 jited:1 37 PASS
+[   89.932322] test_bpf: #283 JMP_JEQ_X: if (3 == 3) return 1 jited:1 37 PASS
+[   89.939801] test_bpf: #284 JMP_JSET_X: if (0x3 & 0x2) return 1 jited:1 37 PASS
+[   89.947636] test_bpf: #285 JMP_JSET_X: if (0x3 & 0xffffffff) return 1 jited:1 38 PASS
+[   89.956078] test_bpf: #286 JMP_JA: Jump, gap, jump, ... jited:1 38 PASS
+[   89.963301] test_bpf: #287 BPF_MAXINSNS: Maximum possible literals jited:1 37 PASS
+[   89.975505] test_bpf: #288 BPF_MAXINSNS: Single literal jited:1 37 PASS
+[   89.987834] test_bpf: #289 BPF_MAXINSNS: Run/add until end jited:1 17460 PASS
+[   90.175059] test_bpf: #290 BPF_MAXINSNS: Too many instructions PASS
+[   90.181362] test_bpf: #291 BPF_MAXINSNS: Very long jump jited:1 37 PASS
+[   90.193744] test_bpf: #292 BPF_MAXINSNS: Ctx heavy transformations jited:1 33978 33944 PASS
+[   90.891428] test_bpf: #293 BPF_MAXINSNS: Call heavy transformations jited:1 85173 85138 PASS
+[   92.615759] test_bpf: #294 BPF_MAXINSNS: Jump heavy test jited:1 17229 PASS
+[   92.801244] test_bpf: #295 BPF_MAXINSNS: Very long jump backwards jited:1 37 PASS
+[   92.812021] test_bpf: #296 BPF_MAXINSNS: Edge hopping nuthouse jited:1 15637 PASS
+[   92.977335] test_bpf: #297 BPF_MAXINSNS: Jump, gap, jump, ... jited:1 259 PASS
+[   92.989691] test_bpf: #298 BPF_MAXINSNS: ld_abs+get_processor_id jited:1 131075 PASS
+[   94.323078] test_bpf: #299 BPF_MAXINSNS: ld_abs+vlan_push/pop jited:1 138981 PASS
+[   95.726254] test_bpf: #300 BPF_MAXINSNS: jump around ld_abs jited:1 70 PASS
+[   95.748911] test_bpf: #301 LD_IND byte frag jited:1 191 PASS
+[   95.756810] test_bpf: #302 LD_IND halfword frag jited:1 190 PASS
+[   95.764962] test_bpf: #303 LD_IND word frag jited:1 191 PASS
+[   95.772798] test_bpf: #304 LD_IND halfword mixed head/frag jited:1 222 PASS
+[   95.782219] test_bpf: #305 LD_IND word mixed head/frag jited:1 217 PASS
+[   95.791211] test_bpf: #306 LD_ABS byte frag jited:1 197 PASS
+[   95.799057] test_bpf: #307 LD_ABS halfword frag jited:1 196 PASS
+[   95.807235] test_bpf: #308 LD_ABS word frag jited:1 197 PASS
+[   95.815084] test_bpf: #309 LD_ABS halfword mixed head/frag jited:1 229 PASS
+[   95.824561] test_bpf: #310 LD_ABS word mixed head/frag jited:1 208 PASS
+[   95.833519] test_bpf: #311 LD_IND byte default X jited:1 68 PASS
+[   95.840473] test_bpf: #312 LD_IND byte positive offset jited:1 68 PASS
+[   95.847945] test_bpf: #313 LD_IND byte negative offset jited:1 68 PASS
+[   95.855480] test_bpf: #314 LD_IND halfword positive offset jited:1 72 PASS
+[   95.863319] test_bpf: #315 LD_IND halfword negative offset jited:1 72 PASS
+[   95.871173] test_bpf: #316 LD_IND halfword unaligned jited:1 81 PASS
+[   95.878544] test_bpf: #317 LD_IND word positive offset jited:1 80 PASS
+[   95.886086] test_bpf: #318 LD_IND word negative offset jited:1 72 PASS
+[   95.893596] test_bpf: #319 LD_IND word unaligned (addr & 3 == 2) jited:1 73 PASS
+[   95.901952] test_bpf: #320 LD_IND word unaligned (addr & 3 == 1) jited:1 73 PASS
+[   95.910325] test_bpf: #321 LD_IND word unaligned (addr & 3 == 3) jited:1 73 PASS
+[   95.918683] test_bpf: #322 LD_ABS byte jited:1 75 PASS
+[   95.924789] test_bpf: #323 LD_ABS halfword jited:1 71 PASS
+[   95.931238] test_bpf: #324 LD_ABS halfword unaligned jited:1 77 PASS
+[   95.938583] test_bpf: #325 LD_ABS word jited:1 79 PASS
+[   95.944741] test_bpf: #326 LD_ABS word unaligned (addr & 3 == 2) jited:1 71 PASS
+[   95.953078] test_bpf: #327 LD_ABS word unaligned (addr & 3 == 1) jited:1 71 PASS
+[   95.961479] test_bpf: #328 LD_ABS word unaligned (addr & 3 == 3) jited:1 71 PASS
+[   95.969810] test_bpf: #329 ADD default X jited:1 37 PASS
+[   95.975752] test_bpf: #330 ADD default A jited:1 37 PASS
+[   95.981669] test_bpf: #331 SUB default X jited:1 37 PASS
+[   95.987594] test_bpf: #332 SUB default A jited:1 37 PASS
+[   95.993518] test_bpf: #333 MUL default X jited:1 37 PASS
+[   95.999470] test_bpf: #334 MUL default A jited:1 37 PASS
+[   96.005390] test_bpf: #335 DIV default X jited:1 38 PASS
+[   96.011327] test_bpf: #336 DIV default A jited:1 37 PASS
+[   96.017279] test_bpf: #337 MOD default X jited:1 38 PASS
+[   96.023235] test_bpf: #338 MOD default A jited:1 50 PASS
+[   96.029256] test_bpf: #339 JMP EQ default A jited:1 38 PASS
+[   96.035483] test_bpf: #340 JMP EQ default X jited:1 38 PASS
+[   96.041686] test_bpf: Summary: 341 PASSED, 0 FAILED, [333/333 JIT'ed]
+[   96.200846] test_bpf: #0 TAX jited:1 79 78 83 PASS
+[   96.208554] test_bpf: #1 TXA jited:1 42 42 42 PASS
+[   96.214978] test_bpf: #2 ADD_SUB_MUL_K jited:1 46 PASS
+[   96.220809] test_bpf: #3 DIV_MOD_KX jited:1 95 PASS
+[   96.226904] test_bpf: #4 AND_OR_LSH_K jited:1 47 42 PASS
+[   96.233358] test_bpf: #5 LD_IMM_0 jited:1 38 PASS
+[   96.238714] test_bpf: #6 LD_IND jited:1 107 101 101 PASS
+[   96.247401] test_bpf: #7 LD_ABS jited:1 96 96 96 PASS
+[   96.255679] test_bpf: #8 LD_ABS_LL jited:1 150 155 PASS
+[   96.264248] test_bpf: #9 LD_IND_LL jited:1 101 101 101 PASS
+[   96.273190] test_bpf: #10 LD_ABS_NET jited:1 145 157 PASS
+[   96.281862] test_bpf: #11 LD_IND_NET jited:1 98 105 98 PASS
+[   96.290734] test_bpf: #12 LD_PKTTYPE jited:1 58 58 PASS
+[   96.297466] test_bpf: #13 LD_MARK jited:1 38 38 PASS
+[   96.303467] test_bpf: #14 LD_RXHASH jited:1 38 38 PASS
+[   96.309641] test_bpf: #15 LD_QUEUE jited:1 38 38 PASS
+[   96.315727] test_bpf: #16 LD_PROTOCOL jited:1 116 116 PASS
+[   96.323831] test_bpf: #17 LD_VLAN_TAG jited:1 41 41 PASS
+[   96.330230] test_bpf: #18 LD_VLAN_TAG_PRESENT jited:1 43 43 PASS
+[   96.337380] test_bpf: #19 LD_IFINDEX jited:1 45 45 PASS
+[   96.343770] test_bpf: #20 LD_HATYPE jited:1 45 45 PASS
+[   96.350087] test_bpf: #21 LD_CPU jited:1 73 80 PASS
+[   96.356771] test_bpf: #22 LD_NLATTR jited:1 70 106 PASS
+[   96.364025] test_bpf: #23 LD_NLATTR_NEST jited:1 297 650 PASS
+[   96.379545] test_bpf: #24 LD_PAYLOAD_OFF jited:1 885 1303 PASS
+[   96.407600] test_bpf: #25 LD_ANC_XOR jited:1 37 37 PASS
+[   96.413852] test_bpf: #26 SPILL_FILL jited:1 65 65 71 PASS
+[   96.421615] test_bpf: #27 JEQ jited:1 100 84 75 PASS
+[   96.429477] test_bpf: #28 JGT jited:1 100 76 82 PASS
+[   96.437304] test_bpf: #29 JGE (jt 0), test 1 jited:1 100 76 84 PASS
+[   96.446431] test_bpf: #30 JGE (jt 0), test 2 jited:1 76 83 75 PASS
+[   96.455215] test_bpf: #31 JGE jited:1 86 82 82 PASS
+[   96.462884] test_bpf: #32 JSET jited:1 93 90 107 PASS
+[   96.471140] test_bpf: #33 tcpdump port 22 jited:1 104 247 268 PASS
+[   96.483833] test_bpf: #34 tcpdump complex jited:1 98 268 438 PASS
+[   96.498303] test_bpf: #35 RET_A jited:1 36 36 PASS
+[   96.504108] test_bpf: #36 INT: ADD trivial jited:1 43 PASS
+[   96.510272] test_bpf: #37 INT: MUL_X jited:1 41 PASS
+[   96.515910] test_bpf: #38 INT: MUL_X2 jited:1 45 PASS
+[   96.521650] test_bpf: #39 INT: MUL32_X jited:1 43 PASS
+[   96.527472] test_bpf: #40 INT: ADD 64-bit jited:1 192 PASS
+[   96.535214] test_bpf: #41 INT: ADD 32-bit jited:1 185 PASS
+[   96.542820] test_bpf: #42 INT: SUB jited:1 164 PASS
+[   96.549616] test_bpf: #43 INT: XOR jited:1 96 PASS
+[   96.555655] test_bpf: #44 INT: MUL jited:1 208 PASS
+[   96.562911] test_bpf: #45 MOV REG64 jited:1 72 PASS
+[   96.568742] test_bpf: #46 MOV REG32 jited:1 66 PASS
+[   96.574546] test_bpf: #47 LD IMM64 jited:1 66 PASS
+[   96.580249] test_bpf: #48 INT: ALU MIX jited:1 56 PASS
+[   96.586222] test_bpf: #49 INT: shifts by register jited:1 65 PASS
+[   96.593213] test_bpf: #50 INT: DIV + ABS jited:1 133 148 PASS
+[   96.602026] test_bpf: #51 INT: DIV by zero jited:1 96 77 PASS
+[   96.609746] test_bpf: #52 check: missing ret PASS
+[   96.614614] test_bpf: #53 check: div_k_0 PASS
+[   96.619099] test_bpf: #54 check: unknown insn PASS
+[   96.624036] test_bpf: #55 check: out of range spill/fill PASS
+[   96.629900] test_bpf: #56 JUMPS + HOLES jited:1 91 PASS
+[   96.636510] test_bpf: #57 check: RET X PASS
+[   96.640852] test_bpf: #58 check: LDX + RET X PASS
+[   96.645695] test_bpf: #59 M[]: alt STX + LDX jited:1 204 PASS
+[   96.653754] test_bpf: #60 M[]: full STX + full LDX jited:1 184 PASS
+[   96.662137] test_bpf: #61 check: SKF_AD_MAX PASS
+[   96.666912] test_bpf: #62 LD [SKF_AD_OFF-1] jited:1 94 PASS
+[   96.673642] test_bpf: #63 load 64-bit immediate jited:1 51 PASS
+[   96.680326] test_bpf: #64 nmap reduced jited:1 261 PASS
+[   96.688487] test_bpf: #65 ALU_MOV_X: dst = 2 jited:1 35 PASS
+[   96.694726] test_bpf: #66 ALU_MOV_X: dst = 4294967295 jited:1 35 PASS
+[   96.701756] test_bpf: #67 ALU64_MOV_X: dst = 2 jited:1 35 PASS
+[   96.708163] test_bpf: #68 ALU64_MOV_X: dst = 4294967295 jited:1 35 PASS
+[   96.715365] test_bpf: #69 ALU_MOV_K: dst = 2 jited:1 41 PASS
+[   96.721632] test_bpf: #70 ALU_MOV_K: dst = 4294967295 jited:1 35 PASS
+[   96.728659] test_bpf: #71 ALU_MOV_K: 0x0000ffffffff0000 = 0x00000000ffffffff jited:1 40 PASS
+[   96.737711] test_bpf: #72 ALU64_MOV_K: dst = 2 jited:1 35 PASS
+[   96.744155] test_bpf: #73 ALU64_MOV_K: dst = 2147483647 jited:1 35 PASS
+[   96.751366] test_bpf: #74 ALU64_OR_K: dst = 0x0 jited:1 46 PASS
+[   96.757958] test_bpf: #75 ALU64_MOV_K: dst = -1 jited:1 42 PASS
+[   96.764540] test_bpf: #76 ALU_ADD_X: 1 + 2 = 3 jited:1 36 PASS
+[   96.770983] test_bpf: #77 ALU_ADD_X: 1 + 4294967294 = 4294967295 jited:1 36 PASS
+[   96.779001] test_bpf: #78 ALU_ADD_X: 2 + 4294967294 = 0 jited:1 38 PASS
+[   96.786294] test_bpf: #79 ALU64_ADD_X: 1 + 2 = 3 jited:1 36 PASS
+[   96.792912] test_bpf: #80 ALU64_ADD_X: 1 + 4294967294 = 4294967295 jited:1 36 PASS
+[   96.801054] test_bpf: #81 ALU64_ADD_X: 2 + 4294967294 = 4294967296 jited:1 40 PASS
+[   96.809252] test_bpf: #82 ALU_ADD_K: 1 + 2 = 3 jited:1 36 PASS
+[   96.815684] test_bpf: #83 ALU_ADD_K: 3 + 0 = 3 jited:1 36 PASS
+[   96.822108] test_bpf: #84 ALU_ADD_K: 1 + 4294967294 = 4294967295 jited:1 36 PASS
+[   96.830085] test_bpf: #85 ALU_ADD_K: 4294967294 + 2 = 0 jited:1 38 PASS
+[   96.837335] test_bpf: #86 ALU_ADD_K: 0 + (-1) = 0x00000000ffffffff jited:1 38 PASS
+[   96.845503] test_bpf: #87 ALU_ADD_K: 0 + 0xffff = 0xffff jited:1 38 PASS
+[   96.852835] test_bpf: #88 ALU_ADD_K: 0 + 0x7fffffff = 0x7fffffff jited:1 40 PASS
+[   96.860842] test_bpf: #89 ALU_ADD_K: 0 + 0x80000000 = 0x80000000 jited:1 40 PASS
+[   96.868864] test_bpf: #90 ALU_ADD_K: 0 + 0x80008000 = 0x80008000 jited:1 40 PASS
+[   96.876870] test_bpf: #91 ALU64_ADD_K: 1 + 2 = 3 jited:1 36 PASS
+[   96.883481] test_bpf: #92 ALU64_ADD_K: 3 + 0 = 3 jited:1 36 PASS
+[   96.890098] test_bpf: #93 ALU64_ADD_K: 1 + 2147483646 = 2147483647 jited:1 36 PASS
+[   96.898255] test_bpf: #94 ALU64_ADD_K: 4294967294 + 2 = 4294967296 jited:1 40 PASS
+[   96.906433] test_bpf: #95 ALU64_ADD_K: 2147483646 + -2147483647 = -1 jited:1 37 PASS
+[   96.914778] test_bpf: #96 ALU64_ADD_K: 1 + 0 = 1 jited:1 38 PASS
+[   96.921401] test_bpf: #97 ALU64_ADD_K: 0 + (-1) = 0xffffffffffffffff jited:1 41 PASS
+[   96.929791] test_bpf: #98 ALU64_ADD_K: 0 + 0xffff = 0xffff jited:1 38 PASS
+[   96.937267] test_bpf: #99 ALU64_ADD_K: 0 + 0x7fffffff = 0x7fffffff jited:1 40 PASS
+[   96.945492] test_bpf: #100 ALU64_ADD_K: 0 + 0x80000000 = 0xffffffff80000000 jited:1 42 PASS
+[   96.954479] test_bpf: #101 ALU_ADD_K: 0 + 0x80008000 = 0xffffffff80008000 jited:1 42 PASS
+[   96.963305] test_bpf: #102 ALU_SUB_X: 3 - 1 = 2 jited:1 43 PASS
+[   96.969869] test_bpf: #103 ALU_SUB_X: 4294967295 - 4294967294 = 1 jited:1 36 PASS
+[   96.977927] test_bpf: #104 ALU64_SUB_X: 3 - 1 = 2 jited:1 36 PASS
+[   96.984622] test_bpf: #105 ALU64_SUB_X: 4294967295 - 4294967294 = 1 jited:1 36 PASS
+[   96.992845] test_bpf: #106 ALU_SUB_K: 3 - 1 = 2 jited:1 36 PASS
+[   96.999367] test_bpf: #107 ALU_SUB_K: 3 - 0 = 3 jited:1 42 PASS
+[   97.005924] test_bpf: #108 ALU_SUB_K: 4294967295 - 4294967294 = 1 jited:1 36 PASS
+[   97.014011] test_bpf: #109 ALU64_SUB_K: 3 - 1 = 2 jited:1 36 PASS
+[   97.020706] test_bpf: #110 ALU64_SUB_K: 3 - 0 = 3 jited:1 36 PASS
+[   97.027388] test_bpf: #111 ALU64_SUB_K: 4294967294 - 4294967295 = -1 jited:1 42 PASS
+[   97.035733] test_bpf: #112 ALU64_ADD_K: 2147483646 - 2147483647 = -1 jited:1 37 PASS
+[   97.044053] test_bpf: #113 ALU_MUL_X: 2 * 3 = 6 jited:1 36 PASS
+[   97.050585] test_bpf: #114 ALU_MUL_X: 2 * 0x7FFFFFF8 = 0xFFFFFFF0 jited:1 37 PASS
+[   97.058654] test_bpf: #115 ALU_MUL_X: -1 * -1 = 1 jited:1 40 PASS
+[   97.065393] test_bpf: #116 ALU64_MUL_X: 2 * 3 = 6 jited:1 37 PASS
+[   97.072089] test_bpf: #117 ALU64_MUL_X: 1 * 2147483647 = 2147483647 jited:1 38 PASS
+[   97.080358] test_bpf: #118 ALU_MUL_K: 2 * 3 = 6 jited:1 36 PASS
+[   97.086868] test_bpf: #119 ALU_MUL_K: 3 * 1 = 3 jited:1 36 PASS
+[   97.093396] test_bpf: #120 ALU_MUL_K: 2 * 0x7FFFFFF8 = 0xFFFFFFF0 jited:1 37 PASS
+[   97.101462] test_bpf: #121 ALU_MUL_K: 1 * (-1) = 0x00000000ffffffff jited:1 41 PASS
+[   97.109763] test_bpf: #122 ALU64_MUL_K: 2 * 3 = 6 jited:1 37 PASS
+[   97.116458] test_bpf: #123 ALU64_MUL_K: 3 * 1 = 3 jited:1 37 PASS
+[   97.123172] test_bpf: #124 ALU64_MUL_K: 1 * 2147483647 = 2147483647 jited:1 45 PASS
+[   97.131485] test_bpf: #125 ALU64_MUL_K: 1 * -2147483647 = -2147483647 jited:1 46 PASS
+[   97.139976] test_bpf: #126 ALU64_MUL_K: 1 * (-1) = 0xffffffffffffffff jited:1 43 PASS
+[   97.148453] test_bpf: #127 ALU_DIV_X: 6 / 2 = 3 jited:1 36 PASS
+[   97.154984] test_bpf: #128 ALU_DIV_X: 4294967295 / 4294967295 = 1 jited:1 37 PASS
+[   97.163048] test_bpf: #129 ALU64_DIV_X: 6 / 2 = 3 jited:1 36 PASS
+[   97.169787] test_bpf: #130 ALU64_DIV_X: 2147483647 / 2147483647 = 1 jited:1 38 PASS
+[   97.178060] test_bpf: #131 ALU64_DIV_X: 0xffffffffffffffff / (-1) = 0x0000000000000001 jited:1 47 PASS
+[   97.188048] test_bpf: #132 ALU_DIV_K: 6 / 2 = 3 jited:1 36 PASS
+[   97.194567] test_bpf: #133 ALU_DIV_K: 3 / 1 = 3 jited:1 36 PASS
+[   97.201098] test_bpf: #134 ALU_DIV_K: 4294967295 / 4294967295 = 1 jited:1 37 PASS
+[   97.209186] test_bpf: #135 ALU_DIV_K: 0xffffffffffffffff / (-1) = 0x1 jited:1 43 PASS
+[   97.217667] test_bpf: #136 ALU64_DIV_K: 6 / 2 = 3 jited:1 36 PASS
+[   97.224365] test_bpf: #137 ALU64_DIV_K: 3 / 1 = 3 jited:1 36 PASS
+[   97.231054] test_bpf: #138 ALU64_DIV_K: 2147483647 / 2147483647 = 1 jited:1 38 PASS
+[   97.239356] test_bpf: #139 ALU64_DIV_K: 0xffffffffffffffff / (-1) = 0x0000000000000001 jited:1 50 PASS
+[   97.249336] test_bpf: #140 ALU_MOD_X: 3 % 2 = 1 jited:1 42 PASS
+[   97.255923] test_bpf: #141 ALU_MOD_X: 4294967295 % 4294967293 = 2 jited:1 43 PASS
+[   97.264056] test_bpf: #142 ALU64_MOD_X: 3 % 2 = 1 jited:1 43 PASS
+[   97.270833] test_bpf: #143 ALU64_MOD_X: 2147483647 % 2147483645 = 2 jited:1 46 PASS
+[   97.279163] test_bpf: #144 ALU_MOD_K: 3 % 2 = 1 jited:1 50 PASS
+[   97.285791] test_bpf: #145 ALU_MOD_K: 3 % 1 = 0 jited:1 PASS
+[   97.291735] test_bpf: #146 ALU_MOD_K: 4294967295 % 4294967293 = 2 jited:1 43 PASS
+[   97.299867] test_bpf: #147 ALU64_MOD_K: 3 % 2 = 1 jited:1 43 PASS
+[   97.306643] test_bpf: #148 ALU64_MOD_K: 3 % 1 = 0 jited:1 PASS
+[   97.312686] test_bpf: #149 ALU64_MOD_K: 2147483647 % 2147483645 = 2 jited:1 46 PASS
+[   97.321042] test_bpf: #150 ALU_AND_X: 3 & 2 = 2 jited:1 36 PASS
+[   97.327563] test_bpf: #151 ALU_AND_X: 0xffffffff & 0xffffffff = 0xffffffff jited:1 36 PASS
+[   97.336452] test_bpf: #152 ALU64_AND_X: 3 & 2 = 2 jited:1 36 PASS
+[   97.343139] test_bpf: #153 ALU64_AND_X: 0xffffffff & 0xffffffff = 0xffffffff jited:1 36 PASS
+[   97.352176] test_bpf: #154 ALU_AND_K: 3 & 2 = 2 jited:1 36 PASS
+[   97.358691] test_bpf: #155 ALU_AND_K: 0xffffffff & 0xffffffff = 0xffffffff jited:1 36 PASS
+[   97.367528] test_bpf: #156 ALU64_AND_K: 3 & 2 = 2 jited:1 36 PASS
+[   97.374244] test_bpf: #157 ALU64_AND_K: 0xffffffff & 0xffffffff = 0xffffffff jited:1 36 PASS
+[   97.383259] test_bpf: #158 ALU64_AND_K: 0x0000ffffffff0000 & 0x0 = 0x0000ffff00000000 jited:1 46 PASS
+[   97.393126] test_bpf: #159 ALU64_AND_K: 0x0000ffffffff0000 & -1 = 0x0000ffffffffffff jited:1 42 PASS
+[   97.402897] test_bpf: #160 ALU64_AND_K: 0xffffffffffffffff & -1 = 0xffffffffffffffff jited:1 45 PASS
+[   97.412691] test_bpf: #161 ALU_OR_X: 1 | 2 = 3 jited:1 36 PASS
+[   97.419139] test_bpf: #162 ALU_OR_X: 0x0 | 0xffffffff = 0xffffffff jited:1 36 PASS
+[   97.427336] test_bpf: #163 ALU64_OR_X: 1 | 2 = 3 jited:1 43 PASS
+[   97.433993] test_bpf: #164 ALU64_OR_X: 0 | 0xffffffff = 0xffffffff jited:1 36 PASS
+[   97.442140] test_bpf: #165 ALU_OR_K: 1 | 2 = 3 jited:1 36 PASS
+[   97.448599] test_bpf: #166 ALU_OR_K: 0 & 0xffffffff = 0xffffffff jited:1 36 PASS
+[   97.456602] test_bpf: #167 ALU64_OR_K: 1 | 2 = 3 jited:1 36 PASS
+[   97.463225] test_bpf: #168 ALU64_OR_K: 0 & 0xffffffff = 0xffffffff jited:1 43 PASS
+[   97.471422] test_bpf: #169 ALU64_OR_K: 0x0000ffffffff0000 | 0x0 = 0x0000ffff00000000 jited:1 49 PASS
+[   97.481303] test_bpf: #170 ALU64_OR_K: 0x0000ffffffff0000 | -1 = 0xffffffffffffffff jited:1 43 PASS
+[   97.490985] test_bpf: #171 ALU64_OR_K: 0x000000000000000 | -1 = 0xffffffffffffffff jited:1 41 PASS
+[   97.500585] test_bpf: #172 ALU_XOR_X: 5 ^ 6 = 3 jited:1 36 PASS
+[   97.507096] test_bpf: #173 ALU_XOR_X: 0x1 ^ 0xffffffff = 0xfffffffe jited:1 36 PASS
+[   97.515366] test_bpf: #174 ALU64_XOR_X: 5 ^ 6 = 3 jited:1 43 PASS
+[   97.522087] test_bpf: #175 ALU64_XOR_X: 1 ^ 0xffffffff = 0xfffffffe jited:1 36 PASS
+[   97.530325] test_bpf: #176 ALU_XOR_K: 5 ^ 6 = 3 jited:1 36 PASS
+[   97.536831] test_bpf: #177 ALU_XOR_K: 1 ^ 0xffffffff = 0xfffffffe jited:1 36 PASS
+[   97.544905] test_bpf: #178 ALU64_XOR_K: 5 ^ 6 = 3 jited:1 36 PASS
+[   97.551594] test_bpf: #179 ALU64_XOR_K: 1 & 0xffffffff = 0xfffffffe jited:1 36 PASS
+[   97.559849] test_bpf: #180 ALU64_XOR_K: 0x0000ffffffff0000 ^ 0x0 = 0x0000ffffffff0000 jited:1 42 PASS
+[   97.569745] test_bpf: #181 ALU64_XOR_K: 0x0000ffffffff0000 ^ -1 = 0xffff00000000ffff jited:1 41 PASS
+[   97.579528] test_bpf: #182 ALU64_XOR_K: 0x000000000000000 ^ -1 = 0xffffffffffffffff jited:1 47 PASS
+[   97.589240] test_bpf: #183 ALU_LSH_X: 1 << 1 = 2 jited:1 36 PASS
+[   97.595842] test_bpf: #184 ALU_LSH_X: 1 << 31 = 0x80000000 jited:1 36 PASS
+[   97.603305] test_bpf: #185 ALU64_LSH_X: 1 << 1 = 2 jited:1 43 PASS
+[   97.610121] test_bpf: #186 ALU64_LSH_X: 1 << 31 = 0x80000000 jited:1 36 PASS
+[   97.617765] test_bpf: #187 ALU_LSH_K: 1 << 1 = 2 jited:1 35 PASS
+[   97.624348] test_bpf: #188 ALU_LSH_K: 1 << 31 = 0x80000000 jited:1 35 PASS
+[   97.631812] test_bpf: #189 ALU64_LSH_K: 1 << 1 = 2 jited:1 35 PASS
+[   97.638573] test_bpf: #190 ALU64_LSH_K: 1 << 31 = 0x80000000 jited:1 35 PASS
+[   97.646183] test_bpf: #191 ALU_RSH_X: 2 >> 1 = 1 jited:1 36 PASS
+[   97.652788] test_bpf: #192 ALU_RSH_X: 0x80000000 >> 31 = 1 jited:1 37 PASS
+[   97.660277] test_bpf: #193 ALU64_RSH_X: 2 >> 1 = 1 jited:1 36 PASS
+[   97.667044] test_bpf: #194 ALU64_RSH_X: 0x80000000 >> 31 = 1 jited:1 37 PASS
+[   97.674700] test_bpf: #195 ALU_RSH_K: 2 >> 1 = 1 jited:1 35 PASS
+[   97.681286] test_bpf: #196 ALU_RSH_K: 0x80000000 >> 31 = 1 jited:1 37 PASS
+[   97.688775] test_bpf: #197 ALU64_RSH_K: 2 >> 1 = 1 jited:1 35 PASS
+[   97.695532] test_bpf: #198 ALU64_RSH_K: 0x80000000 >> 31 = 1 jited:1 44 PASS
+[   97.703214] test_bpf: #199 ALU_ARSH_X: 0xff00ff0000000000 >> 40 = 0xffffffffffff00ff jited:1 45 PASS
+[   97.713005] test_bpf: #200 ALU_ARSH_K: 0xff00ff0000000000 >> 40 = 0xffffffffffff00ff jited:1 38 PASS
+[   97.722738] test_bpf: #201 ALU_NEG: -(3) = -3 jited:1 35 PASS
+[   97.729066] test_bpf: #202 ALU_NEG: -(-3) = 3 jited:1 35 PASS
+[   97.735417] test_bpf: #203 ALU64_NEG: -(3) = -3 jited:1 41 PASS
+[   97.741974] test_bpf: #204 ALU64_NEG: -(-3) = 3 jited:1 38 PASS
+[   97.748515] test_bpf: #205 ALU_END_FROM_BE 16: 0x0123456789abcdef -> 0xcdef jited:1 42 PASS
+[   97.757518] test_bpf: #206 ALU_END_FROM_BE 32: 0x0123456789abcdef -> 0x89abcdef jited:1 45 PASS
+[   97.766870] test_bpf: #207 ALU_END_FROM_BE 64: 0x0123456789abcdef -> 0x89abcdef jited:1 40 PASS
+[   97.776199] test_bpf: #208 ALU_END_FROM_LE 16: 0x0123456789abcdef -> 0xefcd jited:1 40 PASS
+[   97.785158] test_bpf: #209 ALU_END_FROM_LE 32: 0x0123456789abcdef -> 0xefcdab89 jited:1 45 PASS
+[   97.794530] test_bpf: #210 ALU_END_FROM_LE 64: 0x0123456789abcdef -> 0x67452301 jited:1 37 PASS
+[   97.803811] test_bpf: #211 ST_MEM_B: Store/Load byte: max negative jited:1 41 PASS
+[   97.812040] test_bpf: #212 ST_MEM_B: Store/Load byte: max positive jited:1 41 PASS
+[   97.820246] test_bpf: #213 STX_MEM_B: Store/Load byte: max negative jited:1 41 PASS
+[   97.828549] test_bpf: #214 ST_MEM_H: Store/Load half word: max negative jited:1 41 PASS
+[   97.837174] test_bpf: #215 ST_MEM_H: Store/Load half word: max positive jited:1 41 PASS
+[   97.845823] test_bpf: #216 STX_MEM_H: Store/Load half word: max negative jited:1 41 PASS
+[   97.854537] test_bpf: #217 ST_MEM_W: Store/Load word: max negative jited:1 41 PASS
+[   97.862756] test_bpf: #218 ST_MEM_W: Store/Load word: max positive jited:1 41 PASS
+[   97.870955] test_bpf: #219 STX_MEM_W: Store/Load word: max negative jited:1 42 PASS
+[   97.879273] test_bpf: #220 ST_MEM_DW: Store/Load double word: max negative jited:1 48 PASS
+[   97.888234] test_bpf: #221 ST_MEM_DW: Store/Load double word: max negative 2 jited:1 48 PASS
+[   97.897372] test_bpf: #222 ST_MEM_DW: Store/Load double word: max positive jited:1 41 PASS
+[   97.906278] test_bpf: #223 STX_MEM_DW: Store/Load double word: max negative jited:1 43 PASS
+[   97.915277] test_bpf: #224 STX_XADD_W: Test: 0x12 + 0x10 = 0x22 jited:1 67 PASS
+[   97.923459] test_bpf: #225 STX_XADD_W: Test side-effects, r10: 0x12 + 0x10 = 0x22 jited:1 PASS
+[   97.932275] test_bpf: #226 STX_XADD_W: Test side-effects, r0: 0x12 + 0x10 = 0x22 jited:1 56 PASS
+[   97.941887] test_bpf: #227 STX_XADD_W: X + 1 + 1 + 1 + ... jited:1 72484 PASS
+[   98.683689] test_bpf: #228 STX_XADD_DW: Test: 0x12 + 0x10 = 0x22 jited:1 58 PASS
+[   98.692057] test_bpf: #229 STX_XADD_DW: Test side-effects, r10: 0x12 + 0x10 = 0x22 jited:1 PASS
+[   98.701011] test_bpf: #230 STX_XADD_DW: Test side-effects, r0: 0x12 + 0x10 = 0x22 jited:1 56 PASS
+[   98.710661] test_bpf: #231 STX_XADD_DW: X + 1 + 1 + 1 + ... jited:1 72476 PASS
+[   99.452542] test_bpf: #232 JMP_EXIT jited:1 35 PASS
+[   99.458050] test_bpf: #233 JMP_JA: Unconditional jump: if (true) return 1 jited:1 36 PASS
+[   99.466840] test_bpf: #234 JMP_JSLT_K: Signed jump: if (-2 < -1) return 1 jited:1 40 PASS
+[   99.475631] test_bpf: #235 JMP_JSLT_K: Signed jump: if (-1 < -1) return 0 jited:1 48 PASS
+[   99.484478] test_bpf: #236 JMP_JSGT_K: Signed jump: if (-1 > -2) return 1 jited:1 40 PASS
+[   99.493281] test_bpf: #237 JMP_JSGT_K: Signed jump: if (-1 > -1) return 0 jited:1 40 PASS
+[   99.502070] test_bpf: #238 JMP_JSLE_K: Signed jump: if (-2 <= -1) return 1 jited:1 40 PASS
+[   99.510990] test_bpf: #239 JMP_JSLE_K: Signed jump: if (-1 <= -1) return 1 jited:1 40 PASS
+[   99.519871] test_bpf: #240 JMP_JSLE_K: Signed jump: value walk 1 jited:1 47 PASS
+[   99.528082] test_bpf: #241 JMP_JSLE_K: Signed jump: value walk 2 jited:1 43 PASS
+[   99.536149] test_bpf: #242 JMP_JSGE_K: Signed jump: if (-1 >= -2) return 1 jited:1 40 PASS
+[   99.545046] test_bpf: #243 JMP_JSGE_K: Signed jump: if (-1 >= -1) return 1 jited:1 40 PASS
+[   99.553931] test_bpf: #244 JMP_JSGE_K: Signed jump: value walk 1 jited:1 50 PASS
+[   99.562073] test_bpf: #245 JMP_JSGE_K: Signed jump: value walk 2 jited:1 46 PASS
+[   99.570167] test_bpf: #246 JMP_JGT_K: if (3 > 2) return 1 jited:1 37 PASS
+[   99.577573] test_bpf: #247 JMP_JGT_K: Unsigned jump: if (-1 > 1) return 1 jited:1 40 PASS
+[   99.586373] test_bpf: #248 JMP_JLT_K: if (2 < 3) return 1 jited:1 37 PASS
+[   99.593777] test_bpf: #249 JMP_JGT_K: Unsigned jump: if (1 < -1) return 1 jited:1 37 PASS
+[   99.602543] test_bpf: #250 JMP_JGE_K: if (3 >= 2) return 1 jited:1 37 PASS
+[   99.610034] test_bpf: #251 JMP_JLE_K: if (2 <= 3) return 1 jited:1 37 PASS
+[   99.617515] test_bpf: #252 JMP_JGT_K: if (3 > 2) return 1 (jump backwards) jited:1 38 PASS
+[   99.626405] test_bpf: #253 JMP_JGE_K: if (3 >= 3) return 1 jited:1 37 PASS
+[   99.633907] test_bpf: #254 JMP_JGT_K: if (2 < 3) return 1 (jump backwards) jited:1 38 PASS
+[   99.642791] test_bpf: #255 JMP_JLE_K: if (3 <= 3) return 1 jited:1 37 PASS
+[   99.650282] test_bpf: #256 JMP_JNE_K: if (3 != 2) return 1 jited:1 37 PASS
+[   99.657774] test_bpf: #257 JMP_JEQ_K: if (3 == 3) return 1 jited:1 37 PASS
+[   99.665258] test_bpf: #258 JMP_JSET_K: if (0x3 & 0x2) return 1 jited:1 37 PASS
+[   99.673101] test_bpf: #259 JMP_JSET_K: if (0x3 & 0xffffffff) return 1 jited:1 37 PASS
+[   99.681529] test_bpf: #260 JMP_JSGT_X: Signed jump: if (-1 > -2) return 1 jited:1 43 PASS
+[   99.690382] test_bpf: #261 JMP_JSGT_X: Signed jump: if (-1 > -1) return 0 jited:1 43 PASS
+[   99.699225] test_bpf: #262 JMP_JSLT_X: Signed jump: if (-2 < -1) return 1 jited:1 43 PASS
+[   99.708107] test_bpf: #263 JMP_JSLT_X: Signed jump: if (-1 < -1) return 0 jited:1 43 PASS
+[   99.716953] test_bpf: #264 JMP_JSGE_X: Signed jump: if (-1 >= -2) return 1 jited:1 43 PASS
+[   99.725883] test_bpf: #265 JMP_JSGE_X: Signed jump: if (-1 >= -1) return 1 jited:1 43 PASS
+[   99.734799] test_bpf: #266 JMP_JSLE_X: Signed jump: if (-2 <= -1) return 1 jited:1 43 PASS
+[   99.743729] test_bpf: #267 JMP_JSLE_X: Signed jump: if (-1 <= -1) return 1 jited:1 50 PASS
+[   99.752711] test_bpf: #268 JMP_JGT_X: if (3 > 2) return 1 jited:1 37 PASS
+[   99.760131] test_bpf: #269 JMP_JGT_X: Unsigned jump: if (-1 > 1) return 1 jited:1 40 PASS
+[   99.768965] test_bpf: #270 JMP_JLT_X: if (2 < 3) return 1 jited:1 37 PASS
+[   99.776359] test_bpf: #271 JMP_JLT_X: Unsigned jump: if (1 < -1) return 1 jited:1 40 PASS
+[   99.785171] test_bpf: #272 JMP_JGE_X: if (3 >= 2) return 1 jited:1 37 PASS
+[   99.792653] test_bpf: #273 JMP_JGE_X: if (3 >= 3) return 1 jited:1 37 PASS
+[   99.800152] test_bpf: #274 JMP_JLE_X: if (2 <= 3) return 1 jited:1 37 PASS
+[   99.807636] test_bpf: #275 JMP_JLE_X: if (3 <= 3) return 1 jited:1 44 PASS
+[   99.815166] test_bpf: #276 JMP_JGE_X: ldimm64 test 1 jited:1 40 PASS
+[   99.822167] test_bpf: #277 JMP_JGE_X: ldimm64 test 2 jited:1 40 PASS
+[   99.829166] test_bpf: #278 JMP_JGE_X: ldimm64 test 3 jited:1 37 PASS
+[   99.836150] test_bpf: #279 JMP_JLE_X: ldimm64 test 1 jited:1 40 PASS
+[   99.843149] test_bpf: #280 JMP_JLE_X: ldimm64 test 2 jited:1 40 PASS
+[   99.850153] test_bpf: #281 JMP_JLE_X: ldimm64 test 3 jited:1 37 PASS
+[   99.857126] test_bpf: #282 JMP_JNE_X: if (3 != 2) return 1 jited:1 37 PASS
+[   99.864623] test_bpf: #283 JMP_JEQ_X: if (3 == 3) return 1 jited:1 37 PASS
+[   99.872141] test_bpf: #284 JMP_JSET_X: if (0x3 & 0x2) return 1 jited:1 37 PASS
+[   99.879978] test_bpf: #285 JMP_JSET_X: if (0x3 & 0xffffffff) return 1 jited:1 38 PASS
+[   99.888445] test_bpf: #286 JMP_JA: Jump, gap, jump, ... jited:1 38 PASS
+[   99.895703] test_bpf: #287 BPF_MAXINSNS: Maximum possible literals jited:1 43 PASS
+[   99.907886] test_bpf: #288 BPF_MAXINSNS: Single literal jited:1 37 PASS
+[   99.920219] test_bpf: #289 BPF_MAXINSNS: Run/add until end jited:1 18435 PASS
+[  100.117163] test_bpf: #290 BPF_MAXINSNS: Too many instructions PASS
+[  100.123456] test_bpf: #291 BPF_MAXINSNS: Very long jump jited:1 37 PASS
+[  100.135894] test_bpf: #292 BPF_MAXINSNS: Ctx heavy transformations jited:1 34099 34021 PASS
+[  100.835500] test_bpf: #293 BPF_MAXINSNS: Call heavy transformations jited:1 85170 85145 PASS
+[  102.559900] test_bpf: #294 BPF_MAXINSNS: Jump heavy test jited:1 16422 PASS
+[  102.737427] test_bpf: #295 BPF_MAXINSNS: Very long jump backwards jited:1 45 PASS
+[  102.748255] test_bpf: #296 BPF_MAXINSNS: Edge hopping nuthouse jited:1 15548 PASS
+[  102.912791] test_bpf: #297 BPF_MAXINSNS: Jump, gap, jump, ... jited:1 267 PASS
+[  102.925189] test_bpf: #298 BPF_MAXINSNS: ld_abs+get_processor_id jited:1 133677 PASS
+[  104.284615] test_bpf: #299 BPF_MAXINSNS: ld_abs+vlan_push/pop jited:1 141534 PASS
+[  105.713358] test_bpf: #300 BPF_MAXINSNS: jump around ld_abs jited:1 70 PASS
+[  105.736182] test_bpf: #301 LD_IND byte frag jited:1 197 PASS
+[  105.744175] test_bpf: #302 LD_IND halfword frag jited:1 196 PASS
+[  105.752414] test_bpf: #303 LD_IND word frag jited:1 197 PASS
+[  105.760288] test_bpf: #304 LD_IND halfword mixed head/frag jited:1 229 PASS
+[  105.769767] test_bpf: #305 LD_IND word mixed head/frag jited:1 210 PASS
+[  105.778746] test_bpf: #306 LD_ABS byte frag jited:1 190 PASS
+[  105.786573] test_bpf: #307 LD_ABS halfword frag jited:1 188 PASS
+[  105.794744] test_bpf: #308 LD_ABS word frag jited:1 190 PASS
+[  105.802570] test_bpf: #309 LD_ABS halfword mixed head/frag jited:1 221 PASS
+[  105.812051] test_bpf: #310 LD_ABS word mixed head/frag jited:1 215 PASS
+[  105.821045] test_bpf: #311 LD_IND byte default X jited:1 68 PASS
+[  105.828005] test_bpf: #312 LD_IND byte positive offset jited:1 68 PASS
+[  105.835496] test_bpf: #313 LD_IND byte negative offset jited:1 68 PASS
+[  105.842985] test_bpf: #314 LD_IND halfword positive offset jited:1 72 PASS
+[  105.850839] test_bpf: #315 LD_IND halfword negative offset jited:1 72 PASS
+[  105.858726] test_bpf: #316 LD_IND halfword unaligned jited:1 73 PASS
+[  105.866074] test_bpf: #317 LD_IND word positive offset jited:1 72 PASS
+[  105.873599] test_bpf: #318 LD_IND word negative offset jited:1 72 PASS
+[  105.881114] test_bpf: #319 LD_IND word unaligned (addr & 3 == 2) jited:1 73 PASS
+[  105.889512] test_bpf: #320 LD_IND word unaligned (addr & 3 == 1) jited:1 73 PASS
+[  105.897892] test_bpf: #321 LD_IND word unaligned (addr & 3 == 3) jited:1 73 PASS
+[  105.906293] test_bpf: #322 LD_ABS byte jited:1 67 PASS
+[  105.912372] test_bpf: #323 LD_ABS halfword jited:1 78 PASS
+[  105.918869] test_bpf: #324 LD_ABS halfword unaligned jited:1 71 PASS
+[  105.926187] test_bpf: #325 LD_ABS word jited:1 71 PASS
+[  105.932320] test_bpf: #326 LD_ABS word unaligned (addr & 3 == 2) jited:1 77 PASS
+[  105.940730] test_bpf: #327 LD_ABS word unaligned (addr & 3 == 1) jited:1 78 PASS
+[  105.949138] test_bpf: #328 LD_ABS word unaligned (addr & 3 == 3) jited:1 71 PASS
+[  105.957487] test_bpf: #329 ADD default X jited:1 37 PASS
+[  105.963436] test_bpf: #330 ADD default A jited:1 37 PASS
+[  105.969380] test_bpf: #331 SUB default X jited:1 37 PASS
+[  105.975388] test_bpf: #332 SUB default A jited:1 37 PASS
+[  105.981330] test_bpf: #333 MUL default X jited:1 37 PASS
+[  105.987276] test_bpf: #334 MUL default A jited:1 37 PASS
+[  105.993220] test_bpf: #335 DIV default X jited:1 38 PASS
+[  105.999181] test_bpf: #336 DIV default A jited:1 37 PASS
+[  106.005126] test_bpf: #337 MOD default X jited:1 38 PASS
+[  106.011085] test_bpf: #338 MOD default A jited:1 43 PASS
+[  106.017089] test_bpf: #339 JMP EQ default A jited:1 38 PASS
+[  106.023313] test_bpf: #340 JMP EQ default X jited:1 38 PASS
+[  106.029535] test_bpf: Summary: 341 PASSED, 0 FAILED, [333/333 JIT'ed]
+[  106.164710] test_bpf: #0 TAX jited:1 43 39 39 PASS
+[  106.171033] test_bpf: #1 TXA jited:1 17 17 17 PASS
+[  106.176673] test_bpf: #2 ADD_SUB_MUL_K jited:1 31 PASS
+[  106.182338] test_bpf: #3 DIV_MOD_KX jited:1 41 PASS
+[  106.187868] test_bpf: #4 AND_OR_LSH_K jited:1 25 25 PASS
+[  106.193890] test_bpf: #5 LD_IMM_0 jited:1 21 PASS
+[  106.199020] test_bpf: #6 LD_IND jited:1 44 48 48 PASS
+[  106.205704] test_bpf: #7 LD_ABS jited:1 83 83 83 PASS
+[  106.213475] test_bpf: #8 LD_ABS_LL jited:1 67 67 PASS
+[  106.220082] test_bpf: #9 LD_IND_LL jited:1 48 53 48 PASS
+[  106.227094] test_bpf: #10 LD_ABS_NET jited:1 68 66 PASS
+[  106.233876] test_bpf: #11 LD_IND_NET jited:1 46 43 43 PASS
+[  106.240899] test_bpf: #12 LD_PKTTYPE jited:1 34 34 PASS
+[  106.247056] test_bpf: #13 LD_MARK jited:1 16 16 PASS
+[  106.252546] test_bpf: #14 LD_RXHASH jited:1 16 16 PASS
+[  106.258241] test_bpf: #15 LD_QUEUE jited:1 16 16 PASS
+[  106.263815] test_bpf: #16 LD_PROTOCOL jited:1 58 62 PASS
+[  106.270540] test_bpf: #17 LD_VLAN_TAG jited:1 18 18 PASS
+[  106.276404] test_bpf: #18 LD_VLAN_TAG_PRESENT jited:1 20 20 PASS
+[  106.283008] test_bpf: #19 LD_IFINDEX jited:1 19 19 PASS
+[  106.288829] test_bpf: #20 LD_HATYPE jited:1 23 19 PASS
+[  106.294710] test_bpf: #21 LD_CPU jited:1 73 73 PASS
+[  106.301617] test_bpf: #22 LD_NLATTR jited:1 78 115 PASS
+[  106.309209] test_bpf: #23 LD_NLATTR_NEST jited:1 331 678 PASS
+[  106.325445] test_bpf: #24 LD_PAYLOAD_OFF jited:1 886 1303 PASS
+[  106.353503] test_bpf: #25 LD_ANC_XOR jited:1 46 46 PASS
+[  106.360011] test_bpf: #26 SPILL_FILL jited:1 73 79 73 PASS
+[  106.368326] test_bpf: #27 JEQ jited:1 111 83 82 PASS
+[  106.376434] test_bpf: #28 JGT jited:1 111 83 82 PASS
+[  106.384526] test_bpf: #29 JGE (jt 0), test 1 jited:1 110 83 83 PASS
+[  106.393914] test_bpf: #30 JGE (jt 0), test 2 jited:1 83 83 82 PASS
+[  106.402972] test_bpf: #31 JGE jited:1 92 109 101 PASS
+[  106.411443] test_bpf: #32 JSET jited:1 102 117 142 PASS
+[  106.420754] test_bpf: #33 tcpdump port 22 jited:1 100 283 315 PASS
+[  106.434532] test_bpf: #34 tcpdump complex jited:1 102 305 516 PASS
+[  106.450573] test_bpf: #35 RET_A jited:1 36 36 PASS
+[  106.456454] test_bpf: #36 INT: ADD trivial jited:1 70 PASS
+[  106.463100] test_bpf: #37 INT: MUL_X jited:1 62 PASS
+[  106.469035] test_bpf: #38 INT: MUL_X2 jited:1 78 PASS
+[  106.475212] test_bpf: #39 INT: MUL32_X jited:1 65 PASS
+[  106.481341] test_bpf: #40 INT: ADD 64-bit jited:1 344 PASS
+[  106.490960] test_bpf: #41 INT: ADD 32-bit jited:1 292 PASS
+[  106.499999] test_bpf: #42 INT: SUB jited:1 250 PASS
+[  106.507942] test_bpf: #43 INT: XOR jited:1 138 PASS
+[  106.514624] test_bpf: #44 INT: MUL jited:1 275 PASS
+[  106.522667] test_bpf: #45 MOV REG64 jited:1 78 PASS
+[  106.528691] test_bpf: #46 MOV REG32 jited:1 84 PASS
+[  106.534742] test_bpf: #47 LD IMM64 jited:1 197 PASS
+[  106.542075] test_bpf: #48 INT: ALU MIX jited:1 87 PASS
+[  106.548467] test_bpf: #49 INT: shifts by register jited:1 133 PASS
+[  106.556346] test_bpf: #50 INT: DIV + ABS jited:1 152 155 PASS
+[  106.565498] test_bpf: #51 INT: DIV by zero jited:1 100 73 PASS
+[  106.573383] test_bpf: #52 check: missing ret PASS
+[  106.578272] test_bpf: #53 check: div_k_0 PASS
+[  106.582755] test_bpf: #54 check: unknown insn PASS
+[  106.587680] test_bpf: #55 check: out of range spill/fill PASS
+[  106.593539] test_bpf: #56 JUMPS + HOLES jited:1 113 PASS
+[  106.600794] test_bpf: #57 check: RET X PASS
+[  106.605182] test_bpf: #58 check: LDX + RET X PASS
+[  106.610025] test_bpf: #59 M[]: alt STX + LDX jited:1 260 PASS
+[  106.618851] test_bpf: #60 M[]: full STX + full LDX jited:1 244 PASS
+[  106.628014] test_bpf: #61 check: SKF_AD_MAX PASS
+[  106.632812] test_bpf: #62 LD [SKF_AD_OFF-1] jited:1 98 PASS
+[  106.639648] test_bpf: #63 load 64-bit immediate jited:1 78 PASS
+[  106.646848] test_bpf: #64 nmap reduced jited:1 325 PASS
+[  106.655911] test_bpf: #65 ALU_MOV_X: dst = 2 jited:1 51 PASS
+[  106.662390] test_bpf: #66 ALU_MOV_X: dst = 4294967295 jited:1 40 PASS
+[  106.669553] test_bpf: #67 ALU64_MOV_X: dst = 2 jited:1 40 PASS
+[  106.676092] test_bpf: #68 ALU64_MOV_X: dst = 4294967295 jited:1 40 PASS
+[  106.683409] test_bpf: #69 ALU_MOV_K: dst = 2 jited:1 38 PASS
+[  106.689749] test_bpf: #70 ALU_MOV_K: dst = 4294967295 jited:1 38 PASS
+[  106.696887] test_bpf: #71 ALU_MOV_K: 0x0000ffffffff0000 = 0x00000000ffffffff jited:1 76 PASS
+[  106.706383] test_bpf: #72 ALU64_MOV_K: dst = 2 jited:1 38 PASS
+[  106.712893] test_bpf: #73 ALU64_MOV_K: dst = 2147483647 jited:1 45 PASS
+[  106.720209] test_bpf: #74 ALU64_OR_K: dst = 0x0 jited:1 65 PASS
+[  106.727141] test_bpf: #75 ALU64_MOV_K: dst = -1 jited:1 70 PASS
+[  106.734122] test_bpf: #76 ALU_ADD_X: 1 + 2 = 3 jited:1 52 PASS
+[  106.740796] test_bpf: #77 ALU_ADD_X: 1 + 4294967294 = 4294967295 jited:1 58 PASS
+[  106.749041] test_bpf: #78 ALU_ADD_X: 2 + 4294967294 = 0 jited:1 70 PASS
+[  106.756722] test_bpf: #79 ALU64_ADD_X: 1 + 2 = 3 jited:1 59 PASS
+[  106.763598] test_bpf: #80 ALU64_ADD_X: 1 + 4294967294 = 4294967295 jited:1 52 PASS
+[  106.771987] test_bpf: #81 ALU64_ADD_X: 2 + 4294967294 = 4294967296 jited:1 77 PASS
+[  106.780644] test_bpf: #82 ALU_ADD_K: 1 + 2 = 3 jited:1 56 PASS
+[  106.787329] test_bpf: #83 ALU_ADD_K: 3 + 0 = 3 jited:1 51 PASS
+[  106.793994] test_bpf: #84 ALU_ADD_K: 1 + 4294967294 = 4294967295 jited:1 51 PASS
+[  106.802216] test_bpf: #85 ALU_ADD_K: 4294967294 + 2 = 0 jited:1 61 PASS
+[  106.809777] test_bpf: #86 ALU_ADD_K: 0 + (-1) = 0x00000000ffffffff jited:1 70 PASS
+[  106.818361] test_bpf: #87 ALU_ADD_K: 0 + 0xffff = 0xffff jited:1 70 PASS
+[  106.826130] test_bpf: #88 ALU_ADD_K: 0 + 0x7fffffff = 0x7fffffff jited:1 70 PASS
+[  106.834550] test_bpf: #89 ALU_ADD_K: 0 + 0x80000000 = 0x80000000 jited:1 78 PASS
+[  106.843075] test_bpf: #90 ALU_ADD_K: 0 + 0x80008000 = 0x80008000 jited:1 70 PASS
+[  106.851673] test_bpf: #91 ALU64_ADD_K: 1 + 2 = 3 jited:1 62 PASS
+[  106.858637] test_bpf: #92 ALU64_ADD_K: 3 + 0 = 3 jited:1 51 PASS
+[  106.865476] test_bpf: #93 ALU64_ADD_K: 1 + 2147483646 = 2147483647 jited:1 51 PASS
+[  106.873879] test_bpf: #94 ALU64_ADD_K: 4294967294 + 2 = 4294967296 jited:1 70 PASS
+[  106.882465] test_bpf: #95 ALU64_ADD_K: 2147483646 + -2147483647 = -1 jited:1 51 PASS
+[  106.891038] test_bpf: #96 ALU64_ADD_K: 1 + 0 = 1 jited:1 70 PASS
+[  106.898078] test_bpf: #97 ALU64_ADD_K: 0 + (-1) = 0xffffffffffffffff jited:1 70 PASS
+[  106.906858] test_bpf: #98 ALU64_ADD_K: 0 + 0xffff = 0xffff jited:1 70 PASS
+[  106.914753] test_bpf: #99 ALU64_ADD_K: 0 + 0x7fffffff = 0x7fffffff jited:1 70 PASS
+[  106.923352] test_bpf: #100 ALU64_ADD_K: 0 + 0x80000000 = 0xffffffff80000000 jited:1 70 PASS
+[  106.932718] test_bpf: #101 ALU_ADD_K: 0 + 0x80008000 = 0xffffffff80008000 jited:1 77 PASS
+[  106.941960] test_bpf: #102 ALU_SUB_X: 3 - 1 = 2 jited:1 52 PASS
+[  106.948735] test_bpf: #103 ALU_SUB_X: 4294967295 - 4294967294 = 1 jited:1 58 PASS
+[  106.957073] test_bpf: #104 ALU64_SUB_X: 3 - 1 = 2 jited:1 52 PASS
+[  106.964058] test_bpf: #105 ALU64_SUB_X: 4294967295 - 4294967294 = 1 jited:1 52 PASS
+[  106.972542] test_bpf: #106 ALU_SUB_K: 3 - 1 = 2 jited:1 57 PASS
+[  106.979323] test_bpf: #107 ALU_SUB_K: 3 - 0 = 3 jited:1 51 PASS
+[  106.986065] test_bpf: #108 ALU_SUB_K: 4294967295 - 4294967294 = 1 jited:1 51 PASS
+[  106.994362] test_bpf: #109 ALU64_SUB_K: 3 - 1 = 2 jited:1 51 PASS
+[  107.001290] test_bpf: #110 ALU64_SUB_K: 3 - 0 = 3 jited:1 51 PASS
+[  107.008216] test_bpf: #111 ALU64_SUB_K: 4294967294 - 4294967295 = -1 jited:1 51 PASS
+[  107.016770] test_bpf: #112 ALU64_ADD_K: 2147483646 - 2147483647 = -1 jited:1 57 PASS
+[  107.025344] test_bpf: #113 ALU_MUL_X: 2 * 3 = 6 jited:1 61 PASS
+[  107.032367] test_bpf: #114 ALU_MUL_X: 2 * 0x7FFFFFF8 = 0xFFFFFFF0 jited:1 53 PASS
+[  107.040902] test_bpf: #115 ALU_MUL_X: -1 * -1 = 1 jited:1 72 PASS
+[  107.048031] test_bpf: #116 ALU64_MUL_X: 2 * 3 = 6 jited:1 55 PASS
+[  107.055025] test_bpf: #117 ALU64_MUL_X: 1 * 2147483647 = 2147483647 jited:1 55 PASS
+[  107.063547] test_bpf: #118 ALU_MUL_K: 2 * 3 = 6 jited:1 52 PASS
+[  107.070321] test_bpf: #119 ALU_MUL_K: 3 * 1 = 3 jited:1 52 PASS
+[  107.077092] test_bpf: #120 ALU_MUL_K: 2 * 0x7FFFFFF8 = 0xFFFFFFF0 jited:1 52 PASS
+[  107.085427] test_bpf: #121 ALU_MUL_K: 1 * (-1) = 0x00000000ffffffff jited:1 72 PASS
+[  107.094144] test_bpf: #122 ALU64_MUL_K: 2 * 3 = 6 jited:1 53 PASS
+[  107.101087] test_bpf: #123 ALU64_MUL_K: 3 * 1 = 3 jited:1 53 PASS
+[  107.108063] test_bpf: #124 ALU64_MUL_K: 1 * 2147483647 = 2147483647 jited:1 53 PASS
+[  107.116553] test_bpf: #125 ALU64_MUL_K: 1 * -2147483647 = -2147483647 jited:1 59 PASS
+[  107.125241] test_bpf: #126 ALU64_MUL_K: 1 * (-1) = 0xffffffffffffffff jited:1 73 PASS
+[  107.134128] test_bpf: #127 ALU_DIV_X: 6 / 2 = 3 jited:1 53 PASS
+[  107.140917] test_bpf: #128 ALU_DIV_X: 4294967295 / 4294967295 = 1 jited:1 59 PASS
+[  107.149299] test_bpf: #129 ALU64_DIV_X: 6 / 2 = 3 jited:1 53 PASS
+[  107.156232] test_bpf: #130 ALU64_DIV_X: 2147483647 / 2147483647 = 1 jited:1 53 PASS
+[  107.164744] test_bpf: #131 ALU64_DIV_X: 0xffffffffffffffff / (-1) = 0x0000000000000001 jited:1 167 PASS
+[  107.176102] test_bpf: #132 ALU_DIV_K: 6 / 2 = 3 jited:1 52 PASS
+[  107.182951] test_bpf: #133 ALU_DIV_K: 3 / 1 = 3 jited:1 52 PASS
+[  107.189722] test_bpf: #134 ALU_DIV_K: 4294967295 / 4294967295 = 1 jited:1 52 PASS
+[  107.198060] test_bpf: #135 ALU_DIV_K: 0xffffffffffffffff / (-1) = 0x1 jited:1 72 PASS
+[  107.206947] test_bpf: #136 ALU64_DIV_K: 6 / 2 = 3 jited:1 52 PASS
+[  107.214116] test_bpf: #137 ALU64_DIV_K: 3 / 1 = 3 jited:1 52 PASS
+[  107.221080] test_bpf: #138 ALU64_DIV_K: 2147483647 / 2147483647 = 1 jited:1 52 PASS
+[  107.229767] test_bpf: #139 ALU64_DIV_K: 0xffffffffffffffff / (-1) = 0x0000000000000001 jited:1 83 PASS
+[  107.240238] test_bpf: #140 ALU_MOD_X: 3 % 2 = 1 jited:1 60 PASS
+[  107.247082] test_bpf: #141 ALU_MOD_X: 4294967295 % 4294967293 = 2 jited:1 60 PASS
+[  107.255506] test_bpf: #142 ALU64_MOD_X: 3 % 2 = 1 jited:1 61 PASS
+[  107.262539] test_bpf: #143 ALU64_MOD_X: 2147483647 % 2147483645 = 2 jited:1 61 PASS
+[  107.271134] test_bpf: #144 ALU_MOD_K: 3 % 2 = 1 jited:1 58 PASS
+[  107.277956] test_bpf: #145 ALU_MOD_K: 3 % 1 = 0 jited:1 PASS
+[  107.283939] test_bpf: #146 ALU_MOD_K: 4294967295 % 4294967293 = 2 jited:1 58 PASS
+[  107.292319] test_bpf: #147 ALU64_MOD_K: 3 % 2 = 1 jited:1 60 PASS
+[  107.299376] test_bpf: #148 ALU64_MOD_K: 3 % 1 = 0 jited:1 PASS
+[  107.305522] test_bpf: #149 ALU64_MOD_K: 2147483647 % 2147483645 = 2 jited:1 60 PASS
+[  107.314075] test_bpf: #150 ALU_AND_X: 3 & 2 = 2 jited:1 52 PASS
+[  107.320885] test_bpf: #151 ALU_AND_X: 0xffffffff & 0xffffffff = 0xffffffff jited:1 58 PASS
+[  107.330021] test_bpf: #152 ALU64_AND_X: 3 & 2 = 2 jited:1 52 PASS
+[  107.336952] test_bpf: #153 ALU64_AND_X: 0xffffffff & 0xffffffff = 0xffffffff jited:1 58 PASS
+[  107.346226] test_bpf: #154 ALU_AND_K: 3 & 2 = 2 jited:1 51 PASS
+[  107.353002] test_bpf: #155 ALU_AND_K: 0xffffffff & 0xffffffff = 0xffffffff jited:1 57 PASS
+[  107.362118] test_bpf: #156 ALU64_AND_K: 3 & 2 = 2 jited:1 51 PASS
+[  107.369035] test_bpf: #157 ALU64_AND_K: 0xffffffff & 0xffffffff = 0xffffffff jited:1 51 PASS
+[  107.378288] test_bpf: #158 ALU64_AND_K: 0x0000ffffffff0000 & 0x0 = 0x0000ffff00000000 jited:1 70 PASS
+[  107.388687] test_bpf: #159 ALU64_AND_K: 0x0000ffffffff0000 & -1 = 0x0000ffffffffffff jited:1 76 PASS
+[  107.398890] test_bpf: #160 ALU64_AND_K: 0xffffffffffffffff & -1 = 0xffffffffffffffff jited:1 70 PASS
+[  107.409148] test_bpf: #161 ALU_OR_X: 1 | 2 = 3 jited:1 52 PASS
+[  107.416047] test_bpf: #162 ALU_OR_X: 0x0 | 0xffffffff = 0xffffffff jited:1 63 PASS
+[  107.424584] test_bpf: #163 ALU64_OR_X: 1 | 2 = 3 jited:1 58 PASS
+[  107.431492] test_bpf: #164 ALU64_OR_X: 0 | 0xffffffff = 0xffffffff jited:1 52 PASS
+[  107.439928] test_bpf: #165 ALU_OR_K: 1 | 2 = 3 jited:1 51 PASS
+[  107.446609] test_bpf: #166 ALU_OR_K: 0 & 0xffffffff = 0xffffffff jited:1 51 PASS
+[  107.454824] test_bpf: #167 ALU64_OR_K: 1 | 2 = 3 jited:1 51 PASS
+[  107.461682] test_bpf: #168 ALU64_OR_K: 0 & 0xffffffff = 0xffffffff jited:1 51 PASS
+[  107.470072] test_bpf: #169 ALU64_OR_K: 0x0000ffffffff0000 | 0x0 = 0x0000ffff00000000 jited:1 70 PASS
+[  107.480241] test_bpf: #170 ALU64_OR_K: 0x0000ffffffff0000 | -1 = 0xffffffffffffffff jited:1 70 PASS
+[  107.490365] test_bpf: #171 ALU64_OR_K: 0x000000000000000 | -1 = 0xffffffffffffffff jited:1 70 PASS
+[  107.500339] test_bpf: #172 ALU_XOR_X: 5 ^ 6 = 3 jited:1 52 PASS
+[  107.507121] test_bpf: #173 ALU_XOR_X: 0x1 ^ 0xffffffff = 0xfffffffe jited:1 52 PASS
+[  107.515608] test_bpf: #174 ALU64_XOR_X: 5 ^ 6 = 3 jited:1 52 PASS
+[  107.522563] test_bpf: #175 ALU64_XOR_X: 1 ^ 0xffffffff = 0xfffffffe jited:1 52 PASS
+[  107.531052] test_bpf: #176 ALU_XOR_K: 5 ^ 6 = 3 jited:1 51 PASS
+[  107.537820] test_bpf: #177 ALU_XOR_K: 1 ^ 0xffffffff = 0xfffffffe jited:1 51 PASS
+[  107.546121] test_bpf: #178 ALU64_XOR_K: 5 ^ 6 = 3 jited:1 51 PASS
+[  107.553072] test_bpf: #179 ALU64_XOR_K: 1 & 0xffffffff = 0xfffffffe jited:1 51 PASS
+[  107.561601] test_bpf: #180 ALU64_XOR_K: 0x0000ffffffff0000 ^ 0x0 = 0x0000ffffffff0000 jited:1 70 PASS
+[  107.571828] test_bpf: #181 ALU64_XOR_K: 0x0000ffffffff0000 ^ -1 = 0xffff00000000ffff jited:1 70 PASS
+[  107.582028] test_bpf: #182 ALU64_XOR_K: 0x000000000000000 ^ -1 = 0xffffffffffffffff jited:1 70 PASS
+[  107.592220] test_bpf: #183 ALU_LSH_X: 1 << 1 = 2 jited:1 53 PASS
+[  107.599343] test_bpf: #184 ALU_LSH_X: 1 << 31 = 0x80000000 jited:1 65 PASS
+[  107.607222] test_bpf: #185 ALU64_LSH_X: 1 << 1 = 2 jited:1 53 PASS
+[  107.614316] test_bpf: #186 ALU64_LSH_X: 1 << 31 = 0x80000000 jited:1 53 PASS
+[  107.622240] test_bpf: #187 ALU_LSH_K: 1 << 1 = 2 jited:1 48 PASS
+[  107.629094] test_bpf: #188 ALU_LSH_K: 1 << 31 = 0x80000000 jited:1 48 PASS
+[  107.636824] test_bpf: #189 ALU64_LSH_K: 1 << 1 = 2 jited:1 56 PASS
+[  107.643875] test_bpf: #190 ALU64_LSH_K: 1 << 31 = 0x80000000 jited:1 48 PASS
+[  107.651725] test_bpf: #191 ALU_RSH_X: 2 >> 1 = 1 jited:1 53 PASS
+[  107.658619] test_bpf: #192 ALU_RSH_X: 0x80000000 >> 31 = 1 jited:1 53 PASS
+[  107.666360] test_bpf: #193 ALU64_RSH_X: 2 >> 1 = 1 jited:1 53 PASS
+[  107.673429] test_bpf: #194 ALU64_RSH_X: 0x80000000 >> 31 = 1 jited:1 53 PASS
+[  107.681368] test_bpf: #195 ALU_RSH_K: 2 >> 1 = 1 jited:1 48 PASS
+[  107.688195] test_bpf: #196 ALU_RSH_K: 0x80000000 >> 31 = 1 jited:1 48 PASS
+[  107.695883] test_bpf: #197 ALU64_RSH_K: 2 >> 1 = 1 jited:1 48 PASS
+[  107.702894] test_bpf: #198 ALU64_RSH_K: 0x80000000 >> 31 = 1 jited:1 48 PASS
+[  107.710750] test_bpf: #199 ALU_ARSH_X: 0xff00ff0000000000 >> 40 = 0xffffffffffff00ff jited:1 53 PASS
+[  107.720753] test_bpf: #200 ALU_ARSH_K: 0xff00ff0000000000 >> 40 = 0xffffffffffff00ff jited:1 54 PASS
+[  107.730719] test_bpf: #201 ALU_NEG: -(3) = -3 jited:1 40 PASS
+[  107.737202] test_bpf: #202 ALU_NEG: -(-3) = 3 jited:1 40 PASS
+[  107.743685] test_bpf: #203 ALU64_NEG: -(3) = -3 jited:1 47 PASS
+[  107.750451] test_bpf: #204 ALU64_NEG: -(-3) = 3 jited:1 47 PASS
+[  107.757185] test_bpf: #205 ALU_END_FROM_BE 16: 0x0123456789abcdef -> 0xcdef jited:1 51 PASS
+[  107.766397] test_bpf: #206 ALU_END_FROM_BE 32: 0x0123456789abcdef -> 0x89abcdef jited:1 53 PASS
+[  107.776118] test_bpf: #207 ALU_END_FROM_BE 64: 0x0123456789abcdef -> 0x89abcdef jited:1 48 PASS
+[  107.785793] test_bpf: #208 ALU_END_FROM_LE 16: 0x0123456789abcdef -> 0xefcd jited:1 60 PASS
+[  107.795104] test_bpf: #209 ALU_END_FROM_LE 32: 0x0123456789abcdef -> 0xefcdab89 jited:1 53 PASS
+[  107.804671] test_bpf: #210 ALU_END_FROM_LE 64: 0x0123456789abcdef -> 0x67452301 jited:1 53 PASS
+[  107.814194] test_bpf: #211 ST_MEM_B: Store/Load byte: max negative jited:1 48 PASS
+[  107.822614] test_bpf: #212 ST_MEM_B: Store/Load byte: max positive jited:1 48 PASS
+[  107.830977] test_bpf: #213 STX_MEM_B: Store/Load byte: max negative jited:1 65 PASS
+[  107.839656] test_bpf: #214 ST_MEM_H: Store/Load half word: max negative jited:1 48 PASS
+[  107.848467] test_bpf: #215 ST_MEM_H: Store/Load half word: max positive jited:1 48 PASS
+[  107.857295] test_bpf: #216 STX_MEM_H: Store/Load half word: max negative jited:1 65 PASS
+[  107.866400] test_bpf: #217 ST_MEM_W: Store/Load word: max negative jited:1 48 PASS
+[  107.874800] test_bpf: #218 ST_MEM_W: Store/Load word: max positive jited:1 48 PASS
+[  107.883172] test_bpf: #219 STX_MEM_W: Store/Load word: max negative jited:1 65 PASS
+[  107.891825] test_bpf: #220 ST_MEM_DW: Store/Load double word: max negative jited:1 48 PASS
+[  107.900886] test_bpf: #221 ST_MEM_DW: Store/Load double word: max negative 2 jited:1 83 PASS
+[  107.910474] test_bpf: #222 ST_MEM_DW: Store/Load double word: max positive jited:1 48 PASS
+[  107.919547] test_bpf: #223 STX_MEM_DW: Store/Load double word: max negative jited:1 65 PASS
+[  107.928860] test_bpf: #224 STX_XADD_W: Test: 0x12 + 0x10 = 0x22 jited:1 74 PASS
+[  107.937217] test_bpf: #225 STX_XADD_W: Test side-effects, r10: 0x12 + 0x10 = 0x22 jited:1 PASS
+[  107.946173] test_bpf: #226 STX_XADD_W: Test side-effects, r0: 0x12 + 0x10 = 0x22 jited:1 63 PASS
+[  107.955928] test_bpf: #227 STX_XADD_W: X + 1 + 1 + 1 + ... jited:1 72637 PASS
+[  108.705007] test_bpf: #228 STX_XADD_DW: Test: 0x12 + 0x10 = 0x22 jited:1 73 PASS
+[  108.713751] test_bpf: #229 STX_XADD_DW: Test side-effects, r10: 0x12 + 0x10 = 0x22 jited:1 PASS
+[  108.722997] test_bpf: #230 STX_XADD_DW: Test side-effects, r0: 0x12 + 0x10 = 0x22 jited:1 63 PASS
+[  108.732849] test_bpf: #231 STX_XADD_DW: X + 1 + 1 + 1 + ... jited:1 72644 PASS
+[  109.481823] test_bpf: #232 JMP_EXIT jited:1 40 PASS
+[  109.487590] test_bpf: #233 JMP_JA: Unconditional jump: if (true) return 1 jited:1 40 PASS
+[  109.496539] test_bpf: #234 JMP_JSLT_K: Signed jump: if (-2 < -1) return 1 jited:1 56 PASS
+[  109.505698] test_bpf: #235 JMP_JSLT_K: Signed jump: if (-1 < -1) return 0 jited:1 57 PASS
+[  109.514804] test_bpf: #236 JMP_JSGT_K: Signed jump: if (-1 > -2) return 1 jited:1 56 PASS
+[  109.523903] test_bpf: #237 JMP_JSGT_K: Signed jump: if (-1 > -1) return 0 jited:1 57 PASS
+[  109.532993] test_bpf: #238 JMP_JSLE_K: Signed jump: if (-2 <= -1) return 1 jited:1 63 PASS
+[  109.542208] test_bpf: #239 JMP_JSLE_K: Signed jump: if (-1 <= -1) return 1 jited:1 56 PASS
+[  109.551383] test_bpf: #240 JMP_JSLE_K: Signed jump: value walk 1 jited:1 86 PASS
+[  109.559996] test_bpf: #241 JMP_JSLE_K: Signed jump: value walk 2 jited:1 76 PASS
+[  109.568532] test_bpf: #242 JMP_JSGE_K: Signed jump: if (-1 >= -2) return 1 jited:1 56 PASS
+[  109.577698] test_bpf: #243 JMP_JSGE_K: Signed jump: if (-1 >= -1) return 1 jited:1 56 PASS
+[  109.586880] test_bpf: #244 JMP_JSGE_K: Signed jump: value walk 1 jited:1 86 PASS
+[  109.595506] test_bpf: #245 JMP_JSGE_K: Signed jump: value walk 2 jited:1 76 PASS
+[  109.604040] test_bpf: #246 JMP_JGT_K: if (3 > 2) return 1 jited:1 56 PASS
+[  109.611875] test_bpf: #247 JMP_JGT_K: Unsigned jump: if (-1 > 1) return 1 jited:1 56 PASS
+[  109.621004] test_bpf: #248 JMP_JLT_K: if (2 < 3) return 1 jited:1 62 PASS
+[  109.628768] test_bpf: #249 JMP_JGT_K: Unsigned jump: if (1 < -1) return 1 jited:1 66 PASS
+[  109.638123] test_bpf: #250 JMP_JGE_K: if (3 >= 2) return 1 jited:1 67 PASS
+[  109.646062] test_bpf: #251 JMP_JLE_K: if (2 <= 3) return 1 jited:1 56 PASS
+[  109.653865] test_bpf: #252 JMP_JGT_K: if (3 > 2) return 1 (jump backwards) jited:1 58 PASS
+[  109.663064] test_bpf: #253 JMP_JGE_K: if (3 >= 3) return 1 jited:1 56 PASS
+[  109.670867] test_bpf: #254 JMP_JGT_K: if (2 < 3) return 1 (jump backwards) jited:1 58 PASS
+[  109.680059] test_bpf: #255 JMP_JLE_K: if (3 <= 3) return 1 jited:1 56 PASS
+[  109.687871] test_bpf: #256 JMP_JNE_K: if (3 != 2) return 1 jited:1 56 PASS
+[  109.695658] test_bpf: #257 JMP_JEQ_K: if (3 == 3) return 1 jited:1 56 PASS
+[  109.703457] test_bpf: #258 JMP_JSET_K: if (0x3 & 0x2) return 1 jited:1 56 PASS
+[  109.711587] test_bpf: #259 JMP_JSET_K: if (0x3 & 0xffffffff) return 1 jited:1 56 PASS
+[  109.720337] test_bpf: #260 JMP_JSGT_X: Signed jump: if (-1 > -2) return 1 jited:1 65 PASS
+[  109.729509] test_bpf: #261 JMP_JSGT_X: Signed jump: if (-1 > -1) return 0 jited:1 66 PASS
+[  109.738733] test_bpf: #262 JMP_JSLT_X: Signed jump: if (-2 < -1) return 1 jited:1 65 PASS
+[  109.747938] test_bpf: #263 JMP_JSLT_X: Signed jump: if (-1 < -1) return 0 jited:1 66 PASS
+[  109.757107] test_bpf: #264 JMP_JSGE_X: Signed jump: if (-1 >= -2) return 1 jited:1 72 PASS
+[  109.766427] test_bpf: #265 JMP_JSGE_X: Signed jump: if (-1 >= -1) return 1 jited:1 65 PASS
+[  109.775693] test_bpf: #266 JMP_JSLE_X: Signed jump: if (-2 <= -1) return 1 jited:1 65 PASS
+[  109.784936] test_bpf: #267 JMP_JSLE_X: Signed jump: if (-1 <= -1) return 1 jited:1 72 PASS
+[  109.794238] test_bpf: #268 JMP_JGT_X: if (3 > 2) return 1 jited:1 65 PASS
+[  109.802048] test_bpf: #269 JMP_JGT_X: Unsigned jump: if (-1 > 1) return 1 jited:1 65 PASS
+[  109.811309] test_bpf: #270 JMP_JLT_X: if (2 < 3) return 1 jited:1 65 PASS
+[  109.819387] test_bpf: #271 JMP_JLT_X: Unsigned jump: if (1 < -1) return 1 jited:1 76 PASS
+[  109.828708] test_bpf: #272 JMP_JGE_X: if (3 >= 2) return 1 jited:1 72 PASS
+[  109.836680] test_bpf: #273 JMP_JGE_X: if (3 >= 3) return 1 jited:1 72 PASS
+[  109.844622] test_bpf: #274 JMP_JLE_X: if (2 <= 3) return 1 jited:1 65 PASS
+[  109.852561] test_bpf: #275 JMP_JLE_X: if (3 <= 3) return 1 jited:1 65 PASS
+[  109.860444] test_bpf: #276 JMP_JGE_X: ldimm64 test 1 jited:1 72 PASS
+[  109.867889] test_bpf: #277 JMP_JGE_X: ldimm64 test 2 jited:1 72 PASS
+[  109.875342] test_bpf: #278 JMP_JGE_X: ldimm64 test 3 jited:1 66 PASS
+[  109.882748] test_bpf: #279 JMP_JLE_X: ldimm64 test 1 jited:1 72 PASS
+[  109.890227] test_bpf: #280 JMP_JLE_X: ldimm64 test 2 jited:1 72 PASS
+[  109.897720] test_bpf: #281 JMP_JLE_X: ldimm64 test 3 jited:1 66 PASS
+[  109.905120] test_bpf: #282 JMP_JNE_X: if (3 != 2) return 1 jited:1 71 PASS
+[  109.913035] test_bpf: #283 JMP_JEQ_X: if (3 == 3) return 1 jited:1 72 PASS
+[  109.920963] test_bpf: #284 JMP_JSET_X: if (0x3 & 0x2) return 1 jited:1 72 PASS
+[  109.929237] test_bpf: #285 JMP_JSET_X: if (0x3 & 0xffffffff) return 1 jited:1 72 PASS
+[  109.938100] test_bpf: #286 JMP_JA: Jump, gap, jump, ... jited:1 42 PASS
+[  109.945523] test_bpf: #287 BPF_MAXINSNS: Maximum possible literals jited:1 41 PASS
+[  110.466777] test_bpf: #288 BPF_MAXINSNS: Single literal jited:1 41 PASS
+[  110.977545] test_bpf: #289 BPF_MAXINSNS: Run/add until end jited:1 38194 PASS
+[  111.663511] test_bpf: #290 BPF_MAXINSNS: Too many instructions PASS
+[  111.669827] test_bpf: #291 BPF_MAXINSNS: Very long jump jited:1 41 PASS
+[  112.205229] test_bpf: #292 BPF_MAXINSNS: Ctx heavy transformations jited:1 61007 60865 PASS
+[  114.048674] test_bpf: #293 BPF_MAXINSNS: Call heavy transformations jited:1 111898 112058 PASS
+[  116.331513] test_bpf: #294 BPF_MAXINSNS: Jump heavy test jited:1 52366 PASS
+[  117.499029] test_bpf: #295 BPF_MAXINSNS: Very long jump backwards jited:1 41 PASS
+[  117.801792] test_bpf: #296 BPF_MAXINSNS: Edge hopping nuthouse jited:1 16062 PASS
+[  117.977177] test_bpf: #297 BPF_MAXINSNS: Jump, gap, jump, ... jited:1 267 PASS
+[  117.995389] test_bpf: #298 BPF_MAXINSNS: ld_abs+get_processor_id jited:1 177241 PASS
+[  120.099747] test_bpf: #299 BPF_MAXINSNS: ld_abs+vlan_push/pop jited:1 166819 PASS
+[  122.067475] test_bpf: #300 BPF_MAXINSNS: jump around ld_abs jited:1 76 PASS
+[  122.384907] test_bpf: #301 LD_IND byte frag jited:1 200 PASS
+[  122.393288] test_bpf: #302 LD_IND halfword frag jited:1 206 PASS
+[  122.402019] test_bpf: #303 LD_IND word frag jited:1 206 PASS
+[  122.410288] test_bpf: #304 LD_IND halfword mixed head/frag jited:1 241 PASS
+[  122.420094] test_bpf: #305 LD_IND word mixed head/frag jited:1 221 PASS
+[  122.429350] test_bpf: #306 LD_ABS byte frag jited:1 200 PASS
+[  122.437414] test_bpf: #307 LD_ABS halfword frag jited:1 200 PASS
+[  122.445825] test_bpf: #308 LD_ABS word frag jited:1 201 PASS
+[  122.453887] test_bpf: #309 LD_ABS halfword mixed head/frag jited:1 235 PASS
+[  122.463591] test_bpf: #310 LD_ABS word mixed head/frag jited:1 215 PASS
+[  122.472747] test_bpf: #311 LD_IND byte default X jited:1 72 PASS
+[  122.479872] test_bpf: #312 LD_IND byte positive offset jited:1 77 PASS
+[  122.487591] test_bpf: #313 LD_IND byte negative offset jited:1 77 PASS
+[  122.495297] test_bpf: #314 LD_IND halfword positive offset jited:1 81 PASS
+[  122.503408] test_bpf: #315 LD_IND halfword negative offset jited:1 81 PASS
+[  122.511540] test_bpf: #316 LD_IND halfword unaligned jited:1 82 PASS
+[  122.519118] test_bpf: #317 LD_IND word positive offset jited:1 87 PASS
+[  122.526877] test_bpf: #318 LD_IND word negative offset jited:1 88 PASS
+[  122.534670] test_bpf: #319 LD_IND word unaligned (addr & 3 == 2) jited:1 90 PASS
+[  122.543332] test_bpf: #320 LD_IND word unaligned (addr & 3 == 1) jited:1 82 PASS
+[  122.551981] test_bpf: #321 LD_IND word unaligned (addr & 3 == 3) jited:1 82 PASS
+[  122.560612] test_bpf: #322 LD_ABS byte jited:1 71 PASS
+[  122.566859] test_bpf: #323 LD_ABS halfword jited:1 81 PASS
+[  122.573701] test_bpf: #324 LD_ABS halfword unaligned jited:1 75 PASS
+[  122.581417] test_bpf: #325 LD_ABS word jited:1 86 PASS
+[  122.587840] test_bpf: #326 LD_ABS word unaligned (addr & 3 == 2) jited:1 75 PASS
+[  122.596426] test_bpf: #327 LD_ABS word unaligned (addr & 3 == 1) jited:1 75 PASS
+[  122.605007] test_bpf: #328 LD_ABS word unaligned (addr & 3 == 3) jited:1 75 PASS
+[  122.613552] test_bpf: #329 ADD default X jited:1 41 PASS
+[  122.619710] test_bpf: #330 ADD default A jited:1 40 PASS
+[  122.625840] test_bpf: #331 SUB default X jited:1 41 PASS
+[  122.631982] test_bpf: #332 SUB default A jited:1 40 PASS
+[  122.638086] test_bpf: #333 MUL default X jited:1 42 PASS
+[  122.644235] test_bpf: #334 MUL default A jited:1 41 PASS
+[  122.650355] test_bpf: #335 DIV default X jited:1 42 PASS
+[  122.656503] test_bpf: #336 DIV default A jited:1 41 PASS
+[  122.662623] test_bpf: #337 MOD default X jited:1 42 PASS
+[  122.668775] test_bpf: #338 MOD default A jited:1 47 PASS
+[  122.674972] test_bpf: #339 JMP EQ default A jited:1 52 PASS
+[  122.681447] test_bpf: #340 JMP EQ default X jited:1 43 PASS
+[  122.687868] test_bpf: Summary: 341 PASSED, 0 FAILED, [333/333 JIT'ed]
+[  123.328553] IPv6: ADDRCONF(NETDEV_UP): veth1: link is not ready
+[  123.335451] IPv6: ADDRCONF(NETDEV_UP): veth1: link is not ready
+[  123.352367] IPv6: ADDRCONF(NETDEV_UP): veth2: link is not ready
+[  123.358907] IPv6: ADDRCONF(NETDEV_UP): veth2: link is not ready
+[  123.565529] IPv6: ADDRCONF(NETDEV_UP): veth11: link is not ready
+[  123.571915] IPv6: ADDRCONF(NETDEV_CHANGE): veth11: link becomes ready
+[  123.578462] IPv6: ADDRCONF(NETDEV_CHANGE): veth1: link becomes ready
+[  123.652479] IPv6: ADDRCONF(NETDEV_CHANGE): veth2: link becomes ready
+[  123.723163] NET: Registered protocol family 38
+[  128.941408] IPv6: ADDRCONF(NETDEV_UP): test_sock_addr1: link is not ready
+[  128.966248] IPv6: ADDRCONF(NETDEV_UP): test_sock_addr2: link is not ready
+[  128.973969] IPv6: ADDRCONF(NETDEV_UP): test_sock_addr2: link is not ready
+[  128.980864] IPv6: ADDRCONF(NETDEV_CHANGE): test_sock_addr2: link becomes ready
+[  128.988726] IPv6: ADDRCONF(NETDEV_CHANGE): test_sock_addr1: link becomes ready
+[  129.918168] IPv6: ADDRCONF(NETDEV_UP): veth1: link is not ready
+[  129.925233] IPv6: ADDRCONF(NETDEV_UP): veth1: link is not ready
+[  130.021212] IPv6: ADDRCONF(NETDEV_UP): veth0: link is not ready
+[  130.027408] IPv6: ADDRCONF(NETDEV_CHANGE): veth0: link becomes ready
+[  130.034043] IPv6: ADDRCONF(NETDEV_CHANGE): veth1: link becomes ready
+[  141.232200] IPv6: ADDRCONF(NETDEV_UP): veth1: link is not ready
+[  141.238947] IPv6: ADDRCONF(NETDEV_UP): veth1: link is not ready
+[  141.320140] IPv6: ADDRCONF(NETDEV_CHANGE): veth1: link becomes ready
+# Test case C prog read tcp_mem .. [FAIL]
+case: C_prog #
+# Summary 2 PASSED, 37 FAILED
+2: PASSED,_37 #
+[FAIL] 22 selftests bpf test_sysctl
+selftests: bpf_test_sysctl [FAIL]
+# selftests bpf test_hashmap
+bpf: test_hashmap_ #
+# test_hashmap_generic OK
+OK: _ #
+# test_hashmap_multimap OK
+OK: _ #
+# test_hashmap_empty OK
+OK: _ #
+[PASS] 23 selftests bpf test_hashmap
+selftests: bpf_test_hashmap [PASS]
+# selftests bpf test_btf_dump
+bpf: test_btf_dump_ #
+# Test case #0 (btf_dump_test_case_syntax) test_btf_dump_case71FAIL failed to load test BTF -2
+case: #0_(btf_dump_test_case_syntax) #
+# Test case #1 (btf_dump_test_case_ordering) test_btf_dump_case71FAIL failed to load test BTF -2
+case: #1_(btf_dump_test_case_ordering) #
+# Test case #2 (btf_dump_test_case_padding) test_btf_dump_case71FAIL failed to load test BTF -2
+case: #2_(btf_dump_test_case_padding) #
+# Test case #3 (btf_dump_test_case_packing) test_btf_dump_case71FAIL failed to load test BTF -2
+case: #3_(btf_dump_test_case_packing) #
+# Test case #4 (btf_dump_test_case_bitfields) test_btf_dump_case71FAIL failed to load test BTF -2
+case: #4_(btf_dump_test_case_bitfields) #
+# Test case #5 (btf_dump_test_case_multidim) test_btf_dump_case71FAIL failed to load test BTF -2
+case: #5_(btf_dump_test_case_multidim) #
+# Test cas[  155.919590] IPv6: ADDRCONF(NETDEV_UP): veth1: link is not ready
+e #6 (btf_dump_test_case_namespa[  155.929214] IPv6: ADDRCONF(NETDEV_UP): veth1: link is not ready
+cing) test_btf_dump_case71FAIL failed to load test BTF -2
+case: #6_(btf_dump_test_case_namespacing) #
+# 0 tests succeeded, 7 tests failed.
+tests: succeeded,_7 #
+[FAIL] 24 selftests bpf test_btf_dump
+selftests: bpf_test_btf_dump [FAIL]
+# selftests bpf test_cgroup_attach
+bpf: test_cgroup_attach_ #
+# (test_cgroup_attach.c65 errno Invalid argument) Loading program
+errno: Invalid_argument) #
+# (cgroup_helpers.c154 errno No such file or directory) Opening Cgroup Procs /mnt/cgroup.procs
+errno: No_such #
+# (test_cgroup_attach.c330 errno Invalid argument) Attaching prog to cg1
+errno: Invalid_argument) #
+# (test_cgroup_attach.c488 errno Invalid argument) Attaching prog[0] to cgegress
+errno: Invalid_argument) #
+# Output from verifier
+from: verifier_ #
+# 
+: _ #
+# -------
+: _ #
+# #overrideFAIL
+: _ #
+# failed to create map 'Invalid argument'
+to: create_map #
+# failed to create map 'Inval[  156.013124] IPv6: ADDRCONF(NETDEV_CHANGE): veth1: link becomes ready
+id argument'
+to: create_map #
+# failed to create map 'Invalid argument'
+to: create_map #
+# failed to create map 'Invalid argument'
+to: create_map #
+# failed to create map 'Invalid argument'
+to: create_map #
+# failed to create map 'Invalid argument'
+to: create_map #
+# failed to create map 'Invalid argument'
+to: create_map #
+# #multiFAIL
+: _ #
+# failed to create map 'Invalid argument'
+to: create_map #
+# failed to create map 'Invalid argument'
+to: create_map #
+# #autodetachFAIL
+: _ #
+# test_cgroup_attachFAIL
+: _ #
+[FAIL] 25 selftests bpf test_cgroup_attach
+selftests: bpf_test_cgroup_attach [FAIL]
+# selftests bpf xdping
+bpf: xdping_ #
+# usage xdping [OPTS] -I interface destination
+xdping: [OPTS]_-I #
+# 
+: _ #
+# OPTS
+: _ #
+#     -c count		Stop after sending count requests
+count: Stop_after #
+# 			(default 4, max 10)
+4,: max_10) #
+#     -I interface	interface name
+interface: interface_name #
+#     -N			Run in driver mode
+Run: in_driver #
+#     -s			Server mode
+Server: mode_ #
+#     -S			Run in skb mode
+Run: in_skb #
+[FAIL] 26 selftests bpf xdping
+selftests: bpf_xdping [FAIL]
+# selftests bpf test_sockopt
+bpf: test_sockopt_ #
+# (test_sockopt.c903 errno Argument list too long) Failed to load BPF program
+errno: Argument_list #
+# (test_sockopt.c903 errno Argument list too long) Failed to load BPF program
+errno: Argument_list #
+# (test_sockopt.c903 errno Argument list too long) Failed to load BPF program
+errno: Argument_list #
+# (test_sockopt.c903 errno Argument list too long) Failed to load BPF program
+errno: Argument_list #
+# (test_sockopt.c903 errno Argument list too long) Failed to load BPF program
+errno: Argument_list #
+# (test_sockopt.c903 errno Argument list too long) Failed to load BPF program
+errno: Argument_list #
+# (test_sockopt.c903 errno Argument list too long) Failed to load BPF program
+errno: Argument_list #
+# (test_sockopt.c903 errno Argument list too long) Failed to load BPF program
+errno: Argument_list #
+# (test_sockopt.c903 errno Argument list too long) Failed to load BPF program
+errno: Argument_list #
+# (test_sockopt.c903 errno Argument list too long) Failed to load BPF program
+errno: Argument_list #
+# (test_sockopt.c903 errno Argument list too long) Failed to load BPF program
+errno: Argument_list #
+# (test_sockopt.c903 errno Argument list too long) Failed to load BPF program
+errno: Argument_list #
+# (test_sockopt.c903 errno Argument list too long) Failed to load BPF program
+errno: Argument_list #
+# (test_sockopt.c903 errno Argument list too long) Failed to load BPF program
+errno: Argument_list #
+# (test_sockopt.c903 errno Argument list too long) Failed to load BPF program
+errno: Argument_list #
+# (test_sockopt.c903 errno Argument list too long) Failed to load BPF program
+errno: Argument_list #
+# (test_sockopt.c903 errno Argument list too long) Failed to load BPF program
+errno: Argument_list #
+# (test_sockopt.c903 errno Argument list too long) Failed to load BPF program
+errno: Argument_list #
+# (test_sockopt.c903 errno Argument list too long) Failed to load BPF program
+errno: Argument_list #
+# (test_sockopt.c903 errno Argument list too long) Failed to load BPF program
+errno: Argument_list #
+# (test_sockopt.c903 errno Argument list too long) Failed to load BPF program
+errno: Argument_list #
+# (test_sockopt.c903 errno Argument list too long) Failed to load BPF program
+errno: Argument_list #
+# (test_sockopt.c903 errno Argument list too long) Failed to load BPF program
+errno: Argument_list #
+# (test_sockopt.c903 errno Argument list too long) Failed to load BPF program
+errno: Argument_list #
+[  170.588924] IPv6: ADDRCONF(NETDEV_UP): veth1: link is not ready
+[  170.595898] IPv6: ADDRCONF(NETDEV_UP): veth1: link is not ready
+[  170.687020] IPv6: ADDRCONF(NETDEV_CHANGE): veth1: link becomes ready
+[  181.822664] IPv6: ADDRCONF(NETDEV_UP): veth1: link is not ready
+[  181.829295] IPv6: ADDRCONF(NETDEV_UP): veth1: link is not ready
+[  181.936622] IPv6: ADDRCONF(NETDEV_CHANGE): veth1: link becomes ready
+[  187.280718] IPv6: ADDRCONF(NETDEV_UP): veth1: link is not ready
+[  187.287410] IPv6: ADDRCONF(NETDEV_UP): veth1: link is not ready
+[  187.386041] IPv6: ADDRCONF(NETDEV_CHANGE): veth1: link becomes ready
+[  187.882752] ip_tables: (C) 2000-2006 Netfilter Core Team
+[  187.942836] audit: type=1325 audit(1574425412.261:8): table=filter family=2 entries=0
+[  188.009202] audit: type=1300 audit(1574425412.261:8): arch=c00000b7 syscall=273 success=yes exit=0 a0=0 a1=419fd0 a2=0 a3=0 items=0 ppid=5 pid=4130 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm=\"modprobe\" exe=\"/bin/kmod\" key=(null)
+[  188.034516] audit: type=1327 audit(1574425412.261:8): proctitle=2F7362696E2F6D6F6470726F6265002D71002D2D0069707461626C655F66696C746572
+[  188.046625] audit: type=1325 audit(1574425412.245:9): table=filter family=2 entries=0
+[  188.097182] audit: type=1300 audit(1574425412.245:9): arch=c00000b7 syscall=209 success=yes exit=0 a0=6 a1=0 a2=40 a3=fffffd53cbc8 items=0 ppid=3456 pid=4120 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=ttyAMA0 ses=4294967295 comm=\"iptables\" exe=\"/usr/sbin/xtables-multi\" key=(null)
+[  188.124676] audit: type=1327 audit(1574425412.245:9): proctitle=69707461626C6573002D41004F5554505554002D6A004D41524B002D2D7365742D6D61726B0030783830304646
+[  199.145388] IPv6: ADDRCONF(NETDEV_UP): veth1: link is not ready
+[  199.152010] IPv6: ADDRCONF(NETDEV_UP): veth1: link is not ready
+[  199.251552] IPv6: ADDRCONF(NETDEV_CHANGE): veth1: link becomes ready
+[  214.680229] IPv6: ADDRCONF(NETDEV_UP): veth1: link is not ready
+[  214.687183] IPv6: ADDRCONF(NETDEV_UP): veth1: link is not ready
+[  214.793778] IPv6: ADDRCONF(NETDEV_CHANGE): veth1: link becomes ready
+# (test_sockopt.c903 errno Argument list too long) Failed to load BPF program
+errno: Argument_list #
+# #0 PASS getsockopt no expected_attach_type
+PASS: getsockopt_no #
+# #1 FAIL getsockopt wrong expected_attach_type
+FAIL: getsockopt_wrong #
+# #2 FAIL getsockopt bypass bpf hook
+FAIL: getsockopt_bypass #
+# #3 FAIL getsockopt return EPERM from bpf hook
+FAIL: getsockopt_return #
+# #4 PASS getsockopt no optval bounds check, deny loading
+PASS: getsockopt_no #
+# #5 FAIL getsockopt read ctx->level
+FAIL: getsockopt_read #
+# #6 PASS getsockopt deny writing to ctx->level
+PASS: getsockopt_deny #
+# #7 FAIL getsockopt read ctx->optname
+FAIL: getsockopt_read #
+# #8 FAIL getsockopt read ctx->retval
+FAIL: getsockopt_read #
+# #9 PASS getsockopt deny writing to ctx->optname
+PASS: getsockopt_deny #
+# #10 FAIL getsockopt read ctx->optlen
+FAIL: getsockopt_read #
+# #11 FAIL getsockopt deny bigger ctx->optlen
+FAIL: getsockopt_deny #
+# #12 FAIL getsockopt deny arbitrary ctx->retval
+FAIL: getsockopt_deny #
+# #13 FAIL getsockopt support smaller ctx->optlen
+FAIL: getsoc[  226.025804] IPv6: ADDRCONF(NETDEV_UP): veth1: link is not ready
+kopt_support #
+# #14 PASS getso[  226.034739] IPv6: ADDRCONF(NETDEV_UP): veth1: link is not ready
+ckopt deny writing to ctx->optval
+PASS: getsockopt_deny #
+# #15 PASS getsockopt deny writing to ctx->optval_end
+PASS: getsockopt_deny #
+# #16 FAIL getsockopt rewrite value
+FAIL: getsockopt_rewrite #
+# #17 PASS setsockopt no expected_attach_type
+PASS: setsockopt_no #
+# #18 FAIL setsockopt wrong expected_attach_type
+FAIL: setsockopt_wrong #
+# #19 FAIL setsockopt bypass bpf hook
+FAIL: setsockopt_bypass #
+# #20 FAIL setsockopt return EPERM from bpf hook
+FAIL: setsockopt_return #
+# #21 PASS setsockopt no optval bounds check, deny loading
+PASS: setsockopt_no #
+# #22 FAIL setsockopt read ctx->level
+FAIL: setsockopt_read #
+# #23 FAIL setsockopt allow changing ctx->level
+FAIL: setsockopt_allow #
+# #24 FAIL setsockopt read ctx->optname
+FAIL: setsockopt_read #
+# #25 FAIL setsockopt allow changing ctx->optname
+FAIL: setsockopt_allow #
+# #26 FAIL setsockopt read ctx->optlen
+FAIL: setsockopt_read #
+# #27 FAIL setsockopt ctx->optlen == -1 is ok
+FAIL: setsockopt_ctx->optlen #
+# #28 FAIL setsockopt deny ctx->optlen < 0 (except -1[  226.131091] IPv6: ADDRCONF(NETDEV_CHANGE): veth1: link becomes ready
+)
+FAIL: setsockopt_deny #
+# #29 FAIL setsockopt deny ctx->optlen > input optlen
+FAIL: setsockopt_deny #
+# #30 FAIL setsockopt allow changing ctx->optlen within bounds
+FAIL: setsockopt_allow #
+# #31 PASS setsockopt deny write ctx->retval
+PASS: setsockopt_deny #
+# #32 PASS setsockopt deny read ctx->retval
+PASS: setsockopt_deny #
+# #33 PASS setsockopt deny writing to ctx->optval
+PASS: setsockopt_deny #
+# #34 PASS setsockopt deny writing to ctx->optval_end
+PASS: setsockopt_deny #
+# #35 FAIL setsockopt allow IP_TOS <= 128
+FAIL: setsockopt_allow #
+# #36 FAIL setsockopt deny IP_TOS > 128
+FAIL: setsockopt_deny #
+# Summary 12 PASSED, 25 FAILED
+12: PASSED,_25 #
+[FAIL] 27 selftests bpf test_sockopt
+selftests: bpf_test_sockopt [FAIL]
+# selftests bpf test_sockopt_sk
+bpf: test_sockopt_sk_ #
+# libbpf failed to create map (name 'socket_storage_map') Invalid argument(-22)
+failed: to_create #
+# libbpf failed to load object './sockopt_sk.o'
+failed: to_load #
+# (test_sockopt_sk.c165 errno Invalid argument) Failed to load BPF object
+errno: Invalid_argument) #
+# test_sockopt_sk FAILED
+FAILED: _ #
+[FAIL] 28 selftests bpf test_sockopt_sk
+selftests: bpf_test_sockopt_sk [FAIL]
+# selftests bpf test_sockopt_multi
+bpf: test_sockopt_multi_ #
+# libbpf load bpf program failed Argument list too long
+load: bpf_program #
+# libbpf failed to load program 'cgroup/getsockopt/child'
+failed: to_load #
+# libbpf failed to load object './sockopt_multi.o'
+failed: to_load #
+# (test_sockopt_multi.c346 errno Invalid argument) Failed to load BPF object
+errno: Invalid_argument) #
+# test_sockopt_multi FAILED
+FAILED: _ #
+[FAIL] 29 selftests bpf test_sockopt_multi
+selftests: bpf_test_sockopt_multi [FAIL]
+# selftests bpf test_tcp_rtt
+bpf: test_tcp_rtt_ #
+# libbpf failed to create map (name 'socket_storage_map') Invalid argument(-22)
+failed: to_create #
+# libbpf failed to load object './tcp_rtt.o'
+failed: to_load #
+# (test_tcp_rtt.c125 errno Invalid argument) Failed to load BPF object
+errno: Invalid_argument) #
+# test_sockopt_sk FAILED
+FAILED: _ #
+[FAIL] 30 selftests bpf test_tcp_rtt
+selftests: bpf_test_tcp_rtt [FAIL]
+# selftests bpf urandom_read
+bpf: urandom_read_ #
+[PASS] 31 selftests bpf urandom_read
+selftests: bpf_urandom_read [PASS]
+# selftests bpf test_kmod.sh
+bpf: test_kmod.sh_ #
+# [ JIT enabled0 hardened0 ]
+JIT: enabled0_hardened0 #
+# test_bpf ok
+ok: _ #
+# [   86.098289] test_bpf Summary 341 PASSED, 0 FAILED, [0/333 JIT'ed]
+86.098289]: test_bpf_Summary #
+# [ JIT enabled1 hardened0 ]
+JIT: enabled1_hardened0 #
+# test_bpf ok
+ok: _ #
+# [   96.041686] test_bpf Summary 341 PASSED, 0 FAILED, [333/333 JIT'ed]
+96.041686]: test_bpf_Summary #
+# [ JIT enabled1 hardened1 ]
+JIT: enabled1_hardened1 #
+# test_bpf ok
+ok: _ #
+# [  106.029535] test_bpf Summary 341 PASSED, 0 FAILED, [333/333 JIT'ed]
+106.029535]: test_bpf_Summary #
+# [ JIT enabled1 hardened2 ]
+JIT: enabled1_hardened2 #
+# test_bpf ok
+ok: _ #
+# [  122.687868] test_bpf Summary 341 PASSED, 0 FAILED, [333/333 JIT'ed]
+122.687868]: test_bpf_Summary #
+[PASS] 32 selftests bpf test_kmod.sh
+selftests: bpf_test_kmod.sh [PASS]
+# selftests bpf test_libbpf.sh
+bpf: test_libbpf.sh_ #
+# [0] libbpf BTF is required, but is missing or corrupted.
+libbpf: BTF_is #
+# test_libbpf failed at file test_l4lb.o
+failed: at_file #
+# selftests test_libbpf [FAILED]
+test_libbpf: [FAILED]_ #
+[FAIL] 33 selftests bpf test_libbpf.sh
+selftests: bpf_test_libbpf.sh [FAIL]
+# selftests bpf test_xdp_redirect.sh
+bpf: test_xdp_redirect.sh_ #
+# PING 10.1.1.22 (10.1.1.22) 56(84) bytes of data.
+10.1.1.22: (10.1.1.22)_56(84) #
+# 64 bytes from 10.1.1.22 icmp_seq=1 ttl=64 time=0.522 ms
+bytes: from_10.1.1.22 #
+# 
+: _ #
+# --- 10.1.1.22 ping statistics ---
+10.1.1.22: ping_statistics #
+# 1 packets transmitted, 1 received, 0% packet loss, time 0ms
+packets: transmitted,_1 #
+# rtt min/avg/max/mdev = 0.522/0.522/0.522/0.000 ms
+min/avg/max/mdev: =_0.522/0.522/0.522/0.000 #
+# PING 10.1.1.11 (10.1.1.11) 56(84) bytes of data.
+10.1.1.11: (10.1.1.11)_56(84) #
+# 64 bytes from 10.1.1.11 icmp_seq=1 ttl=64 time=0.114 ms
+bytes: from_10.1.1.11 #
+# 
+: _ #
+# --- 10.1.1.11 ping statistics ---
+10.1.1.11: ping_statistics #
+[  237.540245] IPv6: ADDRCONF(NETDEV_UP): veth1: link is not ready
+[  237.547289] IPv6: ADDRCONF(NETDEV_UP): veth1: link is not ready
+[  237.617424] IPv6: ADDRCONF(NETDEV_CHANGE): veth1: link becomes ready
+[  248.875845] IPv6: ADDRCONF(NETDEV_UP): veth1: link is not ready
+[  248.882784] IPv6: ADDRCONF(NETDEV_UP): veth1: link is not ready
+[  248.972077] IPv6: ADDRCONF(NETDEV_CHANGE): veth1: link becomes ready
+[  263.446995] IPv6: ADDRCONF(NETDEV_UP): veth1: link is not ready
+[  263.453939] IPv6: ADDRCONF(NETDEV_UP): veth1: link is not ready
+[  263.545112] IPv6: ADDRCONF(NETDEV_CHANGE): veth1: link becomes ready
+[  268.913176] IPv6: ADDRCONF(NETDEV_UP): veth1: link is not ready
+[  268.922376] IPv6: ADDRCONF(NETDEV_UP): veth1: link is not ready
+[  268.974650] IPv6: ADDRCONF(NETDEV_UP): veth2: link is not ready
+[  268.982244] IPv6: ADDRCONF(NETDEV_UP): veth2: link is not ready
+[  268.988640] IPv6: ADDRCONF(NETDEV_CHANGE): veth2: link becomes ready
+[  268.995418] IPv6: ADDRCONF(NETDEV_CHANGE): veth1: link becomes ready
+[  269.171654] IPv6: ADDRCONF(NETDEV_UP): veth6: link is not ready
+[  269.178715] IPv6: ADDRCONF(NETDEV_UP): veth6: link is not ready
+[  269.299814] IPv6: ADDRCONF(NETDEV_UP): veth8: link is not ready
+[  269.306455] IPv6: ADDRCONF(NETDEV_UP): veth8: link is not ready
+[  269.411836] IPv6: ADDRCONF(NETDEV_UP): veth10: link is not ready
+[  269.418503] IPv6: ADDRCONF(NETDEV_UP): veth10: link is not ready
+[  269.513584] IPv6: ADDRCONF(NETDEV_UP): veth1: link is not ready
+[  269.601987] IPv6: ADDRCONF(NETDEV_UP): veth2: link is not ready
+[  269.607963] IPv6: ADDRCONF(NETDEV_CHANGE): veth1: link becomes ready
+[  269.614474] IPv6: ADDRCONF(NETDEV_CHANGE): veth2: link becomes ready
+[  269.688857] IPv6: ADDRCONF(NETDEV_UP): veth3: link is not ready
+[  269.753761] IPv6: ADDRCONF(NETDEV_CHANGE): veth3: link becomes ready
+[  269.808935] IPv6: ADDRCONF(NETDEV_UP): veth5: link is not ready
+[  269.877987] IPv6: ADDRCONF(NETDEV_UP): veth6: link is not ready
+[  269.883998] IPv6: ADDRCONF(NETDEV_CHANGE): veth6: link becomes ready
+[  269.890609] IPv6: ADDRCONF(NETDEV_CHANGE): veth5: link becomes ready
+[  269.949014] IPv6: ADDRCONF(NETDEV_UP): veth7: link is not ready
+[  270.033585] IPv6: ADDRCONF(NETDEV_UP): veth8: link is not ready
+[  270.039568] IPv6: ADDRCONF(NETDEV_CHANGE): veth8: link becomes ready
+[  270.046393] IPv6: ADDRCONF(NETDEV_CHANGE): veth7: link becomes ready
+[  270.106295] IPv6: ADDRCONF(NETDEV_UP): veth9: link is not ready
+[  270.186062] IPv6: ADDRCONF(NETDEV_UP): veth10: link is not ready
+[  270.192435] IPv6: ADDRCONF(NETDEV_CHANGE): veth10: link becomes ready
+[  270.199206] IPv6: ADDRCONF(NETDEV_CHANGE): veth9: link becomes ready
+[  271.801053] IPv6: ADDRCONF(NETDEV_UP): test_cgid_1: link is not ready
+[  271.817339] IPv6: ADDRCONF(NETDEV_UP): test_cgid_1: link is not ready
+[  271.845936] IPv6: ADDRCONF(NETDEV_UP): test_cgid_2: link is not ready
+[  271.853653] IPv6: ADDRCONF(NETDEV_CHANGE): test_cgid_1: link becomes ready
+# 1 packets transmitted, 1 received, 0% packet loss, time 0ms
+packets: transmitted,_1 #
+# rtt min/avg/max/mdev = 0.114/0.114/0.114/0.000 ms
+min/avg/max/mdev: =_0.114/0.114/0.114/0.000 #
+# selftests test_xdp_redirect [PASS]
+test_xdp_redirect: [PASS]_ #
+[PASS] 34 selftests bpf test_xdp_redirect.sh
+selftests: bpf_test_xdp_redirect.sh [PASS]
+# selftests bpf test_xdp_meta.sh
+bpf: test_xdp_meta.sh_ #
+# RTNETLINK answers Operation not supported
+answers: Operation_not #
+# selftests test_xdp_meta [FAILED]
+test_xdp_meta: [FAILED]_ #
+[FAIL] 35 selftests bpf test_xdp_meta.sh
+selftests: bpf_test_xdp_meta.sh [FAIL]
+# selftests bpf test_xdp_veth.sh
+bpf: test_xdp_veth.sh_ #
+# selftests xdp_veth [SKIP] Could not run test without bpftool
+xdp_veth: [SKIP]_Could #
+[SKIP] 36 selftests bpf test_xdp_veth.sh # SKIP
+selftests: bpf_test_xdp_veth.sh [SKIP]
+# selftests bpf test_offload.py
+bpf: test_offload.py_ #
+[SKIP] SKIP bpftool not installed
+bpftool: not_installed [SKIP]
+[PASS] 37 selftests bpf test_offload.py
+selftests: bpf_test_offload.py [PASS]
+# selftests bpf test_sock_addr.sh
+bpf: test_sock_addr.sh_ #
+# Wait for testing IPv4/IPv6 to become available .....ERROR Timeout waiting for test IP to become available.
+for: testing_IPv4/IPv6 #
+[FAIL] 38 selftests bpf test_sock_addr.sh
+selftests: bpf_test_sock_addr.sh [FAIL]
+# selftests bpf test_tunnel.sh
+bpf: test_tunnel.sh_ #
+# Testing GRE tunnel...
+GRE: tunnel..._ #
+# RTNETLINK answers Operation not supported
+answers: Operation_not #
+# Cannot find device \"gretap00\"
+find: device_\"gretap00\" #
+# Cannot find device \"gretap00\"
+find: device_\"gretap00\" #
+# RTNETLINK answers Operation not supported
+answers: Operation_not #
+# Cannot find device \"gretap11\"
+find: device_\"gretap11\" #
+# Cannot find device \"gretap11\"
+find: device_\"gretap11\" #
+# Cannot find device \"gretap11\"
+find: device_\"gretap11\" #
+# Cannot find device \"gretap11\"
+find: device_\"gretap11\" #
+# Cannot find device \"gretap11\"
+find: device_\"gretap11\" #
+# PING 10.1.1.100 (10.1.1.100) 56(84) bytes of data.
+10.1.1.100: (10.1.1.100)_56(84) #
+# 
+: _ #
+# --- 10.1.1.100 ping statistics ---
+10.1.1.100: ping_statistics #
+# 10 packets transmitted, 0 received, 100% packet loss, time 9210ms
+packets: transmitted,_0 #
+# 
+: _ #
+# connect Network is unreachable
+Network: is_unreachable #
+# [0;31mFAIL gretap[0m
+gretap[0m: _ #
+# Testing IP6GRE tunnel...
+IP6GRE: tunnel..._ #
+# RTNETLINK answers Operation not supported
+answers: Operation_not #
+# Cannot find device \"ip6gre00\"
+find: device_\"ip6gre00\" #
+# Cannot find device \"ip6gre00\"
+find: device_\"ip6gre00\" #
+# Cannot find device \"ip6gre00\"
+find: device_\"ip6gre00\" #
+# RTNETLINK answers Operation not supported
+answers: Operation_not #
+# Cannot find device \"ip6gre11\"
+find: device_\"ip6gre11\" #
+# Cannot find device \"ip6gre11\"
+find: device_\"ip6gre11\" #
+# Cannot find device \"ip6gre11\"
+find: device_\"ip6gre11\" #
+# Cannot find device \"ip6gre11\"
+find: device_\"ip6gre11\" #
+# Cannot find device \"ip6gre11\"
+find: device_\"ip6gre11\" #
+# Cannot find device \"ip6gre11\"
+find: device_\"ip6gre11\" #
+# PING 11 (11) 56 data bytes
+11: (11)_56 #
+# 
+: _ #
+# --- 11 ping statistics ---
+11: ping_statistics #
+# 4 packets transmitted, 3 packets received, 25% packet loss
+packets: transmitted,_3 #
+# round-trip min/avg/max = 0.304/7.675/22.208 ms
+min/avg/max: =_0.304/7.675/22.208 #
+# connect Network is unreachable
+Network: is_unreachable #
+# PING 10.1.1.100 (10.1.1.100) 56(84) bytes of data.
+10.1.1.100: (10.1.1.100)_56(84) #
+# 
+: _ #
+# --- 10.1.1.100 ping statistics ---
+10.1.1.100: ping_statistics #
+# 10 packets transmitted, 0 received, 100% packet loss, time 9203ms
+packets: transmitted,_0 #
+# 
+: _ #
+# PING fc80200 (fc80200) 56 data bytes
+fc80200: (fc80200)_56 #
+# ping6 sendto Network is unreachable
+sendto: Network_is #
+# [0;31mFAIL ip6gre[0m
+ip6gre[0m: _ #
+# Testing IP6GRETAP tunnel...
+IP6GRETAP: tunnel..._ #
+# RTNETLINK answers Operation not supported
+answers: Operation_not #
+# Cannot find device \"ip6gretap00\"
+find: device_\"ip6gretap00\" #
+# Cannot find device \"ip6gretap00\"
+find: device_\"ip6gretap00\" #
+# Cannot find device \"ip6gretap00\"
+find: device_\"ip6gretap00\" #
+# RTNETLINK answers Operation not supported
+answers: Operation_not #
+# Cannot find device \"ip6gretap11\"
+find: device_\"ip6gretap11\" #
+# Cannot find device \"ip6gretap11\"
+find: device_\"ip6gretap11\" #
+# Cannot find device \"ip6gretap11\"
+find: device_\"ip6gretap11\" #
+# Cannot find device \"ip6gretap11\"
+find: device_\"ip6gretap11\" #
+# Cannot find device \"ip6gretap11\"
+find: device_\"ip6gretap11\" #
+# Cannot find device \"ip6gretap11\"
+find: device_\"ip6gretap11\" #
+# PING 11 (11) 56 data bytes
+11: (11)_56 #
+# 
+: _ #
+# --- 11 ping statistics ---
+11: ping_statistics #
+# 4 packets transmitted, 3 packets received, 25% packet loss
+packets: transmitted,_3 #
+# round-trip min/avg/max = 0.215/7.809/22.982 ms
+min/avg/max: =_0.215/7.809/22.982 #
+# connect Network is unreachable
+Network: is_unreachable #
+# PING 10.1.1.100 (10.1.1.100) 56(84) bytes of data.
+10.1.1.100: (10.1.1.100)_56(84) #
+# 
+: _ #
+# --- 10.1.1.100 ping statistics ---
+10.1.1.100: ping_statistics #
+# 10 packets transmitted, 0 received, 100% packet loss, time 9204ms
+packets: transmitted,_0 #
+# 
+: _ #
+# PING fc80200 (fc80200) 56 data bytes
+fc80200: (fc80200)_56 #
+# ping6 sendto Network is unreachable
+sendto: Network_is #
+# [0;31mFAIL ip6gretap[0m
+ip6gretap[0m: _ #
+# Testing ERSPAN tunnel...
+ERSPAN: tunnel..._ #
+# RTNETLINK answers Operation not supported
+answers: Operation_not #
+# Cannot find device \"erspan00\"
+find: device_\"erspan00\" #
+# Cannot find device \"erspan00\"
+find: device_\"erspan00\" #
+# RTNETLINK answers Operation not supported
+answers: Operation_not #
+# Cannot find device \"erspan11\"
+find: device_\"erspan11\" #
+# Cannot find device \"erspan11\"
+find: device_\"erspan11\" #
+# Cannot find device \"erspan11\"
+find: device_\"erspan11\" #
+# Cannot find device \"erspan11\"
+find: device_\"erspan11\" #
+# Cannot find device \"erspan11\"
+find: device_\"erspan11\" #
+# PING 10.1.1.100 (10.1.1.100) 56(84) bytes of data.
+10.1.1.100: (10.1.1.100)_56(84) #
+# 
+: _ #
+# --- 10.1.1.100 ping statistics ---
+10.1.1.100: ping_statistics #
+# 10 packets transmitted, 0 received, 100% packet loss, time 9219ms
+packets: transmitted,_0 #
+# 
+: _ #
+# connect Network is unreachable
+Network: is_unreachable #
+# [0;31mFAIL erspan[0m
+erspan[0m: _ #
+# Testing IP6ERSPAN tunnel...
+IP6ERSPAN: tunnel..._ #
+# RTNETLINK answers Operation not supported
+answers: Operation_not #
+# Cannot find device \"ip6erspan00\"
+find: device_\"ip6erspan00\" #
+# Cannot find device \"ip6erspan00\"
+find: device_\"ip6erspan00\" #
+# RTNETLINK answers Operation not supported
+answers: Operation_not #
+# Cannot find device \"ip6erspan11\"
+find: device_\"ip6erspan11\" #
+# Cannot find device \"ip6erspan11\"
+find: device_\"ip6erspan11\" #
+# Cannot find device \"ip6erspan11\"
+find: device_\"ip6erspan11\" #
+# Cannot find device \"ip6erspan11\"
+find: device_\"ip6erspan11\" #
+# Cannot find device \"ip6erspan11\"
+find: device_\"ip6erspan11\" #
+# PING 11 (11) 56 data bytes
+11: (11)_56 #
+# 
+: _ #
+# --- 11 ping statistics ---
+11: ping_statistics #
+[  274.812533] IPv6: ADDRCONF(NETDEV_UP): veth2: link is not ready
+[  274.819148] IPv6: ADDRCONF(NETDEV_UP): veth2: link is not ready
+[  275.270657] IPv6: ADDRCONF(NETDEV_UP): veth1: link is not ready
+[  275.397765] 8021q: 802.1Q VLAN Support v1.8
+[  275.526545] IPv6: ADDRCONF(NETDEV_UP): veth2: link is not ready
+[  275.532726] IPv6: ADDRCONF(NETDEV_UP): veth2.4011: link is not ready
+[  275.539286] IPv6: ADDRCONF(NETDEV_CHANGE): veth2.4011: link becomes ready
+[  275.546212] IPv6: ADDRCONF(NETDEV_CHANGE): veth2: link becomes ready
+[  275.552732] IPv6: ADDRCONF(NETDEV_CHANGE): veth1: link becomes ready
+[  277.739010] IPv6: ADDRCONF(NETDEV_UP): veth2: link is not ready
+[  277.747313] IPv6: ADDRCONF(NETDEV_UP): veth2: link is not ready
+[  278.135662] IPv6: ADDRCONF(NETDEV_UP): veth1: link is not ready
+[  278.331169] IPv6: ADDRCONF(NETDEV_UP): veth2: link is not ready
+[  278.337602] IPv6: ADDRCONF(NETDEV_UP): veth2.4011: link is not ready
+[  278.344282] IPv6: ADDRCONF(NETDEV_CHANGE): veth2.4011: link becomes ready
+[  278.351352] IPv6: ADDRCONF(NETDEV_CHANGE): veth2: link becomes ready
+[  278.358058] IPv6: ADDRCONF(NETDEV_CHANGE): veth1: link becomes ready
+[  280.750589] IPv6: ADDRCONF(NETDEV_UP): veth3: link is not ready
+[  280.757304] IPv6: ADDRCONF(NETDEV_UP): veth3: link is not ready
+[  280.780468] IPv6: ADDRCONF(NETDEV_UP): veth1: link is not ready
+[  280.787226] IPv6: ADDRCONF(NETDEV_UP): veth1: link is not ready
+[  280.814785] IPv6: ADDRCONF(NETDEV_UP): veth2: link is not ready
+[  280.821939] IPv6: ADDRCONF(NETDEV_CHANGE): veth1: link becomes ready
+[  280.878500] IPv6: ADDRCONF(NETDEV_UP): veth4: link is not ready
+[  280.885503] IPv6: ADDRCONF(NETDEV_UP): veth4: link is not ready
+[  280.891677] IPv6: ADDRCONF(NETDEV_CHANGE): veth4: link becomes ready
+[  280.898611] IPv6: ADDRCONF(NETDEV_CHANGE): veth3: link becomes ready
+[  280.923603] IPv6: ADDRCONF(NETDEV_UP): veth6: link is not ready
+[  280.930756] IPv6: ADDRCONF(NETDEV_UP): veth6: link is not ready
+[  280.967048] IPv6: ADDRCONF(NETDEV_UP): veth5: link is not ready
+[  280.974814] IPv6: ADDRCONF(NETDEV_UP): veth5: link is not ready
+[  280.981033] IPv6: ADDRCONF(NETDEV_CHANGE): veth5: link becomes ready
+[  280.988005] IPv6: ADDRCONF(NETDEV_CHANGE): veth6: link becomes ready
+[  281.032556] IPv6: ADDRCONF(NETDEV_UP): veth8: link is not ready
+[  281.039229] IPv6: ADDRCONF(NETDEV_UP): veth8: link is not ready
+[  281.106855] IPv6: ADDRCONF(NETDEV_UP): veth7: link is not ready
+[  281.114877] IPv6: ADDRCONF(NETDEV_UP): veth7: link is not ready
+[  281.121004] IPv6: ADDRCONF(NETDEV_CHANGE): veth7: link becomes ready
+[  281.127726] IPv6: ADDRCONF(NETDEV_CHANGE): veth8: link becomes ready
+[  282.104011] IPv6: ADDRCONF(NETDEV_UP): veth1: link is not ready
+[  282.159531] IPv6: ADDRCONF(NETDEV_UP): veth2: link is not ready
+[  282.165503] IPv6: ADDRCONF(NETDEV_CHANGE): veth2: link becomes ready
+[  282.172064] IPv6: ADDRCONF(NETDEV_CHANGE): veth1: link becomes ready
+[  282.224073] IPv6: ADDRCONF(NETDEV_UP): veth3: link is not ready
+[  282.291393] IPv6: ADDRCONF(NETDEV_UP): veth4: link is not ready
+[  282.297349] IPv6: ADDRCONF(NETDEV_CHANGE): veth4: link becomes ready
+[  282.303830] IPv6: ADDRCONF(NETDEV_CHANGE): veth3: link becomes ready
+[  282.351446] IPv6: ADDRCONF(NETDEV_UP): veth5: link is not ready
+[  282.416117] IPv6: ADDRCONF(NETDEV_UP): veth6: link is not ready
+[  282.422155] IPv6: ADDRCONF(NETDEV_CHANGE): veth6: link becomes ready
+[  282.428764] IPv6: ADDRCONF(NETDEV_CHANGE): veth5: link becomes ready
+[  282.487484] IPv6: ADDRCONF(NETDEV_UP): veth7: link is not ready
+[  282.552076] IPv6: ADDRCONF(NETDEV_UP): veth8: link is not ready
+[  282.558166] IPv6: ADDRCONF(NETDEV_CHANGE): veth8: link becomes ready
+[  282.564788] IPv6: ADDRCONF(NETDEV_CHANGE): veth7: link becomes ready
+[  284.900222] IPv6: ADDRCONF(NETDEV_UP): veth1: link is not ready
+[  284.952226] IPv6: ADDRCONF(NETDEV_UP): veth2: link is not ready
+[  284.958196] IPv6: ADDRCONF(NETDEV_CHANGE): veth1: link becomes ready
+[  285.806667] IPv6: ADDRCONF(NETDEV_CHANGE): veth2: link becomes ready
+[  287.840482] IPv6: ADDRCONF(NETDEV_UP): veth_src: link is not ready
+[  287.916848] IPv6: ADDRCONF(NETDEV_UP): veth_dst: link is not ready
+[  287.923112] IPv6: ADDRCONF(NETDEV_CHANGE): veth_dst: link becomes ready
+[  287.929984] IPv6: ADDRCONF(NETDEV_CHANGE): veth_src: link becomes ready
+[  288.813966] IPv6: ADDRCONF(NETDEV_UP): veth1: link is not ready
+[  288.821292] IPv6: ADDRCONF(NETDEV_UP): veth1: link is not ready
+[  288.936385] IPv6: ADDRCONF(NETDEV_UP): veth0: link is not ready
+[  288.942355] IPv6: ADDRCONF(NETDEV_CHANGE): veth0: link becomes ready
+[  288.949149] IPv6: ADDRCONF(NETDEV_CHANGE): veth1: link becomes ready
+[  289.092585] kselftest: Running tests in breakpoints
+[  289.119256] kselftest: Running tests in capabilities
+# 5 packets transmitted, 3 packets received, 40% packet loss
+packets: transmitted,_3 #
+# round-trip min/avg/max = 0.288/16.049/47.570 ms
+min/avg/max: =_0.288/16.049/47.570 #
+# connect Network is unreachable
+Network: is_unreachable #
+# [0;31mFAIL ip6erspan[0m
+ip6erspan[0m: _ #
+# Testing VXLAN tunnel...
+VXLAN: tunnel..._ #
+# RTNETLINK answers Operation not supported
+answers: Operation_not #
+# Cannot find device \"vxlan00\"
+find: device_\"vxl[  289.380147] kselftest: Running tests in cgroup
+an00\" #
+# Cannot find device \"vxlan00\"
+find: device_\"vxlan00\" #
+# SIOCSARP Network is unreachable
+Network: is_unreachable #
+# iptables No chain/target/match by that name.
+No: chain/target/match_by #
+# RTNETLINK answers Operation not supported
+answers: Operation_not #
+# Cannot find device \"vxlan11\"
+find: device_\"vxlan11\" #
+# Cannot find device \"vxlan11\"
+find: device_\"vxlan11\" #
+# SIOCSARP Network is unreachable
+Network: is_unreachable #
+# Cannot find device \"vxlan11\"
+find: device_\"vxlan11\" #
+# Cannot find device \"vxlan11\"
+find: device_\"vxlan11\" #
+# Cannot find device \"vxlan11\"
+find: device_\"vxlan11\" #
+# PING 10.1.1.100 (10.1.1.100) 56(84) bytes of data.
+10.1.1.100: (10.1.1.100)_56(84) #
+# 
+: _ #
+# --- 10.1.1.100 ping statistics ---
+10.1.1.100: ping_statistics #
+# 10 packets transmitted, 0 received, 100% packet loss, time 9210ms
+packets: transmitted,_0 #
+# 
+: _ #
+# connect Network is unreachable
+Network: is_unreachable #
+# [0;31mFAIL vxlan[0m
+vxlan[0m: _ #
+# Testing IP6VXLAN tunnel...
+IP6VXLAN: tunnel..._ #
+# RTNETLINK answers Operation not supported
+answers: Operation_not #
+# Cannot find device \"ip6vxlan00\"
+find: device_\"ip6vxlan00\" #
+# Cannot find device \"ip6vxlan00\"
+find: device_\"ip6vxlan00\" #
+# RTNETLINK answers Operation not supported
+answers: Operation_not #
+# Cannot find device \"ip6vxlan11\"
+find: device_\"ip6vxlan11\" #
+# Cannot find device \"ip6vxlan11\"
+find: device_\"ip6vxlan11\" #
+# Cannot find device \"ip6vxlan11\"
+find: device_\"ip6vxlan11\" #
+# Cannot find device \"ip6vxlan11\"
+find: device_\"ip6vxlan11\" #
+# Cannot find device \"ip6vxlan11\"
+find: device_\"ip6vxlan11\" #
+# PING 11 (11) 56 data bytes
+11: (11)_56 #
+# 
+: _ #
+# --- 11 ping statistics ---
+11: ping_statistics #
+# 5 packets transmitted, 3 packets received, 40% packet loss
+packets: transmitted,_3 #
+# round-trip min/avg/max = 0.391/9.219/26.824 ms
+min/avg/max: =_0.391/9.219/26.824 #
+# PING 10.1.1.100 (10.1.1.100) 56(84) bytes of data.
+10.1.1.100: (10.1.1.100)_56(84) #
+# 
+: _ #
+# --- 10.1.1.100 ping statistics ---
+10.1.1.100: ping_statistics #
+# 10 packets transmitted, 0 received, 100% packet loss, time 9209ms
+packets: transmitted,_0 #
+# 
+: _ #
+# connect Network is unreachable
+Network: is_unreachable #
+# [0;31mFAIL ip6vxlan[0m
+ip6vxlan[0m: _ #
+# Testing GENEVE tunnel...
+GENEVE: tunnel..._ #
+# RTNETLINK answers Operation not supported
+answers: Operation_not #
+# Cannot find device \"geneve00\"
+find: device_\"geneve00\" #
+# Cannot find device \"geneve00\"
+find: device_\"geneve00\" #
+# RTNETLINK answers Operation not supported
+answers: Operation_not #
+# Cannot find device \"geneve11\"
+find: device_\"geneve11\" #
+# Cannot find device \"geneve11\"
+find: device_\"geneve11\" #
+# Cannot find device \"geneve11\"
+find: device_\"geneve11\" #
+# Cannot find device \"geneve11\"
+find: device_\"geneve11\" #
+# Cannot find device \"geneve11\"
+find: device_\"geneve11\" #
+# PING 10.1.1.100 (10.1.1.100) 56(84) bytes of data.
+10.1.1.100: (10.1.1.100)_56(84) #
+# 
+: _ #
+# --- 10.1.1.100 ping statistics ---
+10.1.1.100: ping_statistics #
+# 10 packets transmitted, 0 received, 100% packet loss, time 9222ms
+packets: transmitted,_0 #
+# 
+: _ #
+# connect Network is unreachable
+Network: is_unreachable #
+# [0;31mFAIL geneve[0m
+geneve[0m: _ #
+# Testing IP6GENEVE tunnel...
+IP6GENEVE: tunnel..._ #
+# RTNETLINK answers Operation not supported
+answers: Operation_not #
+# Cannot find device \"ip6geneve00\"
+find: device_\"ip6geneve00\" #
+# Cannot find device \"ip6geneve00\"
+find: device_\"ip6geneve00\" #
+# RTNETLINK answers Operation not supported
+answers: Operation_not #
+# Cannot find device \"ip6geneve11\"
+find: device_\"ip6geneve11\" #
+# Cannot find device \"ip6geneve11\"
+find: device_\"ip6geneve11\" #
+# Cannot find device \"ip6geneve11\"
+find: device_\"ip6geneve11\" #
+# Cannot find device \"ip6geneve11\"
+find: device_\"ip6geneve11\" #
+# Cannot find device \"ip6geneve11\"
+find: device_\"ip6geneve11\" #
+# PING 10.1.1.100 (10.1.1.100) 56(84) bytes of data.
+10.1.1.100: (10.1.1.100)_56(84) #
+# 
+: _ #
+# --- 10.1.1.100 ping statistics ---
+10.1.1.100: ping_statistics #
+# 10 packets transmitted, 0 received, 100% packet loss, time 9214ms
+packets: transmitted,_0 #
+# 
+: _ #
+# connect Network is unreachable
+Network: is_unreachable #
+# [0;31mFAIL ip6geneve[0m
+ip6geneve[0m: _ #
+# Testing IPIP tunnel...
+IPIP: tunnel..._ #
+# RTNETLINK answers Operation not supported
+answers: Operation_not #
+# Cannot find device \"ipip00\"
+find: device_\"ipip00\" #
+# Cannot find device \"ipip00\"
+find: device_\"ipip00\" #
+# RTNETLINK answers Operation not supported
+answers: Operation_not #
+# Cannot find device \"ipip11\"
+find: device_\"ipip11\" #
+# Cannot find device \"ipip11\"
+find: device_\"ipip11\" #
+# Cannot find device \"ipip11\"
+find: device_\"ipip11\" #
+# Cannot find device \"ipip11\"
+find: device_\"ipip11\" #
+# Cannot find device \"ipip11\"
+find: device_\"ipip11\" #
+# PING 10.1.1.100 (10.1.1.100) 56(84) bytes of data.
+10.1.1.100: (10.1.1.100)_56(84) #
+# 
+: _ #
+# --- 10.1.1.100 ping statistics ---
+10.1.1.100: ping_statistics #
+# 10 packets transmitted, 0 received, 100% packet loss, time 9196ms
+packets: transmitted,_0 #
+# 
+: _ #
+# connect Network is unreachable
+Network: is_unreachable #
+# [0;31mFAIL ipip[0m
+ipip[0m: _ #
+# Testing IPIP6 tunnel...
+IPIP6: tunnel..._ #
+# RTNETLINK answers Operation not supported
+answers: Operation_not #
+# Cannot find device \"ipip6tnl00\"
+find: device_\"ipip6tnl00\" #
+# Cannot find device \"ipip6tnl00\"
+find: device_\"ipip6tnl00\" #
+# RTNETLINK answers Operation not supported
+answers: Operation_not #
+# Cannot find device \"ipip6tnl11\"
+find: device_\"ipip6tnl11\" #
+# Cannot find device \"ipip6tnl11\"
+find: device_\"ipip6tnl11\" #
+# Cannot find device \"ipip6tnl11\"
+find: device_\"ipip6tnl11\" #
+# Cannot find device \"ipip6tnl11\"
+find: device_\"ipip6tnl11\" #
+# Cannot find device \"ipip6tnl11\"
+find: device_\"ipip6tnl11\" #
+# PING 11 (11) 56 data bytes
+11: (11)_56 #
+# 
+: _ #
+# --- 11 ping statistics ---
+11: ping_statistics #
+# 4 packets transmitted, 3 packets received, 25% packet loss
+packets: transmitted,_3 #
+# round-trip min/avg/max = 0.507/3.945/10.602 ms
+min/avg/max: =_0.507/3.945/10.602 #
+# PING 10.1.1.100 (10.1.1.100) 56(84) bytes of data.
+10.1.1.100: (10.1.1.100)_56(84) #
+# 
+: _ #
+# --- 10.1.1.100 ping statistics ---
+10.1.1.100: ping_statistics #
+# 10 packets transmitted, 0 received, 100% packet loss, time 9194ms
+packets: transmitted,_0 #
+# 
+: _ #
+# connect Network is unreachable
+Network: is_unreachable #
+# [0;31mFAIL ip6tnl[0m
+ip6tnl[0m: _ #
+# Testing IPSec tunnel...
+IPSec: tunnel..._ #
+# Cannot open netlink socket Protocol not supported
+open: netlink_socket #
+[  290.767000] kselftest: Running tests in cpufreq
+[  291.105201] kselftest: Running tests in cpu-hotplug
+[  291.346995] CPU5: shutdown
+[  291.350002] psci: CPU5 killed.
+[  291.375907] Detected VIPT I-cache on CPU5
+[  291.379969] CPU5: Booted secondary processor [410fd033]
+[  291.418993] kselftest: Running tests in drivers/dma-buf
+[  291.617067] kselftest: Running tests in efivarfs
+[  291.808622] kselftest: Running tests in exec
+# Cannot open netlink socket Protocol not supported
+open: netlink_socket #
+# Cannot open netlink socket Protocol not supported
+open: netlink_socket #
+# Cannot open netlink socket Protocol not supported
+open: netlink_socket #
+# Cannot open netlink socket Protocol not supported
+open: netlink_socket #
+# Cannot open netlink socket Protocol not supported
+open: netlink_socket #
+# Cannot open netlink socket Protocol not supported
+open: netlink_socket #
+# Cannot open netlink socket Protocol not supported
+open: netlink_socket #
+# RTNETLINK answers Operation not supported
+answers: Operation_not #
+# 
+: _ #
+# Prog section 'xfrm_get_state' rejected Invalid argument (22)!
+section: 'xfrm_get_state'_rejected #
+#  - Type         3
+Type: 3_ #
+#  - Instructions 35 (0 over limit)
+Instructions: 35_(0 #
+#  - License      GPL
+License: GPL_ #
+# 
+: _ #
+# Verifier analysis
+analysis: _ #
+# 
+: _ #
+# 0 (b7) r2 = 10
+(b7): r2_= #
+# 1 (6b) *(u16 *)(r10 -40) = r2
+(6b): *(u16_*)(r10 #
+# 2 (18) r2 = 0x7825783020706920
+(18): r2_= #
+# 4 (7b) *(u64 *)(r10 -48) = r2
+(7b): *(u64_*)(r10 #
+# 5 (18) r2 = 0x65746f6d65722078
+(18): r2_= #
+# 7 (7b) *(u64 *)(r10 -56) = r2
+(7b): *(u64_*)(r10 #
+# 8 (18) r2 = 0x2578302069707320
+(18): r2_= #
+# 10 (7b) *(u64 *)(r10 -64) = r2
+(7b): *(u64_*)(r10 #
+# 11 (18) r2 = 0x6425206469716572
+(18): r2_= #
+# 13 (7b) *(u64 *)(r10 -72) = r2
+(7b): *(u64_*)(r10 #
+# 14 (bf) r3 = r10
+(bf): r3_= #
+# 15 (07) r3 += -32
+(07): r3_+= #
+# 16 (b7) r6 = 0
+(b7): r6_= #
+# 17 (b7) r2 = 0
+(b7): r2_= #
+# 18 (b7) r4 = 28
+(b7): r4_= #
+# 19 (b7) r5 = 0
+(b7): r5_= #
+# 20 (85) call unknown#66
+(85): call_unknown#66 #
+# invalid func unknown#66
+func: unknown#66_ #
+# 
+: _ #
+# Error fetching program/map!
+fetching: program/map!_ #
+# Unable to load program
+to: load_program #
+# PING 10.1.1.200 (10.1.1.200) 56(84) bytes of data.
+10.1.1.200: (10.1.1.200)_56(84) #
+# 
+: _ #
+# --- 10.1.1.200 ping statistics ---
+10.1.1.200: ping_statistics #
+# 3 packets transmitted, 3 received, 0% packet loss, time 2051ms
+packets: transmitted,_3 #
+# rtt min/avg/max/mdev = 0.139/0.225/0.396/0.121 ms
+min/avg/max/mdev: =_0.139/0.225/0.396/0.121 #
+# [0;31mFAIL xfrm tunnel[0m
+xfrm: tunnel[0m_ #
+# test_tunnel.sh [0;31mFAIL[0m
+[0;31mFAIL[0m: _ #
+[FAIL] 39 selftests bpf test_tunnel.sh
+selftests: bpf_test_tunnel.sh [FAIL]
+# selftests bpf test_lwt_seg6local.sh
+bpf: test_lwt_seg6local.sh_ #
+# RTNETLINK answers File exists
+answers: File_exists #
+# selftests test_lwt_seg6local [FAILED]
+test_lwt_seg6local: [FAILED]_ #
+[FAIL] 40 selftests bpf test_lwt_seg6local.sh
+selftests: bpf_test_lwt_seg6local.sh [FAIL]
+# selftests bpf test_lirc_mode2.sh
+bpf: test_lirc_mode2.sh_ #
+# modprobe FATAL Module rc-loopback not found in directory /lib/modules/4.14.156-rc1
+FATAL: Module_rc-loopback #
+# grep /sys/class/rc/rc*/uevent No su[  292.581558] kselftest: Running tests in filesystems
+ch file or directory
+/sys/class/rc/rc*/uevent: No_such #
+# Usage ./test_lirc_mode2_user /dev/lircN /dev/input/eventM
+./test_lirc_mode2_user: /dev/lircN_/dev/input/eventM #
+# [0;31mFAIL lirc_mode2[0m
+lirc_mode2[0m: _ #
+[PASS] 41 selftests bpf test_lirc_mode2.sh
+selftests: bpf_test_lirc_mode2.sh [PASS]
+# selftests bpf test_skb_cgroup_id.sh
+bpf: test_skb_cgroup_id.sh_ #
+# Wait for testing link-local IP to become available ... OK
+for: testing_link-local #
+# RTNETLINK answers Operation not supported
+answers: Operation_not #
+[FAIL] 42 selftests bpf test_skb_cgroup_id.sh
+selftests: bpf_test_skb_cgroup_id.sh [FAIL]
+# selftests bpf test_flow_dissector.sh
+bpf: test_flow_dissector.sh_ #
+# bpffs not mounted. Mounting...
+not: mounted._Mounting... #
+# libbpf BTF is required, but is missing or corrupted.
+BTF: is_required, #
+# ./flow_dissector_load bpf_flow_load bpf_flow.o
+bpf_flow_load: bpf_flow.o_ #
+# selftests test_flow_dissector [FAILED]
+test_flow_dissector: [FAILED]_ #
+[FAIL] 43 selftests bpf test_flow_dissector.sh
+selftests: bpf_test_flow_dissector.sh [FAIL]
+# selftests bpf test_xdp_vlan_mode_generic.sh
+bpf: test_xdp_vlan_mode_generic.sh_ #
+# PING 100.64.41.1 (100.64.41.1) 56(84) bytes of data.
+100.64.41.1: (100.64.41.1)_56(84) #
+# 
+: _ #
+# --- 100.64.41.1 ping statistics ---
+100.64.41.1: ping_statistics #
+# 1 packets transmitted, 0 received, 100% packet loss, time 0ms
+packets: transmitted,_0 #
+# 
+: _ #
+# Success First ping must fail
+First: ping_must #
+# RTNETLINK answers Operation not supported
+answers: Operation_not #
+# selftests xdp_vlan_mode_generic [FAILED]
+xdp_vlan_mode_generic: [FAILED]_ #
+[FAIL] 44 selftests bpf test_xdp_vlan_mode_generic.sh
+selftests: bpf_test_xdp_vlan_mode_generic.sh [FAIL]
+# selftests bpf test_xdp_vlan_mode_native.sh
+bpf: test_xdp_vlan_mode_native.sh_ #
+# PING 100.64.41.1 (100.64.41.1) 56(84) bytes of[  292.750696] kselftest: Running tests in filesystems/binderfs
+ data.
+100.64.41.1: (100.64.41.1)_56(84) #
+# 
+: _ #
+# --- 100.64.41.1 ping statistics ---
+100.64.41.1: ping_statistics #
+# 1 packets transmitted, 0 received, 100% packet loss, time 0ms
+packets: transmitted,_0 #
+# 
+: _ #
+# Success First ping must fail
+First: ping_must #
+# RTNETLINK answers Operation not supported
+answers: Operation_not #
+# selftests xdp_vlan_mode_native [FAILED]
+xdp_vlan_mode_native: [FAILED]_ #
+[FAIL] 45 selftests bpf test_xdp_vlan_mode_native.sh
+selftests: bpf_test_xdp_vlan_mode_native.sh [FAIL]
+# selftests bpf test_lwt_ip_encap.sh
+bpf: test_lwt_ip_encap.sh_ #
+# starting egress IPv4 encap test 
+egress: IPv4_encap #
+# add tunnel \"gre0\" failed No such device
+tunnel: \"gre0\"_failed #
+# rm missing operand
+missing: operand_ #
+# Try 'rm --help' for more information.
+'rm: --help'_for #
+[FAIL] 46 selftests bpf test_lwt_ip_encap.sh
+selftests: bpf_test_lwt_ip_encap.sh [FAIL]
+# selftests bpf test_tcp_check_syncookie.sh
+bpf: test_tcp_check_syncookie.sh_ #
+# sysctl cannot stat /proc/sys/net/ipv4/tcp_syncookies No such file or directory
+cannot: stat_/proc/sys/net/ipv4/tcp_syncookies #
+[FAIL] 47 selftests bpf test_tcp_check_syncookie.sh
+selftests: bpf_test_tcp_check_syncookie.sh [FAIL]
+# selftests bpf test_tc_tunnel.sh
+bpf: test_tc_tunnel.sh_ #
+# ipip
+: _ #
+# encap 192.168.1.1 to 192.168.1.2, type ipip, mac none len 100
+192.168.1.1: to_192.168.1.2, #
+# test basic connectivity
+basic: connectivity_ #
+# BusyBox v1.27.2 (2019-06-24 100411 UTC) multi-call binary.
+v1.27.2: (2019-06-24_100411 #
+# 
+: _ #
+# Usage nc [IPADDR PORT]
+nc: [IPADDR_PORT] #
+# BusyBox v1.27.2 (2019-06-24 100411 UTC) multi-call binary.
+v1.27.2: (2019-06-24_100411 #
+# 
+: _ #
+# Usage nc [IPADDR PORT]
+nc: [IPADDR_PORT] #
+[FAIL] 48 selftests bpf test_tc_tunnel.sh
+selftests: bpf_test_tc_tunnel.sh [FAIL]
+# selftests bpf test_tc_edt.sh
+bpf: test_tc_edt.sh_ #
+# RTNETLINK answers Operation not supported
+answers: Operation_not #
+[FAIL] 49 selftests bpf test_tc_edt.sh
+selftests: bpf_test_tc_edt.sh [FAIL]
+# selftests bpf test_xdping.sh
+bpf: test_xdping.sh_ #
+# Test client args '-I veth1 -S'; server args ''
+client: args_'-I #
+# libbpf BTF is required, but is missing or corrupted.[  292.948492] kselftest: Running tests in firmware
+BTF: is_required, #
+# load of ./xdping_kern.o failed
+of: ./xdping_kern.o_failed #
+[FAIL] 50 selftests bpf test_xdping.sh
+selftests: bpf_test_xdping.sh [FAIL]
+TAP version 13
+13: _ TAP
+1..0
+: _ 1..0
+TAP version 13
+13: _ TAP
+1..1
+: _ 1..1
+# selftests capabilities test_execve
+capabilities: test_execve_ #
+# # validate_cap Capabilities after execve were correct
+validate_cap: Capabilities_after #
+# # validate_cap Capabilities after execve were correct
+validate_cap: Capabilities_after #
+# # validate_cap Capabilities after execve were correct
+validate_cap: Capabilities_after #
+# # validate_cap Capabilities after execve were correct
+validate_cap: Capabilities_after #
+# # validate_cap Capabilities after execve were correct
+validate_cap: Capabilities_after #
+# # validate_cap Capabilities after execve were correct
+validate_cap: Capabilities_after #
+# # validate_cap Capabilities after execve were correct
+validate_cap: Capabilities_after #
+# # validate_cap Capabilities after execve were correct
+validate_cap: Capabilities_after #
+# TAP version 13
+version: 13_ #
+# 1..12
+: _ #
+# # [RUN]	+++ Tests with uid == 0 +++
+[RUN]: +++_Tests #
+# # [NOTE]	Using global UIDs for tests
+[NOTE]: Using_global #
+# # [RUN]	Root => ep
+[RUN]: Root_=> #
+# ok 1 Passed
+1: Passed_ #
+# # Check cap_ambient manipulation rules
+Check: cap_ambient_manipulation #
+# ok 2 PR_CAP_AMBIENT_RAISE failed on non-inheritable cap
+2: PR_CAP_AMBIENT_RAISE_failed #
+# ok 3 PR_CAP_AMBIENT_RAISE failed on non-permitted cap
+3: PR_CAP_AMBIENT_RAISE_failed #
+# ok 4 PR_CAP_AMBIENT_RAISE worked
+4: PR_CAP_AMBIENT_RAISE_worked #
+# ok 5 Basic manipulation appears to work
+5: Basic_manipulation #
+# # [RUN]	Root +i => eip
+[RUN]: Root_+i #
+# ok 6 Passed
+6: Passed_ #
+# # [RUN]	UID 0 +ia => eipa
+[RUN]: UID_0 #
+# ok 7 Passed
+7: Passed_ #
+# # [RUN]	Root +ia, suidroot => eipa
+[RUN]: Root_+ia, #
+# ok 8 Passed
+8: Passed_ #
+# # [RUN]	Root +ia, suidnonroot => ip
+[RUN]: Root_+ia, #
+# ok 9 Passed
+9: Passed_ #
+# # [RUN]	Root +ia, sgidroot => eipa
+[RUN]: Root_+ia, #
+# ok 10 Passed
+10: Passed_ #
+# ok 11 Passed
+11: Passed_ #
+# # [RUN]	Root +ia, sgidnonroot => eip
+[RUN]: Root_+ia, #
+# ok 12 Passed
+12: Passed_ #
+# # Pass 12 Fail 0 Xfail 0 Xpass 0 Skip 0 Error 0
+Pass: 12_Fail #
+# # validate_cap Capabilities after execve were correct
+validate_cap: Capabilities_after #
+# # validate_cap Capabilities after execve were correct
+validate_cap: Capabilities_after #
+# # validate_cap Capabilities after execve were correct
+validate_cap: Capabilities_after #
+# # validate_cap Capabilities after execve were correct
+validate_cap: Capabilities_after #
+# # validate_cap Capabilities after execve were correct
+validate_cap: Capabilities_after #
+# # ==================================================
+==================================================: _ #
+# TAP version 13
+version: 13_ #
+# 1..9
+: _ #
+# # [RUN]	+++ Tests with uid != 0 +++
+[RUN]: +++_Tests #
+# # [NOTE]	Using global UIDs for tests
+[NOTE]: Using_global #
+# # [RUN]	Non-root => no caps
+[RUN]: Non-root_=> #
+# ok 1 Passed
+1: Passed_ #
+# # Check cap_ambient manipulation rules
+Check: cap_ambient_manipulation #
+# ok 2 PR_CAP_AMBIENT_RAISE failed on non-inheritable cap
+2: PR_CAP_AMBIENT_RAISE_failed #
+# ok 3 PR_CAP_AMBIENT_RAISE failed on non-permitted cap
+3: PR_CAP_AMBIENT_RAISE_failed #
+# ok 4 PR_CAP_AMBIENT_RAISE worked
+4: PR_CAP_AMBIENT_RAISE_worked #
+# ok 5 Basic manipulation appears to work
+5: Basic_manipulation #
+# # [RUN]	Non-root +i => i
+[RUN]: Non-root_+i #
+# ok 6 Passed
+6: Passed_ #
+# # [RUN]	UID 1 +ia => eipa
+[RUN]: UID_1 #
+# ok 7 Passed
+7: Passed_ #
+# # [RUN]	Non-root +ia, sgidnonroot => i
+[RUN]: Non-root_+ia, #
+# ok 8 Passed
+8: Passed_ #
+# ok 9 Passed
+9: Passed_ #
+# # Pass 9 Fail 0 Xfail 0 Xpass 0 Skip 0 Error 0
+Pass: 9_Fail #
+# # ==================================================
+==================================================: _ #
+[PASS] 1 selftests capabilities test_execve
+selftests: capabilities_test_execve [PASS]
+TAP version 13
+13: _ TAP
+1..3
+: _ 1..3
+# selftests cgroup test_memcontrol
+cgroup: test_memcontrol_ #
+[SKIP] not ok 1 # SKIP memory controller isn't available
+ok: 1_# [SKIP]
+[SKIP] 1 selftests cgroup test_memcontrol # SKIP
+selftests: cgroup_test_memcontrol [SKIP]
+# selftests cgroup test_core
+cgroup: test_core_ #
+[SKIP] not ok 1 # SKIP Failed to set memory controller
+ok: 1_# [SKIP]
+[SKIP] 2 selftests cgroup test_core # SKIP
+selftests: cgroup_test_core [SKIP]
+# selftests cgroup test_freezer
+cgroup: test_freezer_ #
+# Cgroup /sys/fs/cgroup/unified/cg_test_simple is frozen
+/sys/fs/cgroup/unified/cg_test_simple: is_frozen #
+# Error cg_freeze_nowait() failed
+cg_freeze_nowait(): failed_ #
+# Error cg_freeze_nowait() failed
+cg_freeze_nowait(): failed_ #
+# Error cg_freeze_nowait() failed
+cg_freeze_nowait(): failed_ #
+# Error cg_freeze_nowait() failed
+cg_freeze_nowait(): failed_ #
+# Error cg_freeze_nowait() failed
+cg_freeze_nowait(): failed_ #
+# Error cg_freeze_nowait() failed
+cg_freeze_nowait(): failed_ #
+# Cgroup /sys/fs/cgroup/unified/cg_test_stopped is frozen
+/sys/fs/cgroup/unified/cg_test_stopped: is_frozen #
+# Cgroup /sys/fs/cgroup/unified/cg_test_ptraced is frozen
+/sys/fs/cgroup/unified/cg_test_ptraced: is_frozen #
+# Error cg_freeze_nowait() failed
+cg_freeze_nowait(): failed_ #
+# not ok 1 test_cgfreezer_simple
+ok: 1_test_cgfreezer_simple #
+# not ok 2 test_cgfreezer_tree
+ok: 2_test_cgfreezer_tree #
+# not ok 3 test_cgfreezer_forkbomb
+ok: 3_test_cgfreezer_forkbomb #
+# not ok 4 test_cgfreezer_mkdir
+ok: 4_test_cgfreezer_mkdir #
+# not ok 5 test_cgfreezer_rmdir
+ok: 5_test_cgfreezer_rmdir #
+# not ok 6 test_cgfreezer_migrate
+ok: 6_test_cgfreezer_migrate #
+# not ok 7 test_cgfreezer_ptrace
+ok: 7_test_cgfreezer_ptrace #
+# not ok 8 test_cgfreezer_stopped
+ok: 8_test_cgfreezer_stopped #
+# not ok 9 test_cgfreezer_ptraced
+ok: 9_test_cgfreezer_ptraced #
+# not ok 10 test_cgfreezer_[  293.470402] test_firmware: loading ''
+vfork
+ok: 10_test_cgfreezer_vfo[  293.477008] test_firmware: load of '' failed: -22
+rk #
+[FAIL] 3 selftests cgroup [  293.485023] test_firmware: loading ''
+test_freezer
+selftests: cgroup_[  293.491089] test_firmware: failed to async load firmware
+test_freezer [FAIL]
+TAP version[  293.499018] test_firmware: loading 'nope-test-firmware.bin'
+ 13
+13: _ TAP
+1..1
+: _ 1..1
+[  293.507307] misc test_firmware: Direct firmware load for nope-test-firmware.bin failed with error -2
+# selftests cpufreq main.sh
+cpu[  293.519027] test_firmware: load of 'nope-test-firmware.bin' failed: -2
+freq: main.sh_ #
+# pid 5873's current affinity mask 3f
+5873's: current_affinity #
+# pid 5873's new affinity mask 1
+5873's: new_affinity #
+[FAIL] 1 selftest[  293.539016] test_firmware: loading 'test-firmware.bin'
+s cpufreq main.sh
+selftests: cp[  293.547344] test_firmware: loaded: 9
+ufreq_main.sh [FAIL]
+TAP version 13
+13: _ TAP
+1..1
+: _ 1..1
+# selftests cpu-hotplug cpu-on-off-test.sh
+cpu-hotplug: cpu-on[  293.562027] test_firmware: loading 'test-firmware.bin'
+-off-test.sh_ #
+# pid 5900's cu[  293.569660] test_firmware: loaded: 9
+rrent affinity mask 3f
+5900's: current_affinity #
+# pid 5900's new affinity mask 1
+5900's: new_affinity #
+# CPU online/offline summary
+online/offline: summary_ #
+# present_cpus = 0-5 present_max = 5
+=: 0-5_present_max #
+# 	 Cpus in online state 0-5
+in: online_state #
+# 	 Cpus in offline state 0
+in: offline_state #
+# Limite[  293.602649] test_firmware: reset
+d scope test one hotplug cpu
+sc[  293.608370] test_firmware: batched sync firmware loading 'test-firmware.bin' 4 times
+ope: test_one #
+# 	 (leaves cpu[  293.618385] test_firmware: #0: batched sync loaded 9
+ in the original state)
+cpu: in[  293.618564] test_firmware: #1: batched sync loaded 9
+_the #
+# 	 online to offline to[  293.618823] test_firmware: #2: batched sync loaded 9
+ online cpu 5
+to: offline_to #[  293.619129] test_firmware: #3: batched sync loaded 9
+[PASS] 1 selftests cpu-hotplug cpu-on-off-test.sh
+selftests: cpu-hotplug_cpu-on-off-test.sh [PASS]
+TAP version 13
+13: _ TAP
+1..1
+: _ 1..1
+# selftests dma-buf udmabuf
+dma-buf: udmabuf_ #
+# drivers/dma-buf/udmabuf [skip,no-udmabuf]
+[skip,no-udmabuf]: _ #
+[  293.710204] kselftest: Running tests in ftrace
+[  293.739447] kselftest: Running tests in futex
+[FAIL] 1 selftests dma-buf udmabuf
+selftests: dma-buf_udmabuf [FAIL]
+TAP version 13
+13: _ TAP
+1..1
+: _ 1..1
+# selftests efivarfs efivarfs.sh
+efivarfs: efivarfs.sh_ #
+# skip all tests efivarfs is not mounted on /sys/firmware/efi/efivars
+all: tests_efivarfs #
+[SKIP] 1 selftests efivarfs efivarfs.sh # SKIP
+selftests: efivarfs_efivarfs.sh [SKIP]
+TAP version 13
+13: _ TAP
+1..2
+: _ 1..2
+# selftests exec execveat
+exec: execveat_ #
+[  303.477321] kselftest: Running tests in gpio
+# /bin/sh /dev/fd/8/opt/kselftests/mainline/exec/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/x[  304.227820] gpiochip_find_base: cannot find free range
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx[  304.235893] gpiochip_add_data: GPIOs 0..1023 (gpio-mockup-B) failed to register
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx[  304.245847] gpio-mockup gpio-mockup: adding gpiochip failed: -28 (base: -1, ngpio: 1024)
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx[  304.299909] gpio-mockup: probe of gpio-mockup failed with error -28
+xxxxxx/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx[  304.390904] kselftest: Running tests in intel_pstate
+xxxxxxxxxxxx/yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy File name too long
+/dev/fd/8/opt/kselftests/mainline/exec/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx[  304.544230] kselftest: Running tests in ipc
+xxxxxxxxxxxxxxxxxxxxxxxx/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx[  304.736821] kselftest: Running tests in ir
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy: File_name #
+# Check success of execveat(5, '../execveat', 0)... [OK]
+success: of_execveat(5, #
+# Check success of execveat(7, 'execveat', 0)... [OK]
+success: of_execveat(7, #
+# Check success of execveat(9, 'execveat', 0)... [OK]
+success: of_execveat(9, #
+# Check success of execveat(-100, '/opt/kselftests/mainline/exec/execveat', 0)... [OK]
+success: of_execveat(-100, #
+# Check success of execveat(99, '/opt/kselftests/mainline/exec/execveat', 0)... [OK]
+success: of_execveat(99, #
+# Check success of execveat(11, '', 4096)... [OK]
+success: of_execveat(11, #
+# Check success of execveat(20, '', 4096)... [OK]
+success: of_execveat(20, #
+# Check success of execveat(12, '', 4096)... [OK]
+success: of_execveat(12, #
+# Check success of execveat(17, '', 4096)... [OK]
+success: of_execveat(17, #
+# Check success of execveat(17, '', 4096)... [OK]
+success: of_execveat(17, #
+# Check success of execveat(18, '', 4096)... [OK]
+success: of_execveat(18, #
+# Check failure of execveat(11, '', 0) with ENOENT... [OK]
+failure: of_execveat(11, #
+# Check failure of execveat(11, '(null)', 4096) with EFAULT... [OK]
+failure: of_execveat(11, #
+# Check success of execveat(7, 'execveat.symlink', 0)... [OK]
+success: of_execveat(7, #
+# Check success of execveat(9, 'execveat.symlink', 0)... [OK]
+success: of_execveat(9, #
+# Check success of execveat(-100, '/opt/kselftests/main...xec/execveat.symlink', 0[  304.887824] kselftest: Running tests in kcmp
+)... [OK]
+success: of_execveat(-100, #
+# Check success of execveat(13, '', 4096)... [OK]
+success: of_execveat(13, #
+# Check success of execveat(13, '', 4352)... [OK]
+success: of_execveat(13, #
+# Check failure of execveat(7, 'execveat.symlink', 256) with ELOOP... [OK]
+failure: of_execveat(7, #
+# Check failure of execveat(9, 'execveat.symlink', 256) with ELOOP... [OK]
+failure: of_execveat(9, #
+# Check failure of execveat(-100, '/opt/kselftests/mainline/exec/execveat.symlink', 256) with ELOOP... [OK]
+failure: of_execveat(-100, #
+# Check success of execveat(5, '../script', 0)... [OK]
+success: of_execveat(5, #
+# Check success of execveat(7, 'script', 0)... [OK]
+success: of_execveat(7, #
+# Check success of execveat(9, 'script', 0)... [OK]
+success: of_execveat(9, #
+# Check success of execveat(-100, '/opt/kselftests/mainline/exec/script', 0)... [OK]
+success: of_execveat(-100, #
+# Check success of execveat(16, '', 4096)... [OK]
+success: of_execveat(16, #
+# Check success of execveat(16, '', 4352)... [OK]
+success: of_execveat(16, #
+# Check failure of execveat(21, '', 4096) with ENOENT... [OK]
+failure: of_execveat(21, #
+# Check failure of execveat(10, 'script', 0) with ENOENT... [OK]
+failure: of_execveat(10, #
+# Check success of execveat(19, '', 4096)... [OK]
+success: of_execveat(19, #
+# Check success of execveat(19, '', 4096)... [OK]
+success: of_execveat(19, #
+# Check success of execveat(6, '../script', 0)... [OK]
+success: of_execveat(6, #
+# Check success of execveat(6, 'script', 0)... [OK]
+success: of_execveat(6, #
+# Check success of execveat(6, '../script', 0)... [OK]
+success: of_execveat(6, #
+# Check failure of execveat(6, 'script', 0) with ENOENT... [OK]
+failure: of_execveat(6, #
+# Check failure of execveat(7, 'execveat', 65535) with EINVAL... [OK]
+failure: of_execveat(7, #
+# Check failure of execveat(7, 'no-such-file', 0) with ENOENT... [OK]
+failure: of_execveat(7, #
+# Check failure of execveat(9, 'no-such-file', 0) with ENOENT... [OK]
+failure: of_execveat(9, #
+# Check failure of execveat(-100, 'no-such-file', 0) with ENOENT... [OK]
+failure: of_execveat(-100, #
+# Check failure of execveat(7, '', 4096) with EACCES... [OK]
+failure: of_execveat(7, #
+# Check failure of execveat(7, 'Makefile', 0) wit[  305.087931] kselftest: Running tests in kexec
+h EACCES... [OK]
+failure: of_execveat(7, #
+# Check failure of execveat(14, '', 4096) with EACCES... [OK]
+failure: of_execveat(14, #
+# Check failure of execveat(15, '', 4096) with EACCES... [OK]
+failure: of_execveat(15, #
+# Check failure of execveat(99, '', 4096) with EBADF... [OK]
+failure: of_execveat(99, #
+# Check failure of execveat(99, 'ex[  305.121726] kselftest: Running tests in kvm
+ecveat', 0) with EBADF... [OK]
+failure: of_execveat(99, #
+# Check failure of execveat(11, 'execveat', 0) with ENOTDIR... [OK]
+failure: of_execveat(11, #
+# Invoke copy of 'execveat' via filename of length 4094
+copy: of_'execveat' #
+# Check success of execveat(22, '', 4096)... [OK]
+success: of_execveat(22, #
+# Check success of execveat(8, 'opt/kselftests/mainl...yyyyyyyyyyyyyyyyyyyy', 0)... [OK]
+success: of_execveat(8, #
+# Invoke copy of 'script' via filename of length 4094
+copy: of_'script' #
+# Check success of execveat(23, '', 4096)... [OK]
+success: of_execveat(23, #
+# Check success of execveat(8, 'opt/kselftests/mainl...yyyyyyyyyyyyyyyyyyyy', 0)... [OK]
+success: of_execveat(8, #
+[PASS] 1 selftests exec execveat
+selftests: exec_execveat [PASS]
+# selftests exec recursion-depth
+exec: recursion-depth_ #
+[PASS] 2 selftests exec recursion-depth
+selftests: exec_recursion-depth [PASS]
+TAP version 13
+13: _ TAP
+1..1
+: _ 1..1
+# selftests filesystems devpts_pts
+filesystems: devpts_pts_ #
+# Failed to perform TIOCGPTPEER ioctl
+to: perform_TIOCGPTPEER #
+[PASS] 1 selftests filesystems devpts_pts
+selftests: filesystems_devpts_pts [PASS]
+TAP version 13
+13: _ TAP
+1..1
+: _ 1..1
+# selftests binderfs binderfs_test
+binderfs: binderfs_test_ #
+[SKIP] not ok 1 # SKIP The Android binderfs filesystem is not available
+ok: 1_# [SKIP]
+[SKIP] 1 selftests binderfs binderfs_test # SKIP
+selftests: binderfs_binderfs_test [SKIP]
+TAP version 13
+13: _ TAP
+1..1
+: _ 1..1
+# selftests firmware fw_run_tests.sh
+firmware: fw_run_tests.sh_ #
+# Running basic kernel configuration, working with your config
+basic: kernel_configuration, #
+# ./fw_filesystem.sh filesystem loading works
+filesystem: loading_works #
+# ./fw_filesystem.sh async filesystem loading works
+async: filesystem_loading #
+# 
+: _ #
+# Testing with the file present...
+with: the_file #
+# Batched request_firmware() normal try #1 request #0 firmware was not loaded
+request_firmware(): normal_try #
+[FAIL] 1 selftests firmware fw_run_tests.sh
+selftests: firmware_fw_run_tests.sh [FAIL]
+TAP version 13
+13: _ TAP
+1..0
+: _ 1..0
+TAP version 13
+13: _ TAP
+1..1
+: _ 1..1
+# selftests futex run.sh
+futex: run.sh_ #
+# [37m[m
+: _ #
+# TAP version 13
+version: 13_ #
+# 1..1
+: _ #
+# # futex_requeue_pi Test requeue functionality
+futex_requeue_pi: Test_requeue #
+# # 	Arguments broadcast=0 locked=0 owner=0 timeout=0ns
+Arguments: broadcast=0_locked=0 #
+# ok 1 futex-requeue-pi
+1: futex-requeue-pi_ #
+# # Pass 1 Fail 0 Xfail 0 Xpass 0 Skip 0 Error 0
+Pass: 1_Fail #
+# TAP version 13
+version: 13_ #
+# 1..1
+: _ #
+# # futex_requeue_pi Test requeue functionality
+futex_requeue_pi: Test_requeue #
+# # 	Arguments broadcast=1 locked=0 owner=0 timeout=0ns
+Arguments: broadcast=1_locked=0 #
+# ok 1 futex-requeue-pi
+1: futex-requeue-pi_ #
+# # Pass 1 Fail 0 Xfail 0 Xpass 0 Skip 0 Error 0
+Pass: 1_Fail #
+# TAP version 13
+version: 13_ #
+# 1..1
+: _ #
+# # futex_requeue_pi Test requeue functionality
+futex_requeue_pi: Test_requeue #
+# # 	Arguments broadcast=1 locked=1 owner=0 timeout=0ns
+Arguments: broadcast=1_locked=1 #
+# ok 1 futex-requeue-pi
+1: futex-requeue-pi_ #
+# # Pass 1 Fail 0 Xfail 0 Xpass 0 Skip 0 Error 0
+Pass: 1_Fail #
+# TAP version 13
+version: 13_ #
+# 1..1
+: _ #
+# # futex_requeue_pi Test requeue functionality
+futex_requeue_pi: Test_requeue #
+# # 	Arguments broadcast=1 locked=0 owner=1 timeout=0ns
+Arguments: broadcast=1_locked=0 #
+# ok 1 futex-requeue-pi
+1: futex-requeue-pi_ #
+# # Pass 1 Fail 0 Xfail 0 Xpass 0 Skip 0 Error 0
+Pass: 1_Fail #
+# TAP version 13
+version: 13_ #
+# 1..1
+: _ #
+# # futex_requeue_pi Test requeue functionality
+futex_requeue_pi: Test_requeue #
+# # 	Argumen[  305.447706] kselftest: Running tests in lib
+ts broadcast=0 locked=1 owner=0 timeout=0ns
+Arguments: broadcast=0_locked=1 #
+# ok 1 futex-requeue-pi
+1: futex-requeue-pi_ #
+# # Pass 1 Fail 0 Xfail 0 Xpass 0 Skip 0 Error 0
+Pass: 1_Fail #
+# TAP version 13
+version: 13_ #
+# 1..1
+: _ #
+# # futex_requeue_pi Test requeue functionality
+futex_requeue_pi: Test_requeue #
+# # 	Arguments broadcast=0 locked=0 owner=1 timeout=0ns
+Arguments: broadcast=0_locked=0 #
+# ok 1 futex-requeue-pi
+1: futex-requeue-pi_ #
+# # Pass 1 Fail 0 Xfail 0 Xpass 0 Skip 0 Error 0
+Pass: 1_Fail #
+# TAP version 13
+version: 13_ #
+# 1..1
+: _ #
+# # futex_requeue_pi Test requeue functionality
+futex_requeue_pi: Test_requeue #
+# # 	Arguments broadcast=1 locked=1 owner=0 timeout=5000ns
+Arguments: broadcast=1_locked=1 #
+# ok 1 futex-requeue-pi
+1: futex-requeue-pi_ #
+# # Pass 1 Fail 0 Xfail 0 Xpass 0 Skip 0 Error 0
+Pass: 1_Fail #
+# TAP version 13
+version: 13_ #
+# 1..1
+: _ #
+# # futex_requeue_pi Test requeue functionality
+futex_requeue_pi: Test_requeue #
+# # 	Arguments broadcast=0 locked=1 owner=0 timeout=5000ns
+Arguments: broadcast=0_locked=1 #
+# ok 1 futex-requeue-pi
+1: futex-requeue-pi_ #
+# # Pass 1 Fail 0 Xfail 0 Xpass 0 Skip 0 Error 0
+Pass: 1_Fail #
+# TAP version 13
+version: 13_ #
+# 1..1
+: _ #
+# # futex_requeue_pi Test requeue functionality
+futex_requeue_pi: Test_requeue #
+# # 	Arguments broadcast=1 locked=1 owner=0 timeout=500000ns
+Arguments: broadcast=1_locked=1 #
+# ok 1 futex-requeue-pi
+1: futex-requeue-pi_ #
+# # Pass 1 Fail 0 Xfail 0 Xpass 0 Skip 0 Error 0
+Pass: 1_Fail #
+# TAP version 13
+version: 13_ #
+# 1..1
+: _ #
+# # futex_requeue_pi Test requeue functionality
+futex_requeue_pi: Test_requeue #
+# # 	Arguments broadcast=0 locked=1 owner=0 timeout=500000ns
+Arguments: broadcast=0_locked=1 #
+# ok 1 futex-requeue-pi
+1: futex-requeue-pi_ #
+# # Pass 1 Fail 0 Xfail 0 Xpass 0 Skip 0 Error 0
+Pass: 1_Fail #
+# TAP version 13
+version: 13_ #
+# 1..1
+: _ #
+# # futex_requeue_pi Test requeue functionality
+futex_requeue_pi: Test_requeue #
+# # 	Arguments broadcast=1 locked=0 owner=0 timeout=5000ns
+Arguments: broadcast=1_locked=0 #
+# ok 1 futex-requeue-pi
+1: futex-requeue-pi_ #
+# # Pass 1 Fail 0 Xfail 0 Xpass 0 Skip 0 Error 0
+Pass: 1_Fail #
+# TAP version 13
+version: 13_ #
+# 1..1
+: _ #
+# # futex_requeue_pi Test requeue functionality
+futex_requeue_pi: Test_requeue #
+# # 	Arguments broadcast=0 locked=0 owner=0 timeout=5000ns
+Arguments: broadcast=0_locked=0 #
+# ok 1 futex-requeue-pi
+1: futex-requeue-pi_ #
+# # Pass 1 Fail 0 Xfail 0 Xpass 0 Skip 0 Error 0
+Pass: 1_Fail #
+# TAP version 13
+version: 13_ #
+# 1..1
+: _ #
+# # futex_requeue_pi Test requeue functionality
+futex_requeue_pi: Test_requeue #
+# # 	Arguments broadcast=1 locked=0 owner=0 timeout=500000ns
+Arguments: broadcast=1_locked=0 #
+# ok 1 futex-requeue-pi
+1: futex-requeue-pi_ #
+# # Pass 1 Fail 0 Xfail 0 Xpass 0 Skip 0 Error 0
+Pass: 1_Fail #
+# TAP version 13
+version: 13_ #
+# 1..1
+: _ #
+# # futex_requeue_pi Test requeue functionality
+futex_requeue_pi: Test_requeue #
+# # 	Arguments broadcast=0 locked=0 owner=0 timeout=500000ns
+Arguments: broadcast=0_locked=0 #
+# ok 1 futex-requeue-pi
+1: futex-requeue-pi_ #
+# # Pass 1 Fail 0 Xfail 0 Xpass 0 Skip 0 Error 0
+Pass: 1_Fail #
+# TAP version 13
+version: 13_ #
+# 1..1
+: _ #
+# # futex_requeue_pi Test requeue functionality
+futex_requeue_pi: Test_requeue #
+# # 	Arguments broadcast=1 locked=0 owner=1 timeout=5000ns
+Arguments: broadcast=1_locked=0 #
+# ok 1 futex-requeue-pi
+1: futex-requeue-pi_ #
+# # Pass 1 Fail 0 Xfail 0 Xpass 0 Skip 0 Error 0
+Pass: 1_Fail #
+# TAP version 13
+version: 13_ #
+# 1..1
+: _ #
+# # futex_requeue_pi Test requeue functionality
+futex_requeue_pi: Test_requeue #
+# # 	Arguments broadcast=0 locked=1 owner=0 timeout=5000ns
+Arguments: broadcast=0_locked=1 #
+# ok 1 futex-requeue-pi
+1: futex-requeue-pi_ #
+# # Pass 1 Fail 0 Xfail 0 Xpass 0 Skip 0 Error 0
+Pass: 1_Fail #
+# TAP version 13
+version: 13_ #
+# 1..1
+: _ #
+# # futex_requeue_pi Test requeue functionality
+futex_requeue_pi: Test_requeue #
+# # 	Arguments broadcast=1 locked=0 owner=1 timeout=500000ns
+Arguments: broadcast=1_locked=0 #
+# ok 1 futex-requeue-pi
+1: futex-requeue-pi_ #
+# # Pass 1 Fail 0 Xfail 0 Xpass 0 Skip 0 Error 0
+Pass: 1_Fail #
+# TAP version 13
+version: 13_ #
+# 1..1
+: _ #
+# # futex_requeue_pi Test requeue functionality
+futex_requeue_pi: Test_requeue #
+# # 	Arguments broadcast=0 locked=1 owner=0 timeout=500000ns
+Arguments: broadcast=0_locked=1 #
+# ok 1 futex-requeue-pi
+1: futex-requeue-pi_ #
+# # Pass 1 Fail 0 Xfail 0 Xpass 0 Skip 0 Error 0
+Pass: 1_Fail #
+# TAP version 13
+version: 13_ #
+# 1..1
+: _ #
+# # futex_requeue_pi Test requeue functionality
+futex_requeue_pi: Test_requeue #
+# # 	Arguments broadcast=1 locked=1 owner=0 timeout=2000000000ns
+Arguments: broadcast=1_locked=1 #
+[  306.100856] kselftest: Running tests in livepatch
+[  306.254732] SKIP: unable to load module test_klp_livepatch, verify CONFIG_TEST_LIVEPATCH=m and run self-tests as root
+[  306.425647] SKIP: unable to load module test_klp_callbacks_mod, verify CONFIG_TEST_LIVEPATCH=m and run self-tests as root
+[  306.595253] SKIP: unable to load module test_klp_shadow_vars, verify CONFIG_TEST_LIVEPATCH=m and run self-tests as root
+[  306.656077] kselftest: Running tests in membarrier
+[  306.863627] kselftest: Running tests in memfd
+[  306.941326] audit: type=1701 audit(1574425531.245:10): auid=4294967295 uid=0 gid=0 ses=4294967295 pid=6780 comm=\"memfd_test\" exe=\"/opt/kselftests/mainline/memfd/memfd_test\" sig=6 res=1
+[  309.029077] run_hugetlbfs_t (6817): drop_caches: 3
+[  309.283462] audit: type=1701 audit(1574425533.588:11): auid=4294967295 uid=0 gid=0 ses=4294967295 pid=6821 comm=\"memfd_test\" exe=\"/opt/kselftests/mainline/memfd/memfd_test\" sig=6 res=1
+[  309.439421] audit: type=1701 audit(1574425533.744:12): auid=4294967295 uid=0 gid=0 ses=4294967295 pid=6831 comm=\"fuse_test\" exe=\"/opt/kselftests/mainline/memfd/fuse_test\" sig=6 res=1
+[  309.479646] kselftest: Running tests in memory-hotplug
+[  309.826856] kselftest: Running tests in mount
+[  310.391101] kselftest: Running tests in mqueue
+# ok 1 futex-requeue-pi
+1: futex-requeue-pi_ #
+# # Pass 1 Fail 0 Xfail 0 Xpass 0 Skip 0 Error 0
+Pass: 1_Fail #
+# TAP version 13
+version: 13_ #
+# 1..1
+: _ #
+# # futex_requeue_pi Test requeue functionality
+futex_requeue_pi: Test_requeue #
+# # 	Arguments broadcast=0 locke[  310.626252] kselftest: Running tests in net
+d=1 owner=0 timeout=2000000000ns
+Arguments: broadcast=0_locked=1 #
+# ok 1 futex-requeue-pi
+1: futex-requeue-pi_ #
+# # Pass 1 Fail 0 Xfail 0 Xpass 0 Skip 0 Error 0
+Pass: 1_Fail #
+# 
+: _ #
+# TAP version 13
+version: 13_ #
+# 1..1
+: _ #
+# # futex_requeue_pi_mismatched_ops Detect mismatched requeue_pi operations
+futex_requeue_pi_mismatched_ops: Detect_mismatched #
+# ok 1 futex-requeue-pi-mismatched-ops
+1: futex-requeue-pi-mismatched-ops_ #
+# # Pass 1 Fail 0 Xfail 0 Xpass 0 Skip 0 Error 0
+Pass: 1_Fail #
+# 
+: _ #
+# TAP version 13
+version: 13_ #
+# 1..1
+: _ #
+# # futex_requeue_pi_signal_restart Test signal handling during requeue_pi
+futex_requeue_pi_signal_restart: Test_signal #
+# # 	Arguments <none>
+Arguments: <none>_ #
+# ok 1 futex-requeue-pi-signal-restart
+1: futex-requeue-pi-signal-restart_ #
+# # Pass 1 Fail 0 Xfail 0 Xpass 0 Skip 0 Error 0
+Pass: 1_Fail #
+# 
+: _ #
+# TAP version 13
+version: 13_ #
+# 1..1
+: _ #
+# # futex_wait_timeout Block on a futex and wait for timeout
+futex_wait_timeout: Block_on #
+# # 	Arguments timeout=100000ns
+Arguments: timeout=100000ns_ #
+# ok 1 futex-wait-timeout
+1: futex-wait-timeout_ #
+# # Pass 1 Fail 0 Xfail 0 Xpass 0 Skip 0 Error 0
+Pass: 1_Fail #
+# 
+: _ #
+# TAP version 13
+version: 13_ #
+# 1..1
+: _ #
+# # futex_wait_wouldblock Test the unexpected futex value in FUTEX_WAIT
+futex_wait_wouldblock: Test_the #
+# ok 1 futex-wait-wouldblock
+1: futex-wait-wouldblock_ #
+# # Pass 1 Fail 0 Xfail 0 Xpass 0 Skip 0 Error 0
+Pass: 1_Fail #
+# 
+: _ #
+# TAP version 13
+version: 13_ #
+# 1..1
+: _ #
+# # futex_wait_uninitialized_heap Test the uninitialized futex value in FUTEX_WAIT
+futex_wait_uninitialized_heap: Test_the #
+# ok 1 futex-wait-uninitialized-heap
+1: futex-wait-uninitialized-heap_ #
+# # Pass 1 Fail 0 Xfail 0 Xpass 0 Skip 0 Error 0
+Pass: 1_Fail #
+# TAP version 13
+version: 13_ #
+# 1..1
+: _ #
+# # futex_wait_private_mapped_file Test the futex value of private file mappings in FUTEX_WAIT
+futex_wait_private_mapped_file: Test_the #
+# ok 1 futex-wait-private-mapped-file
+1: futex-wait-private-mapped-file_ #
+# # Pass 1 Fail 0 Xfail 0 Xpass 0 Skip 0 Error 0
+Pass: 1_Fail #
+[PASS] 1 selftests futex run.sh
+selftests: futex_run.sh [PASS]
+TAP version 13
+13: _ TAP
+1..1
+: _ 1..1
+# selftests gpio gpio-mockup.sh
+gpio: gpio-mockup.sh_ #
+# 1.  Test dynamic allocation of gpio successful means insert gpiochip and
+Test: dynamic_allocation #
+#     manipulate gpio pin successful
+gpio: pin_successful #
+# GPIO gpio-mockup test with ranges <-1,32> 
+gpio-mockup: test_with #
+# -1,32      
+: _ #
+# Test gpiochip gpio-mockup line<0>.....line<31>.....line<7>.....successful
+gpiochip: gpio-mockup_line<0>.....line<31>.....line<7>.....successful #
+# GPIO gpio-mockup test with ranges <-1,32,-1,32> 
+gpio-mockup: test_with #
+# -1,32,-1,32 
+: _ #
+# Test gpiochip gpio-mockup line<0>.....line<31>.....line<7>.....line<0>.....line<31>.....line<6>.....successful
+gpiochip: gpio-mockup_line<0>.....line<31>.....line<7>.....line<0>.....line<31>.....line<6>.....successful #
+# GPIO gpio-mockup test with ranges <-1,32,-1,32,-1,32> 
+gpio-mockup: test_with #
+# -1,32,-1,32,-1,32 
+: _ #
+# Test gpiochip gpio-mockup line<0>.....line<31>.....line<7>.....line<0>.....line<31>.....line<6>.....line<0>.....line<31>.....line<9>.....successful
+gpiochip: gpio-mockup_line<0>.....line<31>.....line<7>.....line<0>.....line<31>.....line<6>.....line<0>.....line<31>.....line<9>.....successful #
+# 3.  Error test successful means insert gpiochip failed
+Error: test_successful #
+# 3.1 Test number of gpio overflow
+Test: number_of #
+# GPIO gpio-mockup test with ranges <-1,32,-1,1024> 
+gpio-mockup: test_with #
+# -1,32,-1,1024 
+: _ #
+# Test gpiochip gpio-mockup Invalid test successful
+gpiochip: gpio-mockup_Invalid #
+# GPIO test PASS
+test: PASS_ #
+[PASS] 1 selftests gpio gpio-mockup.sh
+selftests: gpio_gpio-mockup.sh [PASS]
+TAP version 13
+13: _ TAP
+1..1
+: _ 1..1
+# selftests intel_pstate run.sh
+intel_pstate: run.sh_ #
+# ./run.sh # Skipped Test can only run on x86 architectures.
+#: Skipped_Test #
+[SKIP] 1 selftests intel_pstate run.sh # SKIP
+selftests: intel_pstate_run.sh [SKIP]
+TAP version 13
+13: _ TAP
+1..1
+: _ 1..1
+# selftests ipc msgque
+ipc: msgque_ #
+# # Pass 0 Fail 0 Xfail 0 Xpass 0 Skip 0 Error 0
+Pass: 0_Fail #
+[PASS] 1 selftests ipc msgque
+selftests: ipc_msgque [PASS]
+TAP version 13
+13: _ TAP
+1..1
+: _ 1..1
+# selftests ir ir_loopback.sh
+ir: ir_loopback.sh_ #
+# ir_loopback module rc-loopback is not found [SKIP]
+module: rc-loopback_is #
+[SKIP] 1 selftests ir ir_loopback.sh # SKIP
+selftests: ir_ir_loopback.sh [SKIP]
+TAP version 13
+13: _ TAP
+1..1
+: _ 1..1
+# selftests kcmp kcmp_test
+kcmp: kcmp_test_ #
+# pid1   6590 pid2   6591 FD  1 FILES  1 VM  2 FS  2 SIGHAND  1 IO  0 SYSVSEM  0 INV -1
+6590: pid2_6591 #
+# PASS 0 returned as expected
+0: returned_as #
+# PASS 0 returned as expected
+0: returned_as #
+# PASS 0 returned as expected
+0: returned_as #
+# # Planned tests != run tests (0 != 3)
+Planned: tests_!= #
+# # Pass 3 Fail 0 Xfail 0 Xpass 0 Skip 0 Error 0
+Pass: 3_Fail #
+# # Planned tests != run tests (0 != 3)
+Planned: tests_!= #
+# # Pass 3 Fail 0 Xfail 0 Xpass 0 Skip 0 Error 0
+Pass: 3_Fail #
+# # Pass 0 Fail 0 Xfail 0 Xpass 0 Skip 0 Error 0
+Pass: 0_Fail #
+[PASS] 1 selftests kcmp kcmp_test
+selftests: kcmp_kcmp_test [PASS]
+./run_kselftest.sh line 161 cd kexec No such file or directory
+161: cd_kexec ./run_kselftest.sh
+TAP version 13
+13: _ TAP
+1..0
+: _ 1..0
+TAP version 13
+13: _ TAP
+1..15
+: _ 1..15
+# selftests kvm cr4_cpuid_sync_test
+kvm: cr4_cpuid_sync_test_ #
+# Warning file cr4_cpuid_sync_test is missing!
+file: cr4_cpuid_sync_test_is #
+[FAIL] 1 selftests kvm cr4_cpuid_sync_test
+selftests: kvm_cr4_cpuid_sync_test [FAIL]
+# selftests kvm evmcs_test
+kvm: evmcs_test_ #
+# Warning file evmcs_test is missing!
+file: evmcs_test_is #
+[FAIL] 2 selftests kvm evmcs_test
+selftests: kvm_evmcs_test [FAIL]
+# selftests kvm hyperv_cpuid
+kvm: hyperv_cpuid_ #
+# Warning file hyperv_cpuid is missing!
+file: hyperv_cpuid_is #
+[FAIL] 3 selftests kvm hyperv_cpuid
+selftests: kvm_hyperv_cpuid [FAIL]
+# selftests kvm mmio_warning_test
+kvm: mmio_warning_test_ #
+# Warning file mmio_warning_test is missing!
+file: mmio_warning_test_is #
+[FAIL] 4 selftests kvm mmio_warning_test
+selftests: kvm_mmio_warning_test [FAIL]
+# selftests kvm platform_info_test
+kvm: platform_info_test_ #
+# Warning file platform_info_test is missing!
+file: platform_info_test_is #
+[FAIL] 5 selftests kvm platform_info_test
+selftests: kvm_platform_info_test [FAIL]
+# selftests kvm set_sregs_test
+kvm: set_sregs_test_ #
+# Warning file set_sregs_test is missing!
+file: set_sregs_test_is #
+[FAIL] 6 selftests kvm set_sregs_test
+selftests: kvm_set_sregs_test [FAIL]
+# selftests kvm smm_test
+kvm: smm_test_ #
+# Warning file smm_test is missing!
+file: smm_test_is #
+[FAIL] 7 selftests kvm smm_test
+selftests: kvm_smm_test [FAIL]
+# selftests kvm state_test
+kvm: state_test_ #
+# Warning file state_test is missing!
+file: state_test_is #
+[FAIL] 8 selftests kvm state_test
+selftests: kvm_state_test [FAIL]
+# selftests kvm sync_regs_test
+kvm: sync_regs_test_ #
+# Warning file sync_regs_test is missing!
+file: sync_regs_test_is #
+[FAIL] 9 selftests kvm sync_regs_test
+selftests: kvm_sync_regs_test [FAIL]
+# selftests kvm vmx_close_while_nested_test
+kvm: vmx_close_while_nested_test_ #
+# Warning file vmx_close_while_nested_test is missing!
+file: vmx_close_while_nested_test_is #
+[FAIL] 10 selftests kvm vmx_close_while_nested_test
+selftests: kvm_vmx_close_while_nested_test [FAIL]
+# selftests kvm vmx_set_nested_state_test
+kvm: vmx_set_nested_state_test_ #
+# Warning file vmx_set_nested_state_test is missing!
+file: vmx_set_nested_state_test_is #
+[FAIL] 11 selftests kvm vmx_set_nested_state_test
+selftests: kvm_vmx_set_nested_state_test [FAIL]
+# selftests kvm vmx_tsc_adjust_test
+kvm: vmx_tsc_adjust_test_ #
+# Warning file vmx_tsc_adjust_test is missing!
+file: vmx_tsc_adjust_test_is #
+[FAIL] 12 selftests kvm vmx_tsc_adjust_test
+selftests: kvm_vmx_tsc_adjust_test [FAIL]
+# selftests kvm clear_dirty_log_test
+kvm: clear_dirty_log_test_ #
+# Warning file clear_dirty_log_test is missing!
+file: clear_dirty_log_test_is #
+[FAIL] 13 selftests kvm clear_dirty_log_test
+selftests: kvm_clear_dirty_log_test [FAIL]
+# selftests kvm dirty_log_test
+kvm: dirty_log_test_ #
+# Warning file dirty_log_test is missing!
+file: dirty_log_test_is #
+[FAIL] 14 selftests kvm dirty_log_test
+selftests: kvm_dirty_log_test [FAIL]
+# selftests kvm kvm_create_max_vcpus
+kvm: kvm_create_max_vcpus_ #
+# Warning file kvm_create_max_vcpus is missing!
+file: kvm_create_max_vcpus_is #
+[FAIL] 15 selftests kvm kvm_create_max_vcpus
+selftests: kvm_kvm_create_max_vcpus [FAIL]
+TAP version 13
+13: _ TAP
+1..4
+: _ 1..4
+# selftests lib printf.sh
+lib: printf.sh_ #
+# ./printf.sh line 4 ./../kselftest_module.sh No such file or directory
+line: 4_./../kselftest_module.sh #
+[FAIL] 1 selftests lib printf.sh
+selftests: lib_printf.sh [FAIL]
+# selftests lib bitmap.sh
+lib: bitmap.sh_ #
+# ./bitmap.sh line 3 ./../kselftest_module.sh No such file or directory
+line: 3_./../kselftest_module.sh #
+[FAIL] 2 selftests lib bitmap.sh
+selftests: lib_bitmap.sh [FAIL]
+# selftests lib prime_numbers.sh
+lib: prime_numbers.sh_ #
+# ./prime_numbers.sh line 4 ./../kselftest_module.sh No such file or directory
+line: 4_./../kselftest_module.sh #
+[FAIL] 3 selftests lib prime_numbers.sh
+selftests: lib_prime_numbers.sh [FAIL]
+# selftests lib strscpy.sh
+lib: strscpy.sh_ #
+# ./strscpy.sh line 3 ./../kselftest_module.sh No such file or directory
+line: 3_./../kselftest_module.sh #
+[FAIL] 4 selftests lib strscpy.sh
+selftests: lib_strscpy.sh [FAIL]
+TAP version 13
+13: _ TAP
+1..3
+: _ 1..3
+# selftests livepatch test-livepatch.sh
+livepatch: test-livepatch.sh_ #
+# grep /sys/kernel/debug/dynamic_debug/control No such file or directory
+/sys/kernel/debug/dynamic_debug/control: No_such #
+# ./functions.sh line 49 /sys/kernel/debug/dynamic_debug/control No such file or directory
+line: 49_/sys/kernel/debug/dynamic_debug/control #
+# TEST basic function patching ... SKIP unable to load module test_klp_livepatch, verify CONFIG_TEST_LIVEPATCH=m and run self-tests as root
+basic: function_patching #
+[SKIP] 1 selftests livepatch test-livepatch.sh # SKIP
+selftests: livepatch_test-livepatch.sh [SKIP]
+# selftests livepatch test-callbacks.sh
+livepatch: test-callbacks.sh_ #
+# grep /sys/kernel/debug/dynamic_debug/control No such file or directory
+/sys/kernel/debug/dynamic_debug/control: No_such #
+# ./functions.sh line 49 /sys/kernel/debug/dynamic_debug/control No such file or directory
+line: 49_/sys/kernel/debug/dynamic_debug/control #
+# TEST target module before livepatch ... SKIP unable to load module test_klp_callbacks_mod, verify CONFIG_TEST_LIVEPATCH=m and run self-tests as root
+target: module_before #
+[SKIP] 2 selftests livepatch test-callbacks.sh # SKIP
+selftests: livepatch_test-callbacks.sh [SKIP]
+# selftests livepatch test-shadow-vars.sh
+livepatch: test-shadow-vars.sh_ #
+# grep /sys/kernel/debug/dynamic_debug/control No such file or directory
+/sys/kernel/debug/dynamic_debug/control: No_such #
+# ./functions.sh line 49 /sys/kernel/debug/dynamic_debug/control No such file or directory
+line: 49_/sys/kernel/debug/dynamic_debug/control #
+# TEST basic shadow variable API ... SKIP unable to load module test_klp_shadow_vars, verify CONFIG_TEST_LIVEPATCH=m and run self-tests as root
+basic: shadow_variable #
+[SKIP] 3 selftests livepatch test-shadow-vars.sh # SKIP
+selftests: livepatch_test-shadow-vars.sh [SKIP]
+TAP version 13
+13: _ TAP
+1..1
+: _ 1..1
+# selftests membarrier membarrier_test
+membarrier: membarrier_test_ #
+# TAP version 13
+version: 13_ #
+# 1..13
+: _ #
+# ok 1 sys_membarrier available
+1: sys_membarrier_available #
+# ok 2 sys membarrier invalid command test command = -1, flags = 0, errno = 22. Failed as expected
+2: sys_membarrier #
+# ok 3 sys membarrier MEMBARRIER_CMD_QUERY invalid flags test flags = 1, errno = 22. Failed as expected
+3: sys_membarrier #
+# ok 4 sys membarrier MEMBARRIER_CMD_GLOBAL test flags = 0
+4: sys_membarrier #
+# ok 5 sys membarrier MEMBARRIER_CMD_PRIVATE_EXPEDITED not registered failure test flags = 0, errno = 1
+5: sys_membarrier #
+# ok 6 sys membarrier MEMBARRIER_CMD_REGISTER_PRIVATE_EXPEDITED test flags = 0
+6: sys_membarrier #
+# ok 7 sys membarrier MEMBARRIER_CMD_PRIVATE_EXPEDITED test flags = 0
+7: sys_membarrier #
+# Bail out! sys membarrier MEMBARRIER_CMD_GLOBAL_EXPEDITED test flags = 0, errno = 22
+out!: sys_membarrier #
+# # Planned tests != run tests (13 != 7)
+Planned: tests_!= #
+# # Pass 7 Fail 0 Xfail 0 Xpass 0 Skip 0 Error 0
+Pass: 7_Fail #
+[FAIL] 1 selftests membarrier membarrier_test
+selftests: membarrier_membarrier_test [FAIL]
+TAP version 13
+13: _ TAP
+1..3
+: _ 1..3
+# selftests memfd memfd_test
+memfd: memfd_test_ #
+./kselftest/runner.sh line 28  6780 Aborted                 (core dumped) ./$BASENAME_TEST 2>&1
+28: 6780_Aborted ./kselftest/runner.sh
+[FAIL] 1 selftests memfd memfd_test
+selftests: memfd_memfd_test [FAIL]
+# selftests memfd run_fuse_test.sh
+memfd: run_fuse_test.sh_ #
+# opening ./mnt/memfd
+./mnt/memfd: _ #
+# fuse DONE
+DONE: _ #
+[PASS] 2 selftests memfd run_fuse_test.sh
+selftests: memfd_run_fuse_test.sh [PASS]
+# selftests memfd run_hugetlbfs_test.sh
+memfd: run_hugetlbfs_test.sh_ #
+# ./run_hugetlbfs_test.sh line 60  6821 Aborted                 (core dumped) ./memfd_test hugetlbfs
+line: 60_6821 #
+# ./run_fuse_test.sh line 13  6831 Aborted                 (core dumped) ./fuse_test ./mnt/memfd $@
+line: 13_6831 #
+[PASS] 3 selftests memfd run_hugetlbfs_test.sh
+selftests: memfd_run_hugetlbfs_test.sh [PASS]
+TAP version 13
+13: _ TAP
+1..1
+: _ 1..1
+# selftests memory-hotplug mem-on-off-test.sh
+memory-hotplug: mem-on-off-test.sh_ #
+# skip all tests memory hotplug is not supported
+all: tests_memory #
+[SKIP] 1 selftests memory-hotplug mem-on-off-test.sh # SKIP
+selftests: memory-hotplug_mem-on-off-test.sh [SKIP]
+TAP version 13
+13: _ TAP
+1..1
+: _ 1..1
+# selftests mount run_tests.sh
+mount: run_tests.sh_ #
+[PASS] 1 selftests mount run_tests.sh
+selftests: mount_run_tests.sh [PASS]
+TAP version 13
+13: _ TAP
+1..1
+: _ 1..1
+# selftests mqueue mq_open_tests
+mqueue: mq_open_tests_ #
+# Using Default queue path - /test1
+Default: queue_path #
+# 
+: _ #
+# Initial system state
+system: state_ #
+# 	Using queue path		/test1
+queue: path_/test1 #
+# 	RLIMIT_MSGQUEUE(soft)		819200
+819200: _ #
+# 	RLIMIT_MSGQUEUE(hard)		819200
+819200: _ #
+# 	Maximum Message Size		8192
+Message: Size_8192 #
+# 	Maximum Queue Size		10
+Queue: Size_10 #
+# 	Default Message Size		8192
+Message: Size_8192 #
+# 	Default Queue Size		10
+Queue: Size_10 #
+# 
+: _ #
+# Adjusted system state for testing
+system: state_for #
+# 	RLIMIT_MSGQUEUE(soft)		819200
+819200: _ #
+# 	RLIMIT_MSGQUEUE(hard)		819200
+819200: _ #
+# 	Maximum Message Size		8192
+Message: Size_8192 #
+# 	Maximum Queue Size		10
+Queue: Size_10 #
+# 	Default Message Size		8192
+Message: Size_8192 #
+# 	Default Queue Size		10
+Queue: Size_10 #
+# 
+: _ #
+# 
+: _ #
+# Test series 1, behavior when no attr struct passed to mq_open
+series: 1,_behavior #
+# Kernel supports setting defaults separately from maximums		PASS
+supports: setting_defaults #
+# Given sane values, mq_open without an attr struct succeeds		PASS
+sane: values,_mq_open #
+# Kernel properly honors default setting knobs				PASS
+properly: honors_default #
+# Kernel properly limits default values to lesser of default/max		PASS
+properly: limits_default #
+# Kernel properly fails to create queue when defaults would
+properly: fails_to #
+# exceed rlimit								PASS
+rlimit: PASS_ #
+# 
+: _ #
+# 
+: _ #
+# Test series 2, behavior when attr struct is passed to mq_open
+series: 2,_behavior #
+# Queue open in excess of rlimit max when euid = 0 failed		PASS
+open: in_excess #
+# Queue open with mq_maxmsg > limit when euid = 0 succeeded		PASS
+open: with_mq_maxmsg #
+# Queue open with mq_msgsize > limit when euid = 0 succeeded		PASS
+open: with_mq_msgsize #
+# Queue open with total size > 2GB when euid = 0 failed			PASS
+open: with_total #
+# Queue open in excess of rlimit max when euid = 99 failed		PASS
+open: in_excess #
+# Queue open with mq_maxmsg > limit when euid = 99 failed		PASS
+open: with_mq_maxmsg #
+# Queue open with mq_msgsize > limit when euid = 99 failed		PASS
+open: with_mq_msgsize #
+# Queue open with total size > 2GB when euid = 99 failed			PASS
+open: with_total #
+[PASS] 1 selftests mqueue mq_open_tests
+selftests: mqueue_mq_open_tests [PASS]
+TAP version 13
+13: _ TAP
+1..30
+: _ 1..30
+# selftests net reuseport_bpf
+net: reuseport_bpf_ #
+# ---- IPv4 UDP ----
+IPv4: UDP_---- #
+# Testing EBPF mod 10...
+EBPF: mod_10... #
+# Socket 0 0
+0: 0_ #
+# Socket 1 1
+1: 1_ #
+# Socket 2 2
+2: 2_ #
+# Socket 3 3
+3: 3_ #
+# Socket 4 4
+4: 4_ #
+# Socket 5 5
+5: 5_ #
+# Socket 6 6
+6: 6_ #
+# Socket 7 7
+7: 7_ #
+# Socket 8 8
+8: 8_ #
+# Socket 9 9
+9: 9_ #
+# Socket 0 10
+0: 10_ #
+# Socket 1 11
+1: 11_ #
+# Socket 2 12
+2: 12_ #
+# Socket 3 13
+3: 13_ #
+# Socket 4 14
+4: 14_ #
+# Socket 5 15
+5: 15_ #
+# Socket 6 16
+6: 16_ #
+# Socket 7 17
+7: 17_ #
+# Socket 8 18
+8: 18_ #
+# Socket 9 19
+9: 19_ #
+# Reprograming, testing mod 5...
+testing: mod_5... #
+# Socket 0 0
+0: 0_ #
+# Socket 1 1
+1: 1_ #
+# Socket 2 2
+2: 2_ #
+# Socket 3 3
+3: 3_ #
+# Socket 4 4
+4: 4_ #
+# Socket 0 5
+0: 5_ #
+# Socket 1 6
+1: 6_ #
+# Socket 2 7
+2: 7_ #
+# Socket 3 8
+3: 8_ #
+# Socket 4 9
+4: 9_ #
+# Socket 0 10
+0: 10_ #
+# Socket 1 11
+1: 11_ #
+# Socket 2 12
+2: 12_ #
+# Socket 3 13
+3: 13_ #
+# Socket 4 14
+4: 14_ #
+# Socket 0 15
+0: 15_ #
+# Socket 1 16
+1: 16_ #
+# Socket 2 17
+2: 17_ #
+# Socket 3 18
+3: 18_ #
+# Socket 4 19
+4: 19_ #
+# Testing EBPF mod 20...
+EBPF: mod_20... #
+# Socket 0 0
+0: 0_ #
+# Socket 1 1
+1: 1_ #
+# Socket 2 2
+2: 2_ #
+# Socket 3 3
+3: 3_ #
+# Socket 4 4
+4: 4_ #
+# Socket 5 5
+5: 5_ #
+# Socket 6 6
+6: 6_ #
+# Socket 7 7
+7: 7_ #
+# Socket 8 8
+8: 8_ #
+# Socket 9 9
+9: 9_ #
+# Socket 10 10
+10: 10_ #
+# Socket 11 11
+11: 11_ #
+# Socket 12 12
+12: 12_ #
+# Socket 13 13
+13: 13_ #
+# Socket 14 14
+14: 14_ #
+# Socket 15 15
+15: 15_ #
+# Socket 16 16
+16: 16_ #
+# Socket 17 17
+17: 17_ #
+# Socket 18 18
+18: 18_ #
+# Socket 19 19
+19: 19_ #
+# Socket 0 20
+0: 20_ #
+# Socket 1 21
+1: 21_ #
+# Socket 2 22
+2: 22_ #
+# Socket 3 23
+3: 23_ #
+# Socket 4 24
+4: 24_ #
+# Socket 5 25
+5: 25_ #
+# Socket 6 26
+6: 26_ #
+# Socket 7 27
+7: 27_ #
+# Socket 8 28
+8: 28_ #
+# Socket 9 29
+9: 29_ #
+# Socket 10 30
+10: 30_ #
+# Socket 11 31
+11: 31_ #
+# Socket 12 32
+12: 32_ #
+# Socket 13 33
+13: 33_ #
+# Socket 14 34
+14: 34_ #
+# Socket 15 35
+15: 35_ #
+# Socket 16 36
+16: 36_ #
+# Socket 17 37
+17: 37_ #
+# Socket 18 38
+18: 38_ #
+# Socket 19 39
+19: 39_ #
+# Reprograming, testing mod 10...
+testing: mod_10... #
+# Socket 0 0
+0: 0_ #
+# Socket 1 1
+1: 1_ #
+# Socket 2 2
+2: 2_ #
+# Socket 3 3
+3: 3_ #
+# Socket 4 4
+4: 4_ #
+# Socket 5 5
+5: 5_ #
+# Socket 6 6
+6: 6_ #
+# Socket 7 7
+7: 7_ #
+# Socket 8 8
+8: 8_ #
+# Socket 9 9
+9: 9_ #
+# Socket 0 10
+0: 10_ #
+# Socket 1 11
+1: 11_ #
+# Socket 2 12
+2: 12_ #
+# Socket 3 13
+3: 13_ #
+# Socket 4 14
+4: 14_ #
+# Socket 5 15
+5: 15_ #
+# Socket 6 16
+6: 16_ #
+# Socket 7 17
+7: 17_ #
+# Socket 8 18
+8: 18_ #
+# Socket 9 19
+9: 19_ #
+# Socket 0 20
+0: 20_ #
+# Socket 1 21
+1: 21_ #
+# Socket 2 22
+2: 22_ #
+# Socket 3 23
+3: 23_ #
+# Socket 4 24
+4: 24_ #
+# Socket 5 25
+5: 25_ #
+# Socket 6 26
+6: 26_ #
+# Socket 7 27
+7: 27_ #
+# Socket 8 28
+8: 28_ #
+# Socket 9 29
+9: 29_ #
+# Socket 0 30
+0: 30_ #
+# Socket 1 31
+1: 31_ #
+# Socket 2 32
+2: 32_ #
+# Socket 3 33
+3: 33_ #
+# Socket 4 34
+4: 34_ #
+# Socket 5 35
+5: 35_ #
+# Socket 6 36
+6: 36_ #
+# Socket 7 37
+7: 37_ #
+# Socket 8 38
+8: 38_ #
+# Socket 9 39
+9: 39_ #
+# Testing CBPF mod 10...
+CBPF: mod_10... #
+# Socket 0 0
+0: 0_ #
+# Socket 1 1
+1: 1_ #
+# Socket 2 2
+2: 2_ #
+# Socket 3 3
+3: 3_ #
+# Socket 4 4
+4: 4_ #
+# Socket 5 5
+5: 5_ #
+# Socket 6 6
+6: 6_ #
+# Socket 7 7
+7: 7_ #
+# Socket 8 8
+8: 8_ #
+# Socket 9 9
+9: 9_ #
+# Socket 0 10
+0: 10_ #
+# Socket 1 11
+1: 11_ #
+# Socket 2 12
+2: 12_ #
+# Socket 3 13
+3: 13_ #
+# Socket 4 14
+4: 14_ #
+# Socket 5 15
+5: 15_ #
+# Socket 6 16
+6: 16_ #
+# Socket 7 17
+7: 17_ #
+# Socket 8 18
+8: 18_ #
+# Socket 9 19
+9: 19_ #
+# Reprograming, testing mod 5...
+testing: mod_5... #
+# Socket 0 0
+0: 0_ #
+# Socket 1 1
+1: 1_ #
+# Socket 2 2
+2: 2_ #
+# Socket 3 3
+3: 3_ #
+# Socket 4 4
+4: 4_ #
+# Socket 0 5
+0: 5_ #
+# Socket 1 6
+1: 6_ #
+# Socket 2 7
+2: 7_ #
+# Socket 3 8
+3: 8_ #
+# Socket 4 9
+4: 9_ #
+# Socket 0 10
+0: 10_ #
+# Socket 1 11
+1: 11_ #
+# Socket 2 12
+2: 12_ #
+# Socket 3 13
+3: 13_ #
+# Socket 4 14
+4: 14_ #
+# Socket 0 15
+0: 15_ #
+# Socket 1 16
+1: 16_ #
+# Socket 2 17
+2: 17_ #
+# Socket 3 18
+3: 18_ #
+# Socket 4 19
+4: 19_ #
+# Testing CBPF mod 20...
+CBPF: mod_20... #
+# Socket 0 0
+0: 0_ #
+# Socket 1 1
+1: 1_ #
+# Socket 2 2
+2: 2_ #
+# Socket 3 3
+3: 3_ #
+# Socket 4 4
+4: 4_ #
+# Socket 5 5
+5: 5_ #
+# Socket 6 6
+6: 6_ #
+# Socket 7 7
+7: 7_ #
+# Socket 8 8
+8: 8_ #
+# Socket 9 9
+9: 9_ #
+# Socket 10 10
+10: 10_ #
+# Socket 11 11
+11: 11_ #
+# Socket 12 12
+12: 12_ #
+# Socket 13 13
+13: 13_ #
+# Socket 14 14
+14: 14_ #
+# Socket 15 15
+15: 15_ #
+# Socket 16 16
+16: 16_ #
+# Socket 17 17
+17: 17_ #
+# Socket 18 18
+18: 18_ #
+# Socket 19 19
+19: 19_ #
+# Socket 0 20
+0: 20_ #
+# Socket 1 21
+1: 21_ #
+# Socket 2 22
+2: 22_ #
+# Socket 3 23
+3: 23_ #
+# Socket 4 24
+4: 24_ #
+# Socket 5 25
+5: 25_ #
+# Socket 6 26
+6: 26_ #
+# Socket 7 27
+7: 27_ #
+# Socket 8 28
+8: 28_ #
+# Socket 9 29
+9: 29_ #
+# Socket 10 30
+10: 30_ #
+# Socket 11 31
+11: 31_ #
+# Socket 12 32
+12: 32_ #
+# Socket 13 33
+13: 33_ #
+# Socket 14 34
+14: 34_ #
+# Socket 15 35
+15: 35_ #
+# Socket 16 36
+16: 36_ #
+# Socket 17 37
+17: 37_ #
+# Socket 18 38
+18: 38_ #
+# Socket 19 39
+19: 39_ #
+# Reprograming, testing mod 10...
+testing: mod_10... #
+# Socket 0 0
+0: 0_ #
+# Socket 1 1
+1: 1_ #
+# Socket 2 2
+2: 2_ #
+# Socket 3 3
+3: 3_ #
+# Socket 4 4
+4: 4_ #
+# Socket 5 5
+5: 5_ #
+# Socket 6 6
+6: 6_ #
+# Socket 7 7
+7: 7_ #
+# Socket 8 8
+8: 8_ #
+# Socket 9 9
+9: 9_ #
+# Socket 0 10
+0: 10_ #
+# Socket 1 11
+1: 11_ #
+# Socket 2 12
+2: 12_ #
+# Socket 3 13
+3: 13_ #
+# Socket 4 14
+4: 14_ #
+# Socket 5 15
+5: 15_ #
+# Socket 6 16
+6: 16_ #
+# Socket 7 17
+7: 17_ #
+# Socket 8 18
+8: 18_ #
+# Socket 9 19
+9: 19_ #
+# Socket 0 20
+0: 20_ #
+# Socket 1 21
+1: 21_ #
+# Socket 2 22
+2: 22_ #
+# Socket 3 23
+3: 23_ #
+# Socket 4 24
+4: 24_ #
+# Socket 5 25
+5: 25_ #
+# Socket 6 26
+6: 26_ #
+# Socket 7 27
+7: 27_ #
+# Socket 8 28
+8: 28_ #
+# Socket 9 29
+9: 29_ #
+# Socket 0 30
+0: 30_ #
+# Socket 1 31
+1: 31_ #
+# Socket 2 32
+2: 32_ #
+# Socket 3 33
+3: 33_ #
+# Socket 4 34
+4: 34_ #
+# Socket 5 35
+5: 35_ #
+# Socket 6 36
+6: 36_ #
+# Socket 7 37
+7: 37_ #
+# Socket 8 38
+8: 38_ #
+# Socket 9 39
+9: 39_ #
+# Testing too many filters...
+too: many_filters... #
+# Testing filters on non-SO_REUSEPORT socket...
+filters: on_non-SO_REUSEPORT #
+# ---- IPv6 UDP ----
+IPv6: UDP_---- #
+# Testing EBPF mod 10...
+EBPF: mod_10... #
+# Socket 0 0
+0: 0_ #
+# Socket 1 1
+1: 1_ #
+# Socket 2 2
+2: 2_ #
+# Socket 3 3
+3: 3_ #
+# Socket 4 4
+4: 4_ #
+# Socket 5 5
+5: 5_ #
+# Socket 6 6
+6: 6_ #
+# Socket 7 7
+7: 7_ #
+# Socket 8 8
+8: 8_ #
+# Socket 9 9
+9: 9_ #
+# Socket 0 10
+0: 10_ #
+# Socket 1 11
+1: 11_ #
+# Socket 2 12
+2: 12_ #
+# Socket 3 13
+3: 13_ #
+# Socket 4 14
+4: 14_ #
+# Socket 5 15
+5: 15_ #
+# Socket 6 16
+6: 16_ #
+# Socket 7 17
+7: 17_ #
+# Socket 8 18
+8: 18_ #
+# Socket 9 19
+9: 19_ #
+# Reprograming, testing mod 5...
+testing: mod_5... #
+# Socket 0 0
+0: 0_ #
+# Socket 1 1
+1: 1_ #
+# Socket 2 2
+2: 2_ #
+# Socket 3 3
+3: 3_ #
+# Socket 4 4
+4: 4_ #
+# Socket 0 5
+0: 5_ #
+# Socket 1 6
+1: 6_ #
+# Socket 2 7
+2: 7_ #
+# Socket 3 8
+3: 8_ #
+# Socket 4 9
+4: 9_ #
+# Socket 0 10
+0: 10_ #
+# Socket 1 11
+1: 11_ #
+# Socket 2 12
+2: 12_ #
+# Socket 3 13
+3: 13_ #
+# Socket 4 14
+4: 14_ #
+# Socket 0 15
+0: 15_ #
+# Socket 1 16
+1: 16_ #
+# Socket 2 17
+2: 17_ #
+# Socket 3 18
+3: 18_ #
+# Socket 4 19
+4: 19_ #
+# Testing EBPF mod 20...
+EBPF: mod_20... #
+# Socket 0 0
+0: 0_ #
+# Socket 1 1
+1: 1_ #
+# Socket 2 2
+2: 2_ #
+# Socket 3 3
+3: 3_ #
+# Socket 4 4
+4: 4_ #
+# Socket 5 5
+5: 5_ #
+# Socket 6 6
+6: 6_ #
+# Socket 7 7
+7: 7_ #
+# Socket 8 8
+8: 8_ #
+# Socket 9 9
+9: 9_ #
+# Socket 10 10
+10: 10_ #
+# Socket 11 11
+11: 11_ #
+# Socket 12 12
+12: 12_ #
+# Socket 13 13
+13: 13_ #
+# Socket 14 14
+14: 14_ #
+# Socket 15 15
+15: 15_ #
+# Socket 16 16
+16: 16_ #
+# Socket 17 17
+17: 17_ #
+# Socket 18 18
+18: 18_ #
+# Socket 19 19
+19: 19_ #
+# Socket 0 20
+0: 20_ #
+# Socket 1 21
+1: 21_ #
+# Socket 2 22
+2: 22_ #
+# Socket 3 23
+3: 23_ #
+# Socket 4 24
+4: 24_ #
+# Socket 5 25
+5: 25_ #
+# Socket 6 26
+6: 26_ #
+# Socket 7 27
+7: 27_ #
+# Socket 8 28
+8: 28_ #
+# Socket 9 29
+9: 29_ #
+# Socket 10 30
+10: 30_ #
+# Socket 11 31
+11: 31_ #
+# Socket 12 32
+12: 32_ #
+# Socket 13 33
+13: 33_ #
+# Socket 14 34
+14: 34_ #
+# Socket 15 35
+15: 35_ #
+# Socket 16 36
+16: 36_ #
+# Socket 17 37
+17: 37_ #
+# Socket 18 38
+18: 38_ #
+# Socket 19 39
+19: 39_ #
+# Reprograming, testing mod 10...
+testing: mod_10... #
+# Socket 0 0
+0: 0_ #
+# Socket 1 1
+1: 1_ #
+# Socket 2 2
+2: 2_ #
+# Socket 3 3
+3: 3_ #
+# Socket 4 4
+4: 4_ #
+# Socket 5 5
+5: 5_ #
+# Socket 6 6
+6: 6_ #
+# Socket 7 7
+7: 7_ #
+# Socket 8 8
+8: 8_ #
+# Socket 9 9
+9: 9_ #
+# Socket 0 10
+0: 10_ #
+# Socket 1 11
+1: 11_ #
+# Socket 2 12
+2: 12_ #
+# Socket 3 13
+3: 13_ #
+# Socket 4 14
+4: 14_ #
+# Socket 5 15
+5: 15_ #
+# Socket 6 16
+6: 16_ #
+# Socket 7 17
+7: 17_ #
+# Socket 8 18
+8: 18_ #
+# Socket 9 19
+9: 19_ #
+# Socket 0 20
+0: 20_ #
+# Socket 1 21
+1: 21_ #
+# Socket 2 22
+2: 22_ #
+# Socket 3 23
+3: 23_ #
+# Socket 4 24
+4: 24_ #
+# Socket 5 25
+5: 25_ #
+# Socket 6 26
+6: 26_ #
+# Socket 7 27
+7: 27_ #
+# Socket 8 28
+8: 28_ #
+# Socket 9 29
+9: 29_ #
+# Socket 0 30
+0: 30_ #
+# Socket 1 31
+1: 31_ #
+# Socket 2 32
+2: 32_ #
+# Socket 3 33
+3: 33_ #
+# Socket 4 34
+4: 34_ #
+# Socket 5 35
+5: 35_ #
+# Socket 6 36
+6: 36_ #
+# Socket 7 37
+7: 37_ #
+# Socket 8 38
+8: 38_ #
+# Socket 9 39
+9: 39_ #
+# Testing CBPF mod 10...
+CBPF: mod_10... #
+# Socket 0 0
+0: 0_ #
+# Socket 1 1
+1: 1_ #
+# Socket 2 2
+2: 2_ #
+# Socket 3 3
+3: 3_ #
+# Socket 4 4
+4: 4_ #
+# Socket 5 5
+5: 5_ #
+# Socket 6 6
+6: 6_ #
+# Socket 7 7
+7: 7_ #
+# Socket 8 8
+8: 8_ #
+# Socket 9 9
+9: 9_ #
+# Socket 0 10
+0: 10_ #
+# Socket 1 11
+1: 11_ #
+# Socket 2 12
+2: 12_ #
+# Socket 3 13
+3: 13_ #
+# Socket 4 14
+4: 14_ #
+# Socket 5 15
+5: 15_ #
+# Socket 6 16
+6: 16_ #
+# Socket 7 17
+7: 17_ #
+# Socket 8 18
+8: 18_ #
+# Socket 9 19
+9: 19_ #
+# Reprograming, testing mod 5...
+testing: mod_5... #
+# Socket 0 0
+0: 0_ #
+# Socket 1 1
+1: 1_ #
+# Socket 2 2
+2: 2_ #
+# Socket 3 3
+3: 3_ #
+# Socket 4 4
+4: 4_ #
+# Socket 0 5
+0: 5_ #
+# Socket 1 6
+1: 6_ #
+# Socket 2 7
+2: 7_ #
+# Socket 3 8
+3: 8_ #
+# Socket 4 9
+4: 9_ #
+# Socket 0 10
+0: 10_ #
+# Socket 1 11
+1: 11_ #
+# Socket 2 12
+2: 12_ #
+# Socket 3 13
+3: 13_ #
+# Socket 4 14
+4: 14_ #
+# Socket 0 15
+0: 15_ #
+# Socket 1 16
+1: 16_ #
+# Socket 2 17
+2: 17_ #
+# Socket 3 18
+3: 18_ #
+# Socket 4 19
+4: 19_ #
+# Testing CBPF mod 20...
+CBPF: mod_20... #
+# Socket 0 0
+0: 0_ #
+# Socket 1 1
+1: 1_ #
+# Socket 2 2
+2: 2_ #
+# Socket 3 3
+3: 3_ #
+# Socket 4 4
+4: 4_ #
+# Socket 5 5
+5: 5_ #
+# Socket 6 6
+6: 6_ #
+# Socket 7 7
+7: 7_ #
+# Socket 8 8
+8: 8_ #
+# Socket 9 9
+9: 9_ #
+# Socket 10 10
+10: 10_ #
+# Socket 11 11
+11: 11_ #
+# Socket 12 12
+12: 12_ #
+# Socket 13 13
+13: 13_ #
+# Socket 14 14
+14: 14_ #
+# Socket 15 15
+15: 15_ #
+# Socket 16 16
+16: 16_ #
+# Socket 17 17
+17: 17_ #
+# Socket 18 18
+18: 18_ #
+# Socket 19 19
+19: 19_ #
+# Socket 0 20
+0: 20_ #
+# Socket 1 21
+1: 21_ #
+# Socket 2 22
+2: 22_ #
+# Socket 3 23
+3: 23_ #
+# Socket 4 24
+4: 24_ #
+# Socket 5 25
+5: 25_ #
+# Socket 6 26
+6: 26_ #
+# Socket 7 27
+7: 27_ #
+# Socket 8 28
+8: 28_ #
+# Socket 9 29
+9: 29_ #
+# Socket 10 30
+10: 30_ #
+# Socket 11 31
+11: 31_ #
+# Socket 12 32
+12: 32_ #
+# Socket 13 33
+13: 33_ #
+# Socket 14 34
+14: 34_ #
+# Socket 15 35
+15: 35_ #
+# Socket 16 36
+16: 36_ #
+# Socket 17 37
+17: 37_ #
+# Socket 18 38
+18: 38_ #
+# Socket 19 39
+19: 39_ #
+# Reprograming, testing mod 10...
+testing: mod_10... #
+# Socket 0 0
+0: 0_ #
+# Socket 1 1
+1: 1_ #
+# Socket 2 2
+2: 2_ #
+# Socket 3 3
+3: 3_ #
+# Socket 4 4
+4: 4_ #
+# Socket 5 5
+5: 5_ #
+# Socket 6 6
+6: 6_ #
+# Socket 7 7
+7: 7_ #
+# Socket 8 8
+8: 8_ #
+# Socket 9 9
+9: 9_ #
+# Socket 0 10
+0: 10_ #
+# Socket 1 11
+1: 11_ #
+# Socket 2 12
+2: 12_ #
+# Socket 3 13
+3: 13_ #
+# Socket 4 14
+4: 14_ #
+# Socket 5 15
+5: 15_ #
+# Socket 6 16
+6: 16_ #
+# Socket 7 17
+7: 17_ #
+# Socket 8 18
+8: 18_ #
+# Socket 9 19
+9: 19_ #
+# Socket 0 20
+0: 20_ #
+# Socket 1 21
+1: 21_ #
+# Socket 2 22
+2: 22_ #
+# Socket 3 23
+3: 23_ #
+# Socket 4 24
+4: 24_ #
+# Socket 5 25
+5: 25_ #
+# Socket 6 26
+6: 26_ #
+# Socket 7 27
+7: 27_ #
+# Socket 8 28
+8: 28_ #
+# Socket 9 29
+9: 29_ #
+# Socket 0 30
+0: 30_ #
+# Socket 1 31
+1: 31_ #
+# Socket 2 32
+2: 32_ #
+# Socket 3 33
+3: 33_ #
+# Socket 4 34
+4: 34_ #
+# Socket 5 35
+5: 35_ #
+# Socket 6 36
+6: 36_ #
+# Socket 7 37
+7: 37_ #
+# Socket 8 38
+8: 38_ #
+# Socket 9 39
+9: 39_ #
+# Testing too many filters...
+too: many_filters... #
+# Testing filters on non-SO_REUSEPORT socket...
+filters: on_non-SO_REUSEPORT #
+# ---- IPv6 UDP w/ mapped IPv4 ----
+IPv6: UDP_w/ #
+# Testing EBPF mod 20...
+EBPF: mod_20... #
+# Socket 0 0
+0: 0_ #
+# Socket 1 1
+1: 1_ #
+# Socket 2 2
+2: 2_ #
+# Socket 3 3
+3: 3_ #
+# Socket 4 4
+4: 4_ #
+# Socket 5 5
+5: 5_ #
+# Socket 6 6
+6: 6_ #
+# Socket 7 7
+7: 7_ #
+# Socket 8 8
+8: 8_ #
+# Socket 9 9
+9: 9_ #
+# Socket 10 10
+10: 10_ #
+# Socket 11 11
+11: 11_ #
+# Socket 12 12
+12: 12_ #
+# Socket 13 13
+13: 13_ #
+# Socket 14 14
+14: 14_ #
+# Socket 15 15
+15: 15_ #
+# Socket 16 16
+16: 16_ #
+# Socket 17 17
+17: 17_ #
+# Socket 18 18
+18: 18_ #
+# Socket 19 19
+19: 19_ #
+# Socket 0 20
+0: 20_ #
+# Socket 1 21
+1: 21_ #
+# Socket 2 22
+2: 22_ #
+# Socket 3 23
+3: 23_ #
+# Socket 4 24
+4: 24_ #
+# Socket 5 25
+5: 25_ #
+# Socket 6 26
+6: 26_ #
+# Socket 7 27
+7: 27_ #
+# Socket 8 28
+8: 28_ #
+# Socket 9 29
+9: 29_ #
+# Socket 10 30
+10: 30_ #
+# Socket 11 31
+11: 31_ #
+# Socket 12 32
+12: 32_ #
+# Socket 13 33
+13: 33_ #
+# Socket 14 34
+14: 34_ #
+# Socket 15 35
+15: 35_ #
+# Socket 16 36
+16: 36_ #
+# Socket 17 37
+17: 37_ #
+# Socket 18 38
+18: 38_ #
+# Socket 19 39
+19: 39_ #
+# Reprograming, testing mod 10...
+testing: mod_10... #
+# Socket 0 0
+0: 0_ #
+# Socket 1 1
+1: 1_ #
+# Socket 2 2
+2: 2_ #
+# Socket 3 3
+3: 3_ #
+# Socket 4 4
+4: 4_ #
+# Socket 5 5
+5: 5_ #
+# Socket 6 6
+6: 6_ #
+# Socket 7 7
+7: 7_ #
+# Socket 8 8
+8: 8_ #
+# Socket 9 9
+9: 9_ #
+# Socket 0 10
+0: 10_ #
+# Socket 1 11
+1: 11_ #
+# Socket 2 12
+2: 12_ #
+# Socket 3 13
+3: 13_ #
+# Socket 4 14
+4: 14_ #
+# Socket 5 15
+5: 15_ #
+# Socket 6 16
+6: 16_ #
+# Socket 7 17
+7: 17_ #
+# Socket 8 18
+8: 18_ #
+# Socket 9 19
+9: 19_ #
+# Socket 0 20
+0: 20_ #
+# Socket 1 21
+1: 21_ #
+# Socket 2 22
+2: 22_ #
+# Socket 3 23
+3: 23_ #
+# Socket 4 24
+4: 24_ #
+# Socket 5 25
+5: 25_ #
+# Socket 6 26
+6: 26_ #
+# Socket 7 27
+7: 27_ #
+# Socket 8 28
+8: 28_ #
+# Socket 9 29
+9: 29_ #
+# Socket 0 30
+0: 30_ #
+# Socket 1 31
+1: 31_ #
+# Socket 2 32
+2: 32_ #
+# Socket 3 33
+3: 33_ #
+# Socket 4 34
+4: 34_ #
+# Socket 5 35
+5: 35_ #
+# Socket 6 36
+6: 36_ #
+# Socket 7 37
+7: 37_ #
+# Socket 8 38
+8: 38_ #
+# Socket 9 39
+9: 39_ #
+# Testing EBPF mod 10...
+EBPF: mod_10... #
+# Socket 0 0
+0: 0_ #
+# Socket 1 1
+1: 1_ #
+# Socket 2 2
+2: 2_ #
+# Socket 3 3
+3: 3_ #
+# Socket 4 4
+4: 4_ #
+# Socket 5 5
+5: 5_ #
+# Socket 6 6
+6: 6_ #
+# Socket 7 7
+7: 7_ #
+# Socket 8 8
+8: 8_ #
+# Socket 9 9
+9: 9_ #
+# Socket 0 10
+0: 10_ #
+# Socket 1 11
+1: 11_ #
+# Socket 2 12
+2: 12_ #
+# Socket 3 13
+3: 13_ #
+# Socket 4 14
+4: 14_ #
+# Socket 5 15
+5: 15_ #
+# Socket 6 16
+6: 16_ #
+# Socket 7 17
+7: 17_ #
+# Socket 8 18
+8: 18_ #
+# Socket 9 19
+9: 19_ #
+# Reprograming, testing mod 5...
+testing: mod_5... #
+# Socket 0 0
+0: 0_ #
+# Socket 1 1
+1: 1_ #
+# Socket 2 2
+2: 2_ #
+# Socket 3 3
+3: 3_ #
+# Socket 4 4
+4: 4_ #
+# Socket 0 5
+0: 5_ #
+# Socket 1 6
+1: 6_ #
+# Socket 2 7
+2: 7_ #
+# Socket 3 8
+3: 8_ #
+# Socket 4 9
+4: 9_ #
+# Socket 0 10
+0: 10_ #
+# Socket 1 11
+1: 11_ #
+# Socket 2 12
+2: 12_ #
+# Socket 3 13
+3: 13_ #
+# Socket 4 14
+4: 14_ #
+# Socket 0 15
+0: 15_ #
+# Socket 1 16
+1: 16_ #
+# Socket 2 17
+2: 17_ #
+# Socket 3 18
+3: 18_ #
+# Socket 4 19
+4: 19_ #
+# Testing CBPF mod 10...
+CBPF: mod_10... #
+# Socket 0 0
+0: 0_ #
+# Socket 1 1
+1: 1_ #
+# Socket 2 2
+2: 2_ #
+# Socket 3 3
+3: 3_ #
+# Socket 4 4
+4: 4_ #
+# Socket 5 5
+5: 5_ #
+# Socket 6 6
+6: 6_ #
+# Socket 7 7
+7: 7_ #
+# Socket 8 8
+8: 8_ #
+# Socket 9 9
+9: 9_ #
+# Socket 0 10
+0: 10_ #
+# Socket 1 11
+1: 11_ #
+# Socket 2 12
+2: 12_ #
+# Socket 3 13
+3: 13_ #
+# Socket 4 14
+4: 14_ #
+# Socket 5 15
+5: 15_ #
+# Socket 6 16
+6: 16_ #
+# Socket 7 17
+7: 17_ #
+# Socket 8 18
+8: 18_ #
+# Socket 9 19
+9: 19_ #
+# Reprograming, testing mod 5...
+testing: mod_5... #
+# Socket 0 0
+0: 0_ #
+# Socket 1 1
+1: 1_ #
+# Socket 2 2
+2: 2_ #
+# Socket 3 3
+3: 3_ #
+# Socket 4 4
+4: 4_ #
+# Socket 0 5
+0: 5_ #
+# Socket 1 6
+1: 6_ #
+# Socket 2 7
+2: 7_ #
+# Socket 3 8
+3: 8_ #
+# Socket 4 9
+4: 9_ #
+# Socket 0 10
+0: 10_ #
+# Socket 1 11
+1: 11_ #
+# Socket 2 12
+2: 12_ #
+# Socket 3 13
+3: 13_ #
+# Socket 4 14
+4: 14_ #
+# Socket 0 15
+0: 15_ #
+# Socket 1 16
+1: 16_ #
+# Socket 2 17
+2: 17_ #
+# Socket 3 18
+3: 18_ #
+# Socket 4 19
+4: 19_ #
+# Testing CBPF mod 20...
+CBPF: mod_20... #
+# Socket 0 0
+0: 0_ #
+# Socket 1 1
+1: 1_ #
+# Socket 2 2
+2: 2_ #
+# Socket 3 3
+3: 3_ #
+# Socket 4 4
+4: 4_ #
+# Socket 5 5
+5: 5_ #
+# Socket 6 6
+6: 6_ #
+# Socket 7 7
+7: 7_ #
+# Socket 8 8
+8: 8_ #
+# Socket 9 9
+9: 9_ #
+# Socket 10 10
+10: 10_ #
+# Socket 11 11
+11: 11_ #
+# Socket 12 12
+12: 12_ #
+# Socket 13 13
+13: 13_ #
+# Socket 14 14
+14: 14_ #
+# Socket 15 15
+15: 15_ #
+# Socket 16 16
+16: 16_ #
+# Socket 17 17
+17: 17_ #
+# Socket 18 18
+18: 18_ #
+# Socket 19 19
+19: 19_ #
+# Socket 0 20
+0: 20_ #
+# Socket 1 21
+1: 21_ #
+# Socket 2 22
+2: 22_ #
+# Socket 3 23
+3: 23_ #
+# Socket 4 24
+4: 24_ #
+# Socket 5 25
+5: 25_ #
+# Socket 6 26
+6: 26_ #
+# Socket 7 27
+7: 27_ #
+# Socket 8 28
+8: 28_ #
+# Socket 9 29
+9: 29_ #
+# Socket 10 30
+10: 30_ #
+# Socket 11 31
+11: 31_ #
+# Socket 12 32
+12: 32_ #
+# Socket 13 33
+13: 33_ #
+# Socket 14 34
+14: 34_ #
+# Socket 15 35
+15: 35_ #
+# Socket 16 36
+16: 36_ #
+# Socket 17 37
+17: 37_ #
+# Socket 18 38
+18: 38_ #
+# Socket 19 39
+19: 39_ #
+# Reprograming, testing mod 10...
+testing: mod_10... #
+# Socket 0 0
+0: 0_ #
+# Socket 1 1
+1: 1_ #
+# Socket 2 2
+2: 2_ #
+# Socket 3 3
+3: 3_ #
+# Socket 4 4
+4: 4_ #
+# Socket 5 5
+5: 5_ #
+# Socket 6 6
+6: 6_ #
+# Socket 7 7
+7: 7_ #
+# Socket 8 8
+8: 8_ #
+# Socket 9 9
+9: 9_ #
+# Socket 0 10
+0: 10_ #
+# Socket 1 11
+1: 11_ #
+# Socket 2 12
+2: 12_ #
+# Socket 3 13
+3: 13_ #
+# Socket 4 14
+4: 14_ #
+# Socket 5 15
+5: 15_ #
+# Socket 6 16
+6: 16_ #
+# Socket 7 17
+7: 17_ #
+# Socket 8 18
+8: 18_ #
+# Socket 9 19
+9: 19_ #
+# Socket 0 20
+0: 20_ #
+# Socket 1 21
+1: 21_ #
+# Socket 2 22
+2: 22_ #
+# Socket 3 23
+3: 23_ #
+# Socket 4 24
+4: 24_ #
+# Socket 5 25
+5: 25_ #
+# Socket 6 26
+6: 26_ #
+# Socket 7 27
+7: 27_ #
+# Socket 8 28
+8: 28_ #
+# Socket 9 29
+9: 29_ #
+# Socket 0 30
+0: 30_ #
+# Socket 1 31
+1: 31_ #
+# Socket 2 32
+2: 32_ #
+# Socket 3 33
+3: 33_ #
+# Socket 4 34
+4: 34_ #
+# Socket 5 35
+5: 35_ #
+# Socket 6 36
+6: 36_ #
+# Socket 7 37
+7: 37_ #
+# Socket 8 38
+8: 38_ #
+# Socket 9 39
+9: 39_ #
+# ---- IPv4 TCP ----
+IPv4: TCP_---- #
+# Testing EBPF mod 10...
+EBPF: mod_10... #
+# Socket 0 0
+0: 0_ #
+# Socket 1 1
+1: 1_ #
+# Socket 2 2
+2: 2_ #
+# Socket 3 3
+3: 3_ #
+# Socket 4 4
+4: 4_ #
+# Socket 5 5
+5: 5_ #
+# Socket 6 6
+6: 6_ #
+# Socket 7 7
+7: 7_ #
+# Socket 8 8
+8: 8_ #
+# Socket 9 9
+9: 9_ #
+# Socket 0 10
+0: 10_ #
+# Socket 1 11
+1: 11_ #
+# Socket 2 12
+2: 12_ #
+# Socket 3 13
+3: 13_ #
+# Socket 4 14
+4: 14_ #
+# Socket 5 15
+5: 15_ #
+# Socket 6 16
+6: 16_ #
+# Socket 7 17
+7: 17_ #
+# Socket 8 18
+8: 18_ #
+# Socket 9 19
+9: 19_ #
+# Reprograming, testing mod 5...
+testing: mod_5... #
+# Socket 0 0
+0: 0_ #
+# Socket 1 1
+1: 1_ #
+# Socket 2 2
+2: 2_ #
+# Socket 3 3
+3: 3_ #
+# Socket 4 4
+4: 4_ #
+# Socket 0 5
+0: 5_ #
+# Socket 1 6
+1: 6_ #
+# Socket 2 7
+2: 7_ #
+# Socket 3 8
+3: 8_ #
+# Socket 4 9
+4: 9_ #
+# Socket 0 10
+0: 10_ #
+# Socket 1 11
+1: 11_ #
+# Socket 2 12
+2: 12_ #
+# Socket 3 13
+3: 13_ #
+# Socket 4 14
+4: 14_ #
+# Socket 0 15
+0: 15_ #
+# Socket 1 16
+1: 16_ #
+# Socket 2 17
+2: 17_ #
+# Socket 3 18
+3: 18_ #
+# Socket 4 19
+4: 19_ #
+# Testing CBPF mod 10...
+CBPF: mod_10... #
+# Socket 0 0
+0: 0_ #
+# Socket 1 1
+1: 1_ #
+# Socket 2 2
+2: 2_ #
+# Socket 3 3
+3: 3_ #
+# Socket 4 4
+4: 4_ #
+# Socket 5 5
+5: 5_ #
+# Socket 6 6
+6: 6_ #
+# Socket 7 7
+7: 7_ #
+# Socket 8 8
+8: 8_ #
+# Socket 9 9
+9: 9_ #
+# Socket 0 10
+0: 10_ #
+# Socket 1 11
+1: 11_ #
+# Socket 2 12
+2: 12_ #
+# Socket 3 13
+3: 13_ #
+# Socket 4 14
+4: 14_ #
+# Socket 5 15
+5: 15_ #
+# Socket 6 16
+6: 16_ #
+# Socket 7 17
+7: 17_ #
+# Socket 8 18
+8: 18_ #
+# Socket 9 19
+9: 19_ #
+# Reprograming, testing mod 5...
+testing: mod_5... #
+# Socket 0 0
+0: 0_ #
+# Socket 1 1
+1: 1_ #
+# Socket 2 2
+2: 2_ #
+# Socket 3 3
+3: 3_ #
+# Socket 4 4
+4: 4_ #
+# Socket 0 5
+0: 5_ #
+# Socket 1 6
+1: 6_ #
+# Socket 2 7
+2: 7_ #
+# Socket 3 8
+3: 8_ #
+# Socket 4 9
+4: 9_ #
+# Socket 0 10
+0: 10_ #
+# Socket 1 11
+1: 11_ #
+# Socket 2 12
+2: 12_ #
+# Socket 3 13
+3: 13_ #
+# Socket 4 14
+4: 14_ #
+# Socket 0 15
+0: 15_ #
+# Socket 1 16
+1: 16_ #
+# Socket 2 17
+2: 17_ #
+# Socket 3 18
+3: 18_ #
+# Socket 4 19
+4: 19_ #
+# Testing too many filters...
+too: many_filters... #
+# Testing filters on non-SO_REUSEPORT socket...
+filters: on_non-SO_REUSEPORT #
+# ---- IPv6 TCP ----
+IPv6: TCP_---- #
+# Testing EBPF mod 10...
+EBPF: mod_10... #
+# Socket 0 0
+0: 0_ #
+# Socket 1 1
+1: 1_ #
+# Socket 2 2
+2: 2_ #
+# Socket 3 3
+3: 3_ #
+# Socket 4 4
+4: 4_ #
+# Socket 5 5
+5: 5_ #
+# Socket 6 6
+6: 6_ #
+# Socket 7 7
+7: 7_ #
+# Socket 8 8
+8: 8_ #
+# Socket 9 9
+9: 9_ #
+# Socket 0 10
+0: 10_ #
+# Socket 1 11
+1: 11_ #
+# Socket 2 12
+2: 12_ #
+# Socket 3 13
+3: 13_ #
+# Socket 4 14
+4: 14_ #
+# Socket 5 15
+5: 15_ #
+# Socket 6 16
+6: 16_ #
+# Socket 7 17
+7: 17_ #
+# Socket 8 18
+8: 18_ #
+# Socket 9 19
+9: 19_ #
+# Reprograming, testing mod 5...
+testing: mod_5... #
+# Socket 0 0
+0: 0_ #
+# Socket 1 1
+1: 1_ #
+# Socket 2 2
+2: 2_ #
+# Socket 3 3
+3: 3_ #
+# Socket 4 4
+4: 4_ #
+# Socket 0 5
+0: 5_ #
+# Socket 1 6
+1: 6_ #
+# Socket 2 7
+2: 7_ #
+# Socket 3 8
+3: 8_ #
+# Socket 4 9
+4: 9_ #
+# Socket 0 10
+0: 10_ #
+# Socket 1 11
+1: 11_ #
+# Socket 2 12
+2: 12_ #
+# Socket 3 13
+3: 13_ #
+# Socket 4 14
+4: 14_ #
+# Socket 0 15
+0: 15_ #
+# Socket 1 16
+1: 16_ #
+# Socket 2 17
+2: 17_ #
+# Socket 3 18
+3: 18_ #
+# Socket 4 19
+4: 19_ #
+# Testing CBPF mod 10...
+CBPF: mod_10... #
+# Socket 0 0
+0: 0_ #
+# Socket 1 1
+1: 1_ #
+# Socket 2 2
+2: 2_ #
+# Socket 3 3
+3: 3_ #
+# Socket 4 4
+4: 4_ #
+# Socket 5 5
+5: 5_ #
+# Socket 6 6
+6: 6_ #
+# Socket 7 7
+7: 7_ #
+# Socket 8 8
+8: 8_ #
+# Socket 9 9
+9: 9_ #
+# Socket 0 10
+0: 10_ #
+# Socket 1 11
+1: 11_ #
+# Socket 2 12
+2: 12_ #
+# Socket 3 13
+3: 13_ #
+# Socket 4 14
+4: 14_ #
+# Socket 5 15
+5: 15_ #
+# Socket 6 16
+6: 16_ #
+# Socket 7 17
+7: 17_ #
+# Socket 8 18
+8: 18_ #
+# Socket 9 19
+9: 19_ #
+# Reprograming, testing mod 5...
+testing: mod_5... #
+# Socket 0 0
+0: 0_ #
+# Socket 1 1
+1: 1_ #
+# Socket 2 2
+2: 2_ #
+# Socket 3 3
+3: 3_ #
+# Socket 4 4
+4: 4_ #
+# Socket 0 5
+0: 5_ #
+# Socket 1 6
+1: 6_ #
+# Socket 2 7
+2: 7_ #
+# Socket 3 8
+3: 8_ #
+# Socket 4 9
+4: 9_ #
+# Socket 0 10
+0: 10_ #
+# Socket 1 11
+1: 11_ #
+# Socket 2 12
+2: 12_ #
+# Socket 3 13
+3: 13_ #
+# Socket 4 14
+4: 14_ #
+# Socket 0 15
+0: 15_ #
+# Socket 1 16
+1: 16_ #
+# Socket 2 17
+2: 17_ #
+# Socket 3 18
+3: 18_ #
+# Socket 4 19
+4: 19_ #
+# Testing too many filters...
+too: many_filters... #
+# Testing filters on non-SO_REUSEPORT socket...
+filters: on_non-SO_REUSEPORT #
+# ---- IPv6 TCP w/ mapped IPv4 ----
+IPv6: TCP_w/ #
+# Testing EBPF mod 10...
+EBPF: mod_10... #
+# Socket 0 0
+0: 0_ #
+# Socket 1 1
+1: 1_ #
+# Socket 2 2
+2: 2_ #
+# Socket 3 3
+3: 3_ #
+# Socket 4 4
+4: 4_ #
+# Socket 5 5
+5: 5_ #
+# Socket 6 6
+6: 6_ #
+# Socket 7 7
+7: 7_ #
+# Socket 8 8
+8: 8_ #
+# Socket 9 9
+9: 9_ #
+# Socket 0 10
+0: 10_ #
+# Socket 1 11
+1: 11_ #
+# Socket 2 12
+2: 12_ #
+# Socket 3 13
+3: 13_ #
+# Socket 4 14
+4: 14_ #
+# Socket 5 15
+5: 15_ #
+# Socket 6 16
+6: 16_ #
+# Socket 7 17
+7: 17_ #
+# Socket 8 18
+8: 18_ #
+# Socket 9 19
+9: 19_ #
+# Reprograming, testing mod 5...
+testing: mod_5... #
+# Socket 0 0
+0: 0_ #
+# Socket 1 1
+1: 1_ #
+# Socket 2 2
+2: 2_ #
+# Socket 3 3
+3: 3_ #
+# Socket 4 4
+4: 4_ #
+# Socket 0 5
+0: 5_ #
+# Socket 1 6
+1: 6_ #
+# Socket 2 7
+2: 7_ #
+# Socket 3 8
+3: 8_ #
+# Socket 4 9
+4: 9_ #
+# Socket 0 10
+0: 10_ #
+# Socket 1 11
+1: 11_ #
+# Socket 2 12
+2: 12_ #
+# Socket 3 13
+3: 13_ #
+# Socket 4 14
+4: 14_ #
+# Socket 0 15
+0: 15_ #
+# Socket 1 16
+1: 16_ #
+# Socket 2 17
+2: 17_ #
+# Socket 3 18
+3: 18_ #
+# Socket 4 19
+4: 19_ #
+# Testing CBPF mod 10...
+CBPF: mod_10... #
+# Socket 0 0
+0: 0_ #
+# Socket 1 1
+1: 1_ #
+# Socket 2 2
+2: 2_ #
+# Socket 3 3
+3: 3_ #
+# Socket 4 4
+4: 4_ #
+# Socket 5 5
+5: 5_ #
+# Socket 6 6
+6: 6_ #
+# Socket 7 7
+7: 7_ #
+# Socket 8 8
+8: 8_ #
+# Socket 9 9
+9: 9_ #
+# Socket 0 10
+0: 10_ #
+# Socket 1 11
+1: 11_ #
+# Socket 2 12
+2: 12_ #
+# Socket 3 13
+3: 13_ #
+# Socket 4 14
+4: 14_ #
+# Socket 5 15
+5: 15_ #
+# Socket 6 16
+6: 16_ #
+# Socket 7 17
+7: 17_ #
+# Socket 8 18
+8: 18_ #
+# Socket 9 19
+9: 19_ #
+# Reprograming, testing mod 5...
+testing: mod_5... #
+# Socket 0 0
+0: 0_ #
+# Socket 1 1
+1: 1_ #
+# Socket 2 2
+2: 2_ #
+# Socket 3 3
+3: 3_ #
+# Socket 4 4
+4: 4_ #
+# Socket 0 5
+0: 5_ #
+# Socket 1 6
+1: 6_ #
+# Socket 2 7
+2: 7_ #
+# Socket 3 8
+3: 8_ #
+# Socket 4 9
+4: 9_ #
+# Socket 0 10
+0: 10_ #
+# Socket 1 11
+1: 11_ #
+# Socket 2 12
+2: 12_ #
+# Socket 3 13
+3: 13_ #
+# Socket 4 14
+4: 14_ #
+# Socket 0 15
+0: 15_ #
+# Socket 1 16
+1: 16_ #
+# Socket 2 17
+2: 17_ #
+# Socket 3 18
+3: 18_ #
+# Socket 4 19
+4: 19_ #
+# Testing filter add without bind...
+filter: add_without #
+# SUCCESS
+: _ #
+[PASS] 1 selftests net reuseport_bpf
+selftests: net_reuseport_bpf [PASS]
+# selftests net reuseport_bpf_cpu
+net: reuseport_bpf_cpu_ #
+# ---- IPv4 UDP ----
+IPv4: UDP_---- #
+# send cpu 0, receive socket 0
+cpu: 0,_receive #
+# send cpu 1, receive socket 1
+cpu: 1,_receive #
+# send cpu 2, receive socket 2
+cpu: 2,_receive #
+# send cpu 3, receive socket 3
+cpu: 3,_receive #
+# send cpu 4, receive socket 4
+cpu: 4,_receive #
+# send cpu 5, receive socket 5
+cpu: 5,_receive #
+# send cpu 5, receive socket 5
+cpu: 5,_receive #
+# send cpu 4, receive socket 4
+cpu: 4,_receive #
+# send cpu 3, receive socket 3
+cpu: 3,_receive #
+# send cpu 2, receive socket 2
+cpu: 2,_receive #
+# send cpu 1, receive socket 1
+cpu: 1,_receive #
+# send cpu 0, receive socket 0
+cpu: 0,_receive #
+# send cpu 0, receive socket 0
+cpu: 0,_receive #
+# send cpu 2, receive socket 2
+cpu: 2,_receive #
+# send cpu 4, receive socket 4
+cpu: 4,_receive #
+# send cpu 1, receive socket 1
+cpu: 1,_receive #
+# send cpu 3, receive socket 3
+cpu: 3,_receive #
+# send cpu 5, receive socket 5
+cpu: 5,_receive #
+# ---- IPv6 UDP ----
+IPv6: UDP_---- #
+# send cpu 0, receive socket 0
+cpu: 0,_receive #
+# send cpu 1, receive socket 1
+cpu: 1,_receive #
+# send cpu 2, receive socket 2
+cpu: 2,_receive #
+# send cpu 3, receive socket 3
+cpu: 3,_receive #
+# send cpu 4, receive socket 4
+cpu: 4,_receive #
+# send cpu 5, receive socket 5
+cpu: 5,_receive #
+# send cpu 5, receive socket 5
+cpu: 5,_receive #
+# send cpu 4, receive socket 4
+cpu: 4,_receive #
+# send cpu 3, receive socket 3
+cpu: 3,_receive #
+# send cpu 2, receive socket 2
+cpu: 2,_receive #
+# send cpu 1, receive socket 1
+cpu: 1,_receive #
+# send cpu 0, receive socket 0
+cpu: 0,_receive #
+# send cpu 0, receive socket 0
+cpu: 0,_receive #
+# send cpu 2, receive socket 2
+cpu: 2,_receive #
+# send cpu 4, receive socket 4
+cpu: 4,_receive #
+# send cpu 1, receive socket 1
+cpu: 1,_receive #
+# send cpu 3, receive socket 3
+cpu: 3,_receive #
+# send cpu 5, receive socket 5
+cpu: 5,_receive #
+# ---- IPv4 TCP ----
+IPv4: TCP_---- #
+# send cpu 0, receive socket 0
+cpu: 0,_receive #
+# send cpu 1, receive socket 1
+cpu: 1,_receive #
+# send cpu 2, receive socket 2
+cpu: 2,_receive #
+# send cpu 3, receive socket 3
+cpu: 3,_receive #
+# send cpu 4, receive socket 4
+cpu: 4,_receive #
+# send cpu 5, receive socket 5
+cpu: 5,_receive #
+# send cpu 5, receive socket 5
+cpu: 5,_receive #
+# send cpu 4, receive socket 4
+cpu: 4,_receive #
+# send cpu 3, receive socket 3
+cpu: 3,_receive #
+# send cpu 2, receive socket 2
+cpu: 2,_receive #
+# send cpu 1, receive socket 1
+cpu: 1,_receive #
+# send cpu 0, receive socket 0
+cpu: 0,_receive #
+# send cpu 0, receive socket 0
+cpu: 0,_receive #
+# send cpu 2, receive socket 2
+cpu: 2,_receive #
+# send cpu 4, receive socket 4
+cpu: 4,_receive #
+# send cpu 1, receive socket 1
+cpu: 1,_receive #
+# send cpu 3, receive socket 3
+cpu: 3,_receive #
+# send cpu 5, receive socket 5
+cpu: 5,_receive #
+# ---- IPv6 TCP ----
+IPv6: TCP_---- #
+# send cpu 0, receive socket 0
+cpu: 0,_receive #
+# send cpu 1, receive socket 1
+cpu: 1,_receive #
+# send cpu 2, receive socket 2
+cpu: 2,_receive #
+# send cpu 3, receive socket 3
+cpu: 3,_receive #
+# send cpu 4, receive socket 4
+cpu: 4,_receive #
+# send cpu 5, receive socket 5
+cpu: 5,_receive #
+# send cpu 5, receive socket 5
+cpu: 5,_receive #
+# send cpu 4, receive socket 4
+cpu: 4,_receive #
+# send cpu 3, receive socket 3
+cpu: 3,_receive #
+# send cpu 2, receive socket 2
+cpu: 2,_receive #
+# send cpu 1, receive socket 1
+cpu: 1,_receive #
+# send cpu 0, receive socket 0
+cpu: 0,_receive #
+# send cpu 0, receive socket 0
+cpu: 0,_receive #
+# send cpu 2, receive socket 2
+cpu: 2,_receive #
+# send cpu 4, receive socket 4
+cpu: 4,_receive #
+# send cpu 1, receive socket 1
+cpu: 1,_receive #
+# send cpu 3, receive socket 3
+cpu: 3,_receive #
+# send cpu 5, receive socket 5
+cpu: 5,_receive #
+# SUCCESS
+: _ #
+[PASS] 2 selftests net reuseport_bpf_cpu
+selftests: net_reuseport_bpf_cpu [PASS]
+# selftests net reuseport_bpf_numa
+net: reuseport_bpf_numa_ #
+# ---- IPv4 UDP ----
+IPv4: UDP_---- #
+# send node 0, receive socket 0
+node: 0,_receive #
+# send node 0, receive socket 0
+node: 0,_receive #
+# ---- IPv6 UDP ----
+IPv6: UDP_---- #
+# send node 0, receive socket 0
+node: 0,_receive #
+# send node 0, receive socket 0
+node: 0,_receive #
+# ---- IPv4 TCP ----
+IPv4: TCP_---- #
+# send node 0, receive socket 0
+node: 0,_receive #
+# send node 0, receive socket 0
+node: 0,_receive #
+# ---- IPv6 TCP ----
+IPv6: TCP_---- #
+# send node 0, receive socket 0
+node: 0,_receive #
+# send node 0, receive socket 0
+node: 0,_receive #
+# SUCCESS
+: _ #
+[PASS] 3 selftests net reuseport_bpf_numa
+selftests: net_reuseport_bpf_numa [PASS]
+# selftests net reuseport_dualstack
+net: reuseport_dualstack_ #
+# ---- UDP IPv4 created before IPv6 ----
+UDP: IPv4_created #
+# ---- UDP IPv6 created before IPv4 ----
+UDP: IPv6_created #
+# ---- UDP IPv4 created before IPv6 (large) ----
+UDP: IPv4_created #
+# ---- UDP IPv6 created before IPv4 (large) ----
+UDP: IPv6_created #
+# ---- TCP IPv4 created before IPv6 ----
+TCP: IPv4_created #
+# ---- TCP IPv6 created before IPv4 ----
+TCP: IPv6_created #
+# SUCCESS
+: _ #
+[PASS] 4 selftests net reuseport_dualstack
+selftests: net_reuseport_dualstack [PASS]
+# selftests net reuseaddr_conflict
+net: reuseaddr_conflict_ #
+# Opening 127.0.0.19999
+127.0.0.19999: _ #
+# Opening INADDR_ANY9999
+INADDR_ANY9999: _ #
+# bind Address already in use
+Address: already_in #
+# Opening in6addr_any9999
+in6addr_any9999: _ #
+# Opening INADDR_ANY9999
+INADDR_ANY9999: _ #
+# bind Address already in use
+Address: already_in #
+# Opening INADDR_ANY9999 after closing ipv6 socket
+INADDR_ANY9999: after_closing #
+# bind Address already in use
+Address: already_in #
+# Successok 5 selftests net reuseaddr_conflict
+5: selftests_net #
+# selftests net tls
+net: tls_ #
+# [==========] Running 41 tests from 3 test cases.
+Running: 41_tests #
+# [ RUN      ] tls_basic.base_base
+RUN: ]_tls_basic.base_base #
+# [       OK ] tls_basic.base_base
+OK: ]_tls_basic.base_base #
+# [ RUN      ] tls.sendfile
+RUN: ]_tls.sendfile #
+# [       OK ] tls.sendfile
+OK: ]_tls.sendfile #
+# [ RUN      ] tls.send_then_sendfile
+RUN: ]_tls.send_then_sendfile #
+# [       OK ] tls.send_then_sendfile
+OK: ]_tls.send_then_sendfile #
+# [ RUN      ] tls.recv_max
+RUN: ]_tls.recv_max #
+# [       OK ] tls.recv_max
+OK: ]_tls.recv_max #
+# [ RUN      ] tls.recv_small
+RUN: ]_tls.recv_small #
+# [       OK ] tls.recv_small
+OK: ]_tls.recv_small #
+# [ RUN      ] tls.msg_more
+RUN: ]_tls.msg_more #
+# [       OK ] tls.msg_more
+OK: ]_tls.msg_more #
+# [ RUN      ] tls.msg_more_unsent
+RUN: ]_tls.msg_more_unsent #
+# [       OK ] tls.msg_more_unsent
+OK: ]_tls.msg_more_unsent #
+# [ RUN      ] tls.sendmsg_single
+RUN: ]_tls.sendmsg_single #
+# [       OK ] tls.sendmsg_single
+OK: ]_tls.sendmsg_single #
+# [ RUN      ] tls.sendmsg_large
+RUN: ]_tls.sendmsg_large #
+# [       OK ] tls.sendmsg_large
+OK: ]_tls.sendmsg_large #
+# [ RUN      ] tls.sendmsg_multiple
+RUN: ]_tls.sendmsg_multiple #
+# [       OK ] tls.sendmsg_multiple
+OK: ]_tls.sendmsg_multiple #
+# [ RUN      ] tls.sendmsg_multiple_stress
+RUN: ]_tls.sendmsg_multiple_stress #
+# [       OK ] tls.sendmsg_multiple_stress
+OK: ]_tls.sendmsg_multiple_stress #
+# [ RUN      ] tls.splice_from_pipe
+RUN: ]_tls.splice_from_pipe #
+# [       OK ] tls.splice_from_pipe
+OK: ]_tls.splice_from_pipe #
+# [ RUN      ] tls.splice_from_pipe2
+RUN: ]_tls.splice_from_pipe2 #
+# [       OK ] tls.splice_from_pipe2
+OK: ]_tls.splice_from_pipe2 #
+# [ RUN      ] tls.send_and_splice
+RUN: ]_tls.send_and_splice #
+# [       OK ] tls.send_and_splice
+OK: ]_tls.send_and_splice #
+# [ RUN      ] tls.splice_to_pipe
+RUN: ]_tls.splice_to_pipe #
+# [       OK ] tls.splice_to_pipe
+OK: ]_tls.splice_to_pipe #
+# [ RUN      ] tls.recvmsg_single
+RUN: ]_tls.recvmsg_single #
+# [       OK ] tls.recvmsg_single
+OK: ]_tls.recvmsg_single #
+# [ RUN      ] tls.recvmsg_single_max
+RUN: ]_tls.recvmsg_single_max #
+# [       OK ] tls.recvmsg_single_max
+OK: ]_tls.recvmsg_single_max #
+# [ RUN      ] tls.recvmsg_multiple
+RUN: ]_tls.recvmsg_multiple #
+# [       OK ] tls.recvmsg_multiple
+OK: ]_tls.recvmsg_multiple #
+# [ RUN      ] tls.single_send_multiple_recv
+RUN: ]_tls.single_send_multiple_recv #
+# [       OK ] tls.single_send_multiple_recv
+OK: ]_tls.single_send_multiple_recv #
+# [ RUN      ] tls.multiple_send_single_recv
+RUN: ]_tls.multiple_send_single_recv #
+# [       OK ] tls.multiple_send_single_recv
+OK: ]_tls.multiple_send_single_recv #
+# [ RUN      ] tls.single_send_multiple_recv_non_align
+RUN: ]_tls.single_send_multiple_recv_non_align #
+# [       OK ] tls.single_send_multiple_recv_non_align
+OK: ]_tls.single_send_multiple_recv_non_align #
+# [ RUN      ] tls.recv_partial
+RUN: ]_tls.recv_partial #
+# [       OK ] tls.recv_partial
+OK: ]_tls.recv_partial #
+# [ RUN      ] tls.recv_nonblock
+RUN: ]_tls.recv_nonblock #
+# [       OK ] tls.recv_nonblock
+OK: ]_tls.recv_nonblock #
+# [ RUN      ] tls.recv_peek
+RUN: ]_tls.recv_peek #
+# [       OK ] tls.recv_peek
+OK: ]_tls.recv_peek #
+# [ RUN      ] tls.recv_peek_multiple
+RUN: ]_tls.recv_peek_multiple #
+# [       OK ] tls.recv_peek_multiple
+OK: ]_tls.recv_peek_multiple #
+# [ RUN      ] tls.recv_peek_multiple_records
+RUN: ]_tls.recv_peek_multiple_records #
+# [       OK ] tls.recv_peek_multiple_records
+OK: ]_tls.recv_peek_multiple_records #
+# [ RUN      ] tls.recv_peek_large_buf_mult_recs
+RUN: ]_tls.recv_peek_large_buf_mult_recs #
+# [       OK ] tls.recv_peek_large_buf_mult_recs
+OK: ]_tls.recv_peek_large_buf_mult_recs #
+# [ RUN      ] tls.recv_lowat
+RUN: ]_tls.recv_lowat #
+# [       OK ] tls.recv_lowat
+OK: ]_tls.recv_lowat #
+# [ RUN      ] tls.bidir
+RUN: ]_tls.bidir #
+# [       OK ] tls.bidir
+OK: ]_tls.bidir #
+# [ RUN      ] tls.pollin
+RUN: ]_tls.pollin #
+# [       OK ] tls.pollin
+OK: ]_tls.pollin #
+# [ RUN      ] tls.poll_wait
+RUN: ]_tls.poll_wait #
+# [       OK ] tls.poll_wait
+OK: ]_tls.poll_wait #
+# [ RUN      ] tls.poll_wait_split
+RUN: ]_tls.poll_wait_split #
+# [       OK ] tls.poll_wait_split
+OK: ]_tls.poll_wait_split #
+# [ RUN      ] tls.blocking
+RUN: ]_tls.blocking #
+# [       OK ] tls.blocking
+OK: ]_tls.blocking #
+# [ RUN      ] tls.nonblocking
+RUN: ]_tls.nonblocking #
+# [       OK ] tls.nonblocking
+OK: ]_tls.nonblocking #
+# [ RUN      ] tls.control_msg
+RUN: ]_tls.control_msg #
+# [       OK ] tls.control_msg
+OK: ]_tls.control_msg #
+# [ RUN      ] tls.shutdown
+RUN: ]_tls.shutdown #
+# [       OK ] tls.shutdown
+OK: ]_tls.shutdown #
+# [ RUN      ] tls.shutdown_unsent
+RUN: ]_tls.shutdown_unsent #
+# [       OK ] tls.shutdown_unsent
+OK: ]_tls.shutdown_unsent #
+# [ RUN      ] tls.shutdown_reuse
+RUN: ]_tls.shutdown_reuse #
+# [       OK ] tls.shutdown_reuse
+OK: ]_tls.shutdown_reuse #
+# [ RUN      ] global.non_established
+RUN: ]_global.non_established #
+# [       OK ] global.non_established
+OK: ]_global.non_established #
+# [ RUN      ] global.keysizes
+RUN: ]_global.keysizes #
+# [       OK ] global.keysizes
+OK: ]_global.keysizes #
+# [ RUN      ] global.tls12
+RUN: ]_global.tls12 #
+# [       OK ] global.tls12
+OK: ]_global.tls12 #
+# [==========] 41 / 41 tests passed.
+41: /_41 #
+# [  PASSED  ]
+PASSED: ]_ #
+[PASS] 6 selftests net tls
+selftests: net_tls [PASS]
+# selftests net run_netsocktests
+net: run_netsocktests_ #
+# --------------------
+: _ #
+# running socket test
+socket: test_ #
+# --------------------
+: _ #
+# [PASS]
+: _ #
+[PASS] 7 selftests net run_netsocktests
+selftests: net_run_netsocktests [PASS]
+# selftests net run_afpackettests
+net: run_afpackettests_ #
+# --------------------
+: _ #
+# running psock_fanout test
+psock_fanout: test_ #
+# --------------------
+: _ #
+# test control single socket
+control: single_socket #
+# test control multiple sockets
+control: multiple_sockets #
+# test unique ids
+unique: ids_ #
+# 
+: _ #
+# test datapath 0x0 ports 8000,8002
+datapath: 0x0_ports #
+# info count=0,0, expect=0,0
+count=0,0,: expect=0,0_ #
+# info count=0,20, expect=15,5
+count=0,20,: expect=15,5_ #
+# warning incorrect queue lengths
+incorrect: queue_lengths #
+# info count=0,20, expect=20,5
+count=0,20,: expect=20,5_ #
+# warning incorrect queue lengths
+incorrect: queue_lengths #
+# info trying alternate ports (20)
+trying: alternate_ports #
+# 
+: _ #
+# test datapath 0x0 ports 8000,8003
+datapath: 0x0_ports #
+# info count=0,0, expect=0,0
+count=0,0,: expect=0,0_ #
+# info count=5,15, expect=15,5
+count=5,15,: expect=15,5_ #
+# info count=5,20, expect=20,5
+count=5,20,: expect=20,5_ #
+# 
+: _ #
+# test datapath 0x1000 ports 8000,8003
+datapath: 0x1000_ports #
+# info count=0,0, expect=0,0
+count=0,0,: expect=0,0_ #
+# info count=5,15, expect=15,5
+count=5,15,: expect=15,5_ #
+# info count=15,20, expect=20,15
+count=15,20,: expect=20,15_ #
+# 
+: _ #
+# test datapath 0x1 ports 8000,8003
+datapath: 0x1_ports #
+# info count=0,0, expect=0,0
+count=0,0,: expect=0,0_ #
+# info count=10,10, expect=10,10
+count=10,10,: expect=10,10_ #
+# info count=17,18, expect=18,17
+count=17,18,: expect=18,17_ #
+# 
+: _ #
+# test datapath 0x3 ports 8000,8003
+datapath: 0x3_ports #
+# info count=0,0, expect=0,0
+count=0,0,: expect=0,0_ #
+# info count=15,5, expect=15,5
+count=15,5,: expect=15,5_ #
+[  316.392132] test_bpf: #0 TAX jited:0 309 303 307 PASS
+[  316.406649] test_bpf: #1 TXA jited:0 1456 173 168 PASS
+[  316.430009] test_bpf: #2 ADD_SUB_MUL_K jited:0 243 PASS
+[  316.437816] test_bpf: #3 DIV_MOD_KX jited:0 555 PASS
+[  316.448474] test_bpf: #4 AND_OR_LSH_K jited:0 239 232 PASS
+[  316.458856] test_bpf: #5 LD_IMM_0 jited:0 166 PASS
+[  316.465501] test_bpf: #6 LD_IND jited:0 192 186 191 PASS
+[  316.476710] test_bpf: #7 LD_ABS jited:0 155 162 155 PASS
+[  316.486947] test_bpf: #8 LD_ABS_LL jited:0 229 260 PASS
+[  316.497244] test_bpf: #9 LD_IND_LL jited:0 251 243 248 PASS
+[  316.510433] test_bpf: #10 LD_ABS_NET jited:0 221 249 PASS
+[  316.520692] test_bpf: #11 LD_IND_NET jited:0 240 241 245 PASS
+[  316.533885] test_bpf: #12 LD_PKTTYPE jited:0 322 319 PASS
+[  316.545861] test_bpf: #13 LD_MARK jited:0 139 131 PASS
+[  316.553856] test_bpf: #14 LD_RXHASH jited:0 139 131 PASS
+[  316.562025] test_bpf: #15 LD_QUEUE jited:0 139 131 PASS
+[  316.570105] test_bpf: #16 LD_PROTOCOL jited:0 316 313 PASS
+[  316.582055] test_bpf: #17 LD_VLAN_TAG jited:0 156 148 PASS
+[  316.590748] test_bpf: #18 LD_VLAN_TAG_PRESENT jited:0 168 168 PASS
+[  316.600557] test_bpf: #19 LD_IFINDEX jited:0 180 188 PASS
+[  316.609799] test_bpf: #20 LD_HATYPE jited:0 187 180 PASS
+[  316.618940] test_bpf: #21 LD_CPU jited:0 342 351 PASS
+[  316.631097] test_bpf: #22 LD_NLATTR jited:0 266 311 PASS
+[  316.642348] test_bpf: #23 LD_NLATTR_NEST jited:0 1053 1393 PASS
+[  316.672903] test_bpf: #24 LD_PAYLOAD_OFF jited:0 1322 1735 PASS
+[  316.709552] test_bpf: #25 LD_ANC_XOR jited:0 167 160 PASS
+[  316.718384] test_bpf: #26 SPILL_FILL jited:0 369 365 365 PASS
+[  316.735298] test_bpf: #27 JEQ jited:0 177 203 200 PASS
+[  316.746416] test_bpf: #28 JGT jited:0 188 193 204 PASS
+[  316.757638] test_bpf: #29 JGE (jt 0), test 1 jited:0 185 193 198 PASS
+[  316.770041] test_bpf: #30 JGE (jt 0), test 2 jited:0 201 193 204 PASS
+[  316.782653] test_bpf: #31 JGE jited:0 235 284 300 PASS
+[  316.796171] test_bpf: #32 JSET jited:0 319 367 519 PASS
+[  316.813643] test_bpf: #33 tcpdump port 22 jited:0 162 481 560 PASS
+[  316.832046] test_bpf: #34 tcpdump complex jited:0 155 454 1109 PASS
+[  316.855696] test_bpf: #35 RET_A jited:0 127 127 PASS
+[  316.863397] test_bpf: #36 INT: ADD trivial jited:0 177 PASS
+[  316.870950] test_bpf: #37 INT: MUL_X jited:0 163 PASS
+[  316.877806] test_bpf: #38 INT: MUL_X2 jited:0 190 PASS
+[  316.884973] test_bpf: #39 INT: MUL32_X jited:0 182 PASS
+[  316.892217] test_bpf: #40 INT: ADD 64-bit jited:0 2882 PASS
+[  316.926749] test_bpf: #41 INT: ADD 32-bit jited:0 2628 PASS
+[  316.958731] test_bpf: #42 INT: SUB jited:0 2533 PASS
+[  316.989160] test_bpf: #43 INT: XOR jited:0 1076 PASS
+[  317.005052] test_bpf: #44 INT: MUL jited:0 1214 PASS
+[  317.022298] test_bpf: #45 MOV REG64 jited:0 656 PASS
+[  317.033955] test_bpf: #46 MOV REG32 jited:0 626 PASS
+[  317.045315] test_bpf: #47 LD IMM64 jited:0 639 PASS
+[  317.056715] test_bpf: #48 INT: ALU MIX jited:0 257 PASS
+[  317.064643] test_bpf: #49 INT: shifts by register jited:0 544 PASS
+[  317.076390] test_bpf: #50 INT: DIV + ABS jited:0 223 263 PASS
+[  317.087155] test_bpf: #51 INT: DIV by zero jited:0 131 122 PASS
+[  317.095799] test_bpf: #52 check: missing ret PASS
+[  317.100626] test_bpf: #53 check: div_k_0 PASS
+[  317.105125] test_bpf: #54 check: unknown insn PASS
+[  317.110041] test_bpf: #55 check: out of range spill/fill PASS
+[  317.115923] test_bpf: #56 JUMPS + HOLES jited:0 379 PASS
+[  317.125209] test_bpf: #57 check: RET X PASS
+[  317.129527] test_bpf: #58 check: LDX + RET X PASS
+[  317.134373] test_bpf: #59 M[]: alt STX + LDX jited:0 1639 PASS
+[  317.156808] test_bpf: #60 M[]: full STX + full LDX jited:0 1326 PASS
+[  317.176567] test_bpf: #61 check: SKF_AD_MAX PASS
+[  317.181320] test_bpf: #62 LD [SKF_AD_OFF-1] jited:0 148 PASS
+[  317.188661] test_bpf: #63 load 64-bit immediate jited:0 278 PASS
+[  317.197578] test_bpf: #64 nmap reduced jited:0 732 PASS
+[  317.210256] test_bpf: #65 ALU_MOV_X: dst = 2 jited:0 97 PASS
+[  317.217013] test_bpf: #66 ALU_MOV_X: dst = 4294967295 jited:0 90 PASS
+[  317.224508] test_bpf: #67 ALU64_MOV_X: dst = 2 jited:0 88 PASS
+[  317.231377] test_bpf: #68 ALU64_MOV_X: dst = 4294967295 jited:0 88 PASS
+[  317.239037] test_bpf: #69 ALU_MOV_K: dst = 2 jited:0 70 PASS
+[  317.245552] test_bpf: #70 ALU_MOV_K: dst = 4294967295 jited:0 70 PASS
+[  317.252850] test_bpf: #71 ALU_MOV_K: 0x0000ffffffff0000 = 0x00000000ffffffff jited:0 146 PASS
+[  317.263020] test_bpf: #72 ALU64_MOV_K: dst = 2 jited:0 70 PASS
+[  317.269729] test_bpf: #73 ALU64_MOV_K: dst = 2147483647 jited:0 70 PASS
+[  317.277189] test_bpf: #74 ALU64_OR_K: dst = 0x0 jited:0 146 PASS
+[  317.284823] test_bpf: #75 ALU64_MOV_K: dst = -1 jited:0 146 PASS
+[  317.292443] test_bpf: #76 ALU_ADD_X: 1 + 2 = 3 jited:0 105 PASS
+[  317.299582] test_bpf: #77 ALU_ADD_X: 1 + 4294967294 = 4294967295 jited:0 105 PASS
+[  317.308254] test_bpf: #78 ALU_ADD_X: 2 + 4294967294 = 0 jited:0 147 PASS
+[  317.316590] test_bpf: #79 ALU64_ADD_X: 1 + 2 = 3 jited:0 105 PASS
+[  317.323882] test_bpf: #80 ALU64_ADD_X: 1 + 4294967294 = 4294967295 jited:0 105 PASS
+[  317.332743] test_bpf: #81 ALU64_ADD_X: 2 + 4294967294 = 4294967296 jited:0 166 PASS
+[  317.342199] test_bpf: #82 ALU_ADD_K: 1 + 2 = 3 jited:0 96 PASS
+[  317.349116] test_bpf: #83 ALU_ADD_K: 3 + 0 = 3 jited:0 88 PASS
+[  317.356004] test_bpf: #84 ALU_ADD_K: 1 + 4294967294 = 4294967295 jited:0 88 PASS
+[  317.364422] test_bpf: #85 ALU_ADD_K: 4294967294 + 2 = 0 jited:0 130 PASS
+[  317.372582] test_bpf: #86 ALU_ADD_K: 0 + (-1) = 0x00000000ffffffff jited:0 148 PASS
+[  317.381863] test_bpf: #87 ALU_ADD_K: 0 + 0xffff = 0xffff jited:0 156 PASS
+[  317.390326] test_bpf: #88 ALU_ADD_K: 0 + 0x7fffffff = 0x7fffffff jited:0 156 PASS
+[  317.399471] test_bpf: #89 ALU_ADD_K: 0 + 0x80000000 = 0x80000000 jited:0 148 PASS
+[  317.408575] test_bpf: #90 ALU_ADD_K: 0 + 0x80008000 = 0x80008000 jited:0 148 PASS
+[  317.417700] test_bpf: #91 ALU64_ADD_K: 1 + 2 = 3 jited:0 88 PASS
+[  317.424749] test_bpf: #92 ALU64_ADD_K: 3 + 0 = 3 jited:0 88 PASS
+[  317.431808] test_bpf: #93 ALU64_ADD_K: 1 + 2147483646 = 2147483647 jited:0 88 PASS
+[  317.440404] test_bpf: #94 ALU64_ADD_K: 4294967294 + 2 = 4294967296 jited:0 147 PASS
+[  317.449689] test_bpf: #95 ALU64_ADD_K: 2147483646 + -2147483647 = -1 jited:0 88 PASS
+[  317.458464] test_bpf: #96 ALU64_ADD_K: 1 + 0 = 1 jited:0 154 PASS
+[  317.466230] test_bpf: #97 ALU64_ADD_K: 0 + (-1) = 0xffffffffffffffff jited:0 156 PASS
+[  317.475725] test_bpf: #98 ALU64_ADD_K: 0 + 0xffff = 0xffff jited:0 148 PASS
+[  317.484325] test_bpf: #99 ALU64_ADD_K: 0 + 0x7fffffff = 0x7fffffff jited:0 148 PASS
+[  317.493602] test_bpf: #100 ALU64_ADD_K: 0 + 0x80000000 = 0xffffffff80000000 jited:0 157 PASS
+[  317.503717] test_bpf: #101 ALU_ADD_K: 0 + 0x80008000 = 0xffffffff80008000 jited:0 148 PASS
+[  317.513616] test_bpf: #102 ALU_SUB_X: 3 - 1 = 2 jited:0 105 PASS
+[  317.520855] test_bpf: #103 ALU_SUB_X: 4294967295 - 4294967294 = 1 jited:0 105 PASS
+[  317.529652] test_bpf: #104 ALU64_SUB_X: 3 - 1 = 2 jited:0 105 PASS
+[  317.537030] test_bpf: #105 ALU64_SUB_X: 4294967295 - 4294967294 = 1 jited:0 105 PASS
+[  317.545973] test_bpf: #106 ALU_SUB_K: 3 - 1 = 2 jited:0 88 PASS
+[  317.552976] test_bpf: #107 ALU_SUB_K: 3 - 0 = 3 jited:0 88 PASS
+[  317.559938] test_bpf: #108 ALU_SUB_K: 4294967295 - 4294967294 = 1 jited:0 88 PASS
+[  317.568463] test_bpf: #109 ALU64_SUB_K: 3 - 1 = 2 jited:0 88 PASS
+[  317.575591] test_bpf: #110 ALU64_SUB_K: 3 - 0 = 3 jited:0 88 PASS
+[  317.582741] test_bpf: #111 ALU64_SUB_K: 4294967294 - 4294967295 = -1 jited:0 94 PASS
+[  317.591541] test_bpf: #112 ALU64_ADD_K: 2147483646 - 2147483647 = -1 jited:0 88 PASS
+[  317.600307] test_bpf: #113 ALU_MUL_X: 2 * 3 = 6 jited:0 107 PASS
+[  317.607557] test_bpf: #114 ALU_MUL_X: 2 * 0x7FFFFFF8 = 0xFFFFFFF0 jited:0 107 PASS
+[  317.616334] test_bpf: #115 ALU_MUL_X: -1 * -1 = 1 jited:0 107 PASS
+[  317.623753] test_bpf: #116 ALU64_MUL_X: 2 * 3 = 6 jited:0 108 PASS
+[  317.631175] test_bpf: #117 ALU64_MUL_X: 1 * 2147483647 = 2147483647 jited:0 108 PASS
+[  317.640163] test_bpf: #118 ALU_MUL_K: 2 * 3 = 6 jited:0 91 PASS
+[  317.647148] test_bpf: #119 ALU_MUL_K: 3 * 1 = 3 jited:0 91 PASS
+[  317.654150] test_bpf: #120 ALU_MUL_K: 2 * 0x7FFFFFF8 = 0xFFFFFFF0 jited:0 97 PASS
+[  317.662715] test_bpf: #121 ALU_MUL_K: 1 * (-1) = 0x00000000ffffffff jited:0 158 PASS
+[  317.672145] test_bpf: #122 ALU64_MUL_K: 2 * 3 = 6 jited:0 92 PASS
+[  317.679326] test_bpf: #123 ALU64_MUL_K: 3 * 1 = 3 jited:0 92 PASS
+[  317.686499] test_bpf: #124 ALU64_MUL_K: 1 * 2147483647 = 2147483647 jited:0 98 PASS
+[  317.695248] test_bpf: #125 ALU64_MUL_K: 1 * -2147483647 = -2147483647 jited:0 92 PASS
+[  317.704155] test_bpf: #126 ALU64_MUL_K: 1 * (-1) = 0xffffffffffffffff jited:0 152 PASS
+[  317.713734] test_bpf: #127 ALU_DIV_X: 6 / 2 = 3 jited:0 142 PASS
+[  317.721292] test_bpf: #128 ALU_DIV_X: 4294967295 / 4294967295 = 1 jited:0 133 PASS
+[  317.730350] test_bpf: #129 ALU64_DIV_X: 6 / 2 = 3 jited:0 118 PASS
+[  317.737844] test_bpf: #130 ALU64_DIV_X: 2147483647 / 2147483647 = 1 jited:0 120 PASS
+[  317.746913] test_bpf: #131 ALU64_DIV_X: 0xffffffffffffffff / (-1) = 0x0000000000000001 jited:0 181 PASS
+[  317.758212] test_bpf: #132 ALU_DIV_K: 6 / 2 = 3 jited:0 113 PASS
+[  317.765474] test_bpf: #133 ALU_DIV_K: 3 / 1 = 3 jited:0 103 PASS
+[  317.772686] test_bpf: #134 ALU_DIV_K: 4294967295 / 4294967295 = 1 jited:0 103 PASS
+[  317.781456] test_bpf: #135 ALU_DIV_K: 0xffffffffffffffff / (-1) = 0x1 jited:0 181 PASS
+[  317.791291] test_bpf: #136 ALU64_DIV_K: 6 / 2 = 3 jited:0 91 PASS
+[  317.798462] test_bpf: #137 ALU64_DIV_K: 3 / 1 = 3 jited:0 97 PASS
+[  317.805659] test_bpf: #138 ALU64_DIV_K: 2147483647 / 2147483647 = 1 jited:0 91 PASS
+[  317.814361] test_bpf: #139 ALU64_DIV_K: 0xffffffffffffffff / (-1) = 0x0000000000000001 jited:0 159 PASS
+[  317.825433] test_bpf: #140 ALU_MOD_X: 3 % 2 = 1 jited:0 136 PASS
+[  317.832974] test_bpf: #141 ALU_MOD_X: 4294967295 % 4294967293 = 2 jited:0 136 PASS
+[  317.842046] test_bpf: #142 ALU64_MOD_X: 3 % 2 = 1 jited:0 134 PASS
+[  317.849686] test_bpf: #143 ALU64_MOD_X: 2147483647 % 2147483645 = 2 jited:0 133 PASS
+[  317.858872] test_bpf: #144 ALU_MOD_K: 3 % 2 = 1 jited:0 113 PASS
+[  317.866133] test_bpf: #145 ALU_MOD_K: 3 % 1 = 0 jited:0 PASS
+[  317.871940] test_bpf: #146 ALU_MOD_K: 4294967295 % 4294967293 = 2 jited:0 106 PASS
+[  317.880707] test_bpf: #147 ALU64_MOD_K: 3 % 2 = 1 jited:0 105 PASS
+[  317.888107] test_bpf: #148 ALU64_MOD_K: 3 % 1 = 0 jited:0 PASS
+[  317.894080] test_bpf: #149 ALU64_MOD_K: 2147483647 % 2147483645 = 2 jited:0 113 PASS
+[  317.903056] test_bpf: #150 ALU_AND_X: 3 & 2 = 2 jited:0 105 PASS
+[  317.910268] test_bpf: #151 ALU_AND_X: 0xffffffff & 0xffffffff = 0xffffffff jited:0 113 PASS
+[  317.919851] test_bpf: #152 ALU64_AND_X: 3 & 2 = 2 jited:0 105 PASS
+[  317.927242] test_bpf: #153 ALU64_AND_X: 0xffffffff & 0xffffffff = 0xffffffff jited:0 105 PASS
+[  317.936947] test_bpf: #154 ALU_AND_K: 3 & 2 = 2 jited:0 88 PASS
+[  317.943920] test_bpf: #155 ALU_AND_K: 0xffffffff & 0xffffffff = 0xffffffff jited:0 88 PASS
+[  317.953202] test_bpf: #156 ALU64_AND_K: 3 & 2 = 2 jited:0 88 PASS
+[  317.960353] test_bpf: #157 ALU64_AND_K: 0xffffffff & 0xffffffff = 0xffffffff jited:0 88 PASS
+[  317.969807] test_bpf: #158 ALU64_AND_K: 0x0000ffffffff0000 & 0x0 = 0x0000ffff00000000 jited:0 157 PASS
+[  317.980777] test_bpf: #159 ALU64_AND_K: 0x0000ffffffff0000 & -1 = 0x0000ffffffffffff jited:0 148 PASS
+[  317.991626] test_bpf: #160 ALU64_AND_K: 0xffffffffffffffff & -1 = 0xffffffffffffffff jited:0 148 PASS
+[  318.002457] test_bpf: #161 ALU_OR_X: 1 | 2 = 3 jited:0 117 PASS
+[  318.009674] test_bpf: #162 ALU_OR_X: 0x0 | 0xffffffff = 0xffffffff jited:0 105 PASS
+[  318.018531] test_bpf: #163 ALU64_OR_X: 1 | 2 = 3 jited:0 111 PASS
+[  318.025851] test_bpf: #164 ALU64_OR_X: 0 | 0xffffffff = 0xffffffff jited:0 105 PASS
+[  318.034730] test_bpf: #165 ALU_OR_K: 1 | 2 = 3 jited:0 98 PASS
+[  318.041669] test_bpf: #166 ALU_OR_K: 0 & 0xffffffff = 0xffffffff jited:0 88 PASS
+[  318.050093] test_bpf: #167 ALU64_OR_K: 1 | 2 = 3 jited:0 95 PASS
+[  318.057175] test_bpf: #168 ALU64_OR_K: 0 & 0xffffffff = 0xffffffff jited:0 88 PASS
+[  318.065787] test_bpf: #169 ALU64_OR_K: 0x0000ffffffff0000 | 0x0 = 0x0000ffff00000000 jited:0 155 PASS
+[  318.076665] test_bpf: #170 ALU64_OR_K: 0x0000ffffffff0000 | -1 = 0xffffffffffffffff jited:0 148 PASS
+[  318.087412] test_bpf: #171 ALU64_OR_K: 0x000000000000000 | -1 = 0xffffffffffffffff jited:0 148 PASS
+[  318.098087] test_bpf: #172 ALU_XOR_X: 5 ^ 6 = 3 jited:0 111 PASS
+[  318.105327] test_bpf: #173 ALU_XOR_X: 0x1 ^ 0xffffffff = 0xfffffffe jited:0 105 PASS
+[  318.114269] test_bpf: #174 ALU64_XOR_X: 5 ^ 6 = 3 jited:0 111 PASS
+[  318.121698] test_bpf: #175 ALU64_XOR_X: 1 ^ 0xffffffff = 0xfffffffe jited:0 105 PASS
+[  318.130624] test_bpf: #176 ALU_XOR_K: 5 ^ 6 = 3 jited:0 179 PASS
+[  318.138542] test_bpf: #177 ALU_XOR_K: 1 ^ 0xffffffff = 0xfffffffe jited:0 96 PASS
+[  318.147132] test_bpf: #178 ALU64_XOR_K: 5 ^ 6 = 3 jited:0 88 PASS
+[  318.154279] test_bpf: #179 ALU64_XOR_K: 1 & 0xffffffff = 0xfffffffe jited:0 95 PASS
+[  318.163000] test_bpf: #180 ALU64_XOR_K: 0x0000ffffffff0000 ^ 0x0 = 0x0000ffffffff0000 jited:0 148 PASS
+[  318.173959] test_bpf: #181 ALU64_XOR_K: 0x0000ffffffff0000 ^ -1 = 0xffff00000000ffff jited:0 157 PASS
+[  318.184847] test_bpf: #182 ALU64_XOR_K: 0x000000000000000 ^ -1 = 0xffffffffffffffff jited:0 148 PASS
+[  318.195612] test_bpf: #183 ALU_LSH_X: 1 << 1 = 2 jited:0 107 PASS
+[  318.202934] test_bpf: #184 ALU_LSH_X: 1 << 31 = 0x80000000 jited:0 112 PASS
+[  318.211125] test_bpf: #185 ALU64_LSH_X: 1 << 1 = 2 jited:0 107 PASS
+[  318.218618] test_bpf: #186 ALU64_LSH_X: 1 << 31 = 0x80000000 jited:0 113 PASS
+[  318.227002] test_bpf: #187 ALU_LSH_K: 1 << 1 = 2 jited:0 91 PASS
+[  318.234121] test_bpf: #188 ALU_LSH_K: 1 << 31 = 0x80000000 jited:0 98 PASS
+[  318.242097] test_bpf: #189 ALU64_LSH_K: 1 << 1 = 2 jited:0 98 PASS
+[  318.249379] test_bpf: #190 ALU64_LSH_K: 1 << 31 = 0x80000000 jited:0 91 PASS
+[  318.257487] test_bpf: #191 ALU_RSH_X: 2 >> 1 = 1 jited:0 107 PASS
+[  318.264805] test_bpf: #192 ALU_RSH_X: 0x80000000 >> 31 = 1 jited:0 107 PASS
+[  318.273002] test_bpf: #193 ALU64_RSH_X: 2 >> 1 = 1 jited:0 107 PASS
+[  318.280496] test_bpf: #194 ALU64_RSH_X: 0x80000000 >> 31 = 1 jited:0 107 PASS
+[  318.288864] test_bpf: #195 ALU_RSH_K: 2 >> 1 = 1 jited:0 91 PASS
+[  318.295966] test_bpf: #196 ALU_RSH_K: 0x80000000 >> 31 = 1 jited:0 91 PASS
+[  318.303915] test_bpf: #197 ALU64_RSH_K: 2 >> 1 = 1 jited:0 91 PASS
+[  318.311168] test_bpf: #198 ALU64_RSH_K: 0x80000000 >> 31 = 1 jited:0 91 PASS
+[  318.319279] test_bpf: #199 ALU_ARSH_X: 0xff00ff0000000000 >> 40 = 0xffffffffffff00ff jited:0 107 PASS
+[  318.329694] test_bpf: #200 ALU_ARSH_K: 0xff00ff0000000000 >> 40 = 0xffffffffffff00ff jited:0 91 PASS
+[  318.339882] test_bpf: #201 ALU_NEG: -(3) = -3 jited:0 87 PASS
+[  318.346658] test_bpf: #202 ALU_NEG: -(-3) = 3 jited:0 94 PASS
+[  318.353467] test_bpf: #203 ALU64_NEG: -(3) = -3 jited:0 88 PASS
+[  318.360430] test_bpf: #204 ALU64_NEG: -(-3) = 3 jited:0 88 PASS
+[  318.367417] test_bpf: #205 ALU_END_FROM_BE 16: 0x0123456789abcdef -> 0xcdef jited:0 100 PASS
+[  318.376986] test_bpf: #206 ALU_END_FROM_BE 32: 0x0123456789abcdef -> 0x89abcdef jited:0 153 PASS
+[  318.387461] test_bpf: #207 ALU_END_FROM_BE 64: 0x0123456789abcdef -> 0x89abcdef jited:0 95 PASS
+[  318.397245] test_bpf: #208 ALU_END_FROM_LE 16: 0x0123456789abcdef -> 0xefcd jited:0 92 PASS
+[  318.406666] test_bpf: #209 ALU_END_FROM_LE 32: 0x0123456789abcdef -> 0xefcdab89 jited:0 157 PASS
+[  318.417142] test_bpf: #210 ALU_END_FROM_LE 64: 0x0123456789abcdef -> 0x67452301 jited:0 86 PASS
+[  318.426824] test_bpf: #211 ST_MEM_B: Store/Load byte: max negative jited:0 119 PASS
+[  318.435773] test_bpf: #212 ST_MEM_B: Store/Load byte: max positive jited:0 111 PASS
+[  318.444695] test_bpf: #213 STX_MEM_B: Store/Load byte: max negative jited:0 128 PASS
+[  318.453864] test_bpf: #214 ST_MEM_H: Store/Load half word: max negative jited:0 111 PASS
+[  318.463259] test_bpf: #215 ST_MEM_H: Store/Load half word: max positive jited:0 111 PASS
+[  318.472610] test_bpf: #216 STX_MEM_H: Store/Load half word: max negative jited:0 128 PASS
+[  318.482207] test_bpf: #217 ST_MEM_W: Store/Load word: max negative jited:0 119 PASS
+[  318.491163] test_bpf: #218 ST_MEM_W: Store/Load word: max positive jited:0 111 PASS
+[  318.500083] test_bpf: #219 STX_MEM_W: Store/Load word: max negative jited:0 128 PASS
+[  318.509253] test_bpf: #220 ST_MEM_DW: Store/Load double word: max negative jited:0 111 PASS
+[  318.518865] test_bpf: #221 ST_MEM_DW: Store/Load double word: max negative 2 jited:0 177 PASS
+[  318.529284] test_bpf: #222 ST_MEM_DW: Store/Load double word: max positive jited:0 111 PASS
+[  318.538872] test_bpf: #223 STX_MEM_DW: Store/Load double word: max negative jited:0 136 PASS
+[  318.548766] test_bpf: #224 STX_XADD_W: Test: 0x12 + 0x10 = 0x22 jited:0 148 PASS
+[  318.557831] test_bpf: #225 STX_XADD_W: Test side-effects, r10: 0x12 + 0x10 = 0x22 jited:0 PASS
+[  318.566550] test_bpf: #226 STX_XADD_W: Test side-effects, r0: 0x12 + 0x10 = 0x22 jited:0 136 PASS
+[  318.576878] test_bpf: #227 STX_XADD_W: X + 1 + 1 + 1 + ... jited:0 155824 PASS
+[  320.142757] test_bpf: #228 STX_XADD_DW: Test: 0x12 + 0x10 = 0x22 jited:0 156 PASS
+[  320.151941] test_bpf: #229 STX_XADD_DW: Test side-effects, r10: 0x12 + 0x10 = 0x22 jited:0 PASS
+[  320.160770] test_bpf: #230 STX_XADD_DW: Test side-effects, r0: 0x12 + 0x10 = 0x22 jited:0 127 PASS
+[  320.171136] test_bpf: #231 STX_XADD_DW: X + 1 + 1 + 1 + ... jited:0 155679 PASS
+[  321.735643] test_bpf: #232 JMP_EXIT jited:0 70 PASS
+[  321.741397] test_bpf: #233 JMP_JA: Unconditional jump: if (true) return 1 jited:0 101 PASS
+[  321.750813] test_bpf: #234 JMP_JSLT_K: Signed jump: if (-2 < -1) return 1 jited:0 136 PASS
+[  321.760548] test_bpf: #235 JMP_JSLT_K: Signed jump: if (-1 < -1) return 0 jited:0 107 PASS
+[  321.770047] test_bpf: #236 JMP_JSGT_K: Signed jump: if (-1 > -2) return 1 jited:0 127 PASS
+[  321.779725] test_bpf: #237 JMP_JSGT_K: Signed jump: if (-1 > -1) return 0 jited:0 107 PASS
+[  321.789217] test_bpf: #238 JMP_JSLE_K: Signed jump: if (-2 <= -1) return 1 jited:0 127 PASS
+[  321.798975] test_bpf: #239 JMP_JSLE_K: Signed jump: if (-1 <= -1) return 1 jited:0 135 PASS
+[  321.808771] test_bpf: #240 JMP_JSLE_K: Signed jump: value walk 1 jited:0 241 PASS
+[  321.818820] test_bpf: #241 JMP_JSLE_K: Signed jump: value walk 2 jited:0 210 PASS
+[  321.828529] test_bpf: #242 JMP_JSGE_K: Signed jump: if (-1 >= -2) return 1 jited:0 127 PASS
+[  321.838280] test_bpf: #243 JMP_JSGE_K: Signed jump: if (-1 >= -1) return 1 jited:0 135 PASS
+[  321.848080] test_bpf: #244 JMP_JSGE_K: Signed jump: value walk 1 jited:0 241 PASS
+[  321.858130] test_bpf: #245 JMP_JSGE_K: Signed jump: value walk 2 jited:0 210 PASS
+[  321.867846] test_bpf: #246 JMP_JGT_K: if (3 > 2) return 1 jited:0 127 PASS
+[  321.876137] test_bpf: #247 JMP_JGT_K: Unsigned jump: if (-1 > 1) return 1 jited:0 127 PASS
+[  321.885851] test_bpf: #248 JMP_JLT_K: if (2 < 3) return 1 jited:0 127 PASS
+[  321.894147] test_bpf: #249 JMP_JGT_K: Unsigned jump: if (1 < -1) return 1 jited:0 127 PASS
+[  321.903835] test_bpf: #250 JMP_JGE_K: if (3 >= 2) return 1 jited:0 127 PASS
+[  321.912213] test_bpf: #251 JMP_JLE_K: if (2 <= 3) return 1 jited:0 127 PASS
+[  321.920607] test_bpf: #252 JMP_JGT_K: if (3 > 2) return 1 (jump backwards) jited:0 143 PASS
+[  321.930527] test_bpf: #253 JMP_JGE_K: if (3 >= 3) return 1 jited:0 135 PASS
+[  321.938949] test_bpf: #254 JMP_JGT_K: if (2 < 3) return 1 (jump backwards) jited:0 151 PASS
+[  321.948905] test_bpf: #255 JMP_JLE_K: if (3 <= 3) return 1 jited:0 127 PASS
+[  321.957295] test_bpf: #256 JMP_JNE_K: if (3 != 2) return 1 jited:0 127 PASS
+[  321.965671] test_bpf: #257 JMP_JEQ_K: if (3 == 3) return 1 jited:0 127 PASS
+[  321.974066] test_bpf: #258 JMP_JSET_K: if (0x3 & 0x2) return 1 jited:0 127 PASS
+[  321.982796] test_bpf: #259 JMP_JSET_K: if (0x3 & 0xffffffff) return 1 jited:0 133 PASS
+[  321.992153] test_bpf: #260 JMP_JSGT_X: Signed jump: if (-1 > -2) return 1 jited:0 146 PASS
+[  322.002028] test_bpf: #261 JMP_JSGT_X: Signed jump: if (-1 > -1) return 0 jited:0 123 PASS
+[  322.011747] test_bpf: #262 JMP_JSLT_X: Signed jump: if (-2 < -1) return 1 jited:0 146 PASS
+[  322.021636] test_bpf: #263 JMP_JSLT_X: Signed jump: if (-1 < -1) return 0 jited:0 123 PASS
+[  322.031277] test_bpf: #264 JMP_JSGE_X: Signed jump: if (-1 >= -2) return 1 jited:0 154 PASS
+[  322.041269] test_bpf: #265 JMP_JSGE_X: Signed jump: if (-1 >= -1) return 1 jited:0 146 PASS
+[  322.051225] test_bpf: #266 JMP_JSLE_X: Signed jump: if (-2 <= -1) return 1 jited:0 152 PASS
+[  322.061213] test_bpf: #267 JMP_JSLE_X: Signed jump: if (-1 <= -1) return 1 jited:0 146 PASS
+[  322.071160] test_bpf: #268 JMP_JGT_X: if (3 > 2) return 1 jited:0 153 PASS
+[  322.079683] test_bpf: #269 JMP_JGT_X: Unsigned jump: if (-1 > 1) return 1 jited:0 146 PASS
+[  322.089556] test_bpf: #270 JMP_JLT_X: if (2 < 3) return 1 jited:0 146 PASS
+[  322.098044] test_bpf: #271 JMP_JLT_X: Unsigned jump: if (1 < -1) return 1 jited:0 146 PASS
+[  322.107975] test_bpf: #272 JMP_JGE_X: if (3 >= 2) return 1 jited:0 146 PASS
+[  322.116560] test_bpf: #273 JMP_JGE_X: if (3 >= 3) return 1 jited:0 146 PASS
+[  322.125143] test_bpf: #274 JMP_JLE_X: if (2 <= 3) return 1 jited:0 146 PASS
+[  322.133729] test_bpf: #275 JMP_JLE_X: if (3 <= 3) return 1 jited:0 146 PASS
+[  322.142322] test_bpf: #276 JMP_JGE_X: ldimm64 test 1 jited:0 156 PASS
+[  322.150442] test_bpf: #277 JMP_JGE_X: ldimm64 test 2 jited:0 155 PASS
+[  322.158545] test_bpf: #278 JMP_JGE_X: ldimm64 test 3 jited:0 137 PASS
+[  322.166475] test_bpf: #279 JMP_JLE_X: ldimm64 test 1 jited:0 155 PASS
+[  322.174591] test_bpf: #280 JMP_JLE_X: ldimm64 test 2 jited:0 154 PASS
+[  322.182695] test_bpf: #281 JMP_JLE_X: ldimm64 test 3 jited:0 137 PASS
+[  322.190623] test_bpf: #282 JMP_JNE_X: if (3 != 2) return 1 jited:0 153 PASS
+[  322.199231] test_bpf: #283 JMP_JEQ_X: if (3 == 3) return 1 jited:0 153 PASS
+[  322.207838] test_bpf: #284 JMP_JSET_X: if (0x3 & 0x2) return 1 jited:0 146 PASS
+[  322.216758] test_bpf: #285 JMP_JSET_X: if (0x3 & 0xffffffff) return 1 jited:0 146 PASS
+[  322.226275] test_bpf: #286 JMP_JA: Jump, gap, jump, ... jited:0 166 PASS
+[  322.234764] test_bpf: #287 BPF_MAXINSNS: Maximum possible literals jited:0 125 PASS
+[  322.245225] test_bpf: #288 BPF_MAXINSNS: Single literal jited:0 133 PASS
+[  322.254654] test_bpf: #289 BPF_MAXINSNS: Run/add until end jited:0 72997 PASS
+[  322.993095] test_bpf: #290 BPF_MAXINSNS: Too many instructions PASS
+[  322.999457] test_bpf: #291 BPF_MAXINSNS: Very long jump jited:0 141 PASS
+[  323.009051] test_bpf: #292 BPF_MAXINSNS: Ctx heavy transformations jited:0 244880 244775 PASS
+[  327.916563] test_bpf: #293 BPF_MAXINSNS: Call heavy transformations jited:0 342952 342938 PASS
+[  334.786931] test_bpf: #294 BPF_MAXINSNS: Jump heavy test jited:0 151037 PASS
+[  336.306419] test_bpf: #295 BPF_MAXINSNS: Very long jump backwards jited:0 102 PASS
+[  336.315205] test_bpf: #296 BPF_MAXINSNS: Edge hopping nuthouse jited:0 68161 PASS
+[  337.004586] test_bpf: #297 BPF_MAXINSNS: Jump, gap, jump, ... jited:0 1171 PASS
+[  337.024859] test_bpf: #298 BPF_MAXINSNS: ld_abs+get_processor_id jited:0 224820 PASS
+[  339.283063] test_bpf: #299 BPF_MAXINSNS: ld_abs+vlan_push/pop jited:0 178235 PASS
+[  341.073403] test_bpf: #300 BPF_MAXINSNS: jump around ld_abs jited:0 132 PASS
+[  341.081953] test_bpf: #301 LD_IND byte frag jited:0 295 PASS
+[  341.090813] test_bpf: #302 LD_IND halfword frag jited:0 287 PASS
+[  341.099875] test_bpf: #303 LD_IND word frag jited:0 294 PASS
+[  341.108632] test_bpf: #304 LD_IND halfword mixed head/frag jited:0 330 PASS
+[  341.119044] test_bpf: #305 LD_IND word mixed head/frag jited:0 307 PASS
+[  341.128951] test_bpf: #306 LD_ABS byte frag jited:0 270 PASS
+[  341.137469] test_bpf: #307 LD_ABS halfword frag jited:0 270 PASS
+[  341.146334] test_bpf: #308 LD_ABS word frag jited:0 261 PASS
+[  341.154775] test_bpf: #309 LD_ABS halfword mixed head/frag jited:0 295 PASS
+[  341.164864] test_bpf: #310 LD_ABS word mixed head/frag jited:0 287 PASS
+[  341.174507] test_bpf: #311 LD_IND byte default X jited:0 143 PASS
+[  341.182203] test_bpf: #312 LD_IND byte positive offset jited:0 160 PASS
+[  341.190588] test_bpf: #313 LD_IND byte negative offset jited:0 160 PASS
+[  341.198972] test_bpf: #314 LD_IND halfword positive offset jited:0 165 PASS
+[  341.207737] test_bpf: #315 LD_IND halfword negative offset jited:0 165 PASS
+[  341.216517] test_bpf: #316 LD_IND halfword unaligned jited:0 166 PASS
+[  341.224817] test_bpf: #317 LD_IND word positive offset jited:0 169 PASS
+[  341.233252] test_bpf: #318 LD_IND word negative offset jited:0 169 PASS
+[  341.241697] test_bpf: #319 LD_IND word unaligned (addr & 3 == 2) jited:0 171 PASS
+[  341.251016] test_bpf: #320 LD_IND word unaligned (addr & 3 == 1) jited:0 163 PASS
+[  341.260295] test_bpf: #321 LD_IND word unaligned (addr & 3 == 3) jited:0 163 PASS
+[  341.269568] test_bpf: #322 LD_ABS byte jited:0 143 PASS
+[  341.276360] test_bpf: #323 LD_ABS halfword jited:0 140 PASS
+[  341.283514] test_bpf: #324 LD_ABS halfword unaligned jited:0 140 PASS
+[  341.291515] test_bpf: #325 LD_ABS word jited:0 137 PASS
+[  341.298371] test_bpf: #326 LD_ABS word unaligned (addr & 3 == 2) jited:0 137 PASS
+[  341.307381] test_bpf: #327 LD_ABS word unaligned (addr & 3 == 1) jited:0 137 PASS
+[  341.316407] test_bpf: #328 LD_ABS word unaligned (addr & 3 == 3) jited:0 137 PASS
+[  341.325411] test_bpf: #329 ADD default X jited:0 151 PASS
+[  341.332456] test_bpf: #330 ADD default A jited:0 127 PASS
+[  341.339307] test_bpf: #331 SUB default X jited:0 143 PASS
+[  341.346363] test_bpf: #332 SUB default A jited:0 127 PASS
+[  341.353211] test_bpf: #333 MUL default X jited:0 152 PASS
+[  341.360268] test_bpf: #334 MUL default A jited:0 130 PASS
+[  341.367144] test_bpf: #335 DIV default X jited:0 155 PASS
+[  341.374257] test_bpf: #336 DIV default A jited:0 142 PASS
+[  341.381266] test_bpf: #337 MOD default X jited:0 162 PASS
+[  341.388418] test_bpf: #338 MOD default A jited:0 145 PASS
+[  341.395429] test_bpf: #339 JMP EQ default A jited:0 145 PASS
+[  341.402714] test_bpf: #340 JMP EQ default X jited:0 161 PASS
+[  341.410147] test_bpf: Summary: 341 PASSED, 0 FAILED, [0/333 JIT'ed]
+[  342.711682] IPv6: ADDRCONF(NETDEV_UP): veth0: link is not ready
+[  343.064386] IPv6: ADDRCONF(NETDEV_UP): veth0: link is not ready
+[  343.412512] IPv6: ADDRCONF(NETDEV_UP): eth1: link is not ready
+[  343.418466] IPv6: ADDRCONF(NETDEV_CHANGE): veth0: link becomes ready
+[  343.483814] IPv6: ADDRCONF(NETDEV_UP): veth0: link is not ready
+[  343.556799] IPv6: ADDRCONF(NETDEV_CHANGE): veth0: link becomes ready
+[  343.616858] IPv6: ADDRCONF(NETDEV_CHANGE): veth0: link becomes ready
+[  343.651067] IPv6: ADDRCONF(NETDEV_CHANGE): eth1: link becomes ready
+[  344.835286] audit: type=1325 audit(1574425569.131:13): table=filter family=2 entries=0
+[  344.899184] audit: type=1300 audit(1574425569.131:13): arch=c00000b7 syscall=209 success=yes exit=0 a0=6 a1=0 a2=40 a3=fffffd2083e8 items=0 ppid=7203 pid=7285 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=ttyAMA0 ses=4294967295 comm=\"iptables\" exe=\"/usr/sbin/xtables-multi\" key=(null)
+[  344.926733] audit: type=1327 audit(1574425569.131:13): proctitle=69707461626C6573002D700069636D70002D4100464F5257415244002D6D00706F6C696379002D2D646972006F7574002D2D706F6C006970736563
+[  345.016819] audit: type=1325 audit(1574425569.315:14): table=filter family=2 entries=0
+[  345.079279] audit: type=1300 audit(1574425569.315:14): arch=c00000b7 syscall=209 success=yes exit=0 a0=6 a1=0 a2=40 a3=fffff9356158 items=0 ppid=7203 pid=7287 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=ttyAMA0 ses=4294967295 comm=\"iptables\" exe=\"/usr/sbin/xtables-multi\" key=(null)
+[  345.106984] audit: type=1327 audit(1574425569.315:14): proctitle=69707461626C6573002D700069636D70002D4100464F5257415244002D6D00706F6C696379002D2D646972006F7574002D2D706F6C006970736563
+[  347.832596] IPv6: ADDRCONF(NETDEV_UP): veth_A-R1: link is not ready
+[  347.877172] IPv6: ADDRCONF(NETDEV_UP): veth_R1-A: link is not ready
+[  347.883525] IPv6: ADDRCONF(NETDEV_CHANGE): veth_A-R1: link becomes ready
+[  348.116414] IPv6: ADDRCONF(NETDEV_UP): veth_A-R2: link is not ready
+[  348.152781] IPv6: ADDRCONF(NETDEV_CHANGE): veth_A-R2: link becomes ready
+[  348.375792] IPv6: ADDRCONF(NETDEV_UP): veth_B-R1: link is not ready
+[  348.408712] IPv6: ADDRCONF(NETDEV_CHANGE): veth_B-R1: link becomes ready
+[  348.672626] IPv6: ADDRCONF(NETDEV_UP): veth_B-R2: link is not ready
+[  348.717541] IPv6: ADDRCONF(NETDEV_CHANGE): veth_B-R2: link becomes ready
+[  348.839594] IPv6: ADDRCONF(NETDEV_CHANGE): veth_R1-A: link becomes ready
+[  353.309122] IPv6: ADDRCONF(NETDEV_UP): veth_A-R1: link is not ready
+[  353.370100] IPv6: ADDRCONF(NETDEV_CHANGE): veth_A-R1: link becomes ready
+[  353.628474] IPv6: ADDRCONF(NETDEV_UP): veth_A-R2: link is not ready
+[  353.661429] IPv6: ADDRCONF(NETDEV_CHANGE): veth_A-R2: link becomes ready
+[  353.919635] IPv6: ADDRCONF(NETDEV_UP): veth_B-R1: link is not ready
+[  353.953480] IPv6: ADDRCONF(NETDEV_CHANGE): veth_B-R1: link becomes ready
+[  354.203936] IPv6: ADDRCONF(NETDEV_UP): veth_B-R2: link is not ready
+[  354.250278] IPv6: ADDRCONF(NETDEV_CHANGE): veth_B-R2: link becomes ready
+[  357.366020] IPv6: ADDRCONF(NETDEV_UP): veth_A-R1: link is not ready
+[  357.406874] IPv6: ADDRCONF(NETDEV_CHANGE): veth_A-R1: link becomes ready
+[  357.653793] IPv6: ADDRCONF(NETDEV_UP): veth_A-R2: link is not ready
+[  357.694960] IPv6: ADDRCONF(NETDEV_CHANGE): veth_A-R2: link becomes ready
+[  357.933644] IPv6: ADDRCONF(NETDEV_UP): veth_B-R1: link is not ready
+[  357.970771] IPv6: ADDRCONF(NETDEV_CHANGE): veth_B-R1: link becomes ready
+[  358.206990] IPv6: ADDRCONF(NETDEV_UP): veth_B-R2: link is not ready
+[  358.250944] IPv6: ADDRCONF(NETDEV_CHANGE): veth_B-R2: link becomes ready
+[  360.702253] IPv6: ADDRCONF(NETDEV_UP): veth_A-R1: link is not ready
+[  360.739235] IPv6: ADDRCONF(NETDEV_CHANGE): veth_A-R1: link becomes ready
+[  360.986011] IPv6: ADDRCONF(NETDEV_UP): veth_A-R2: link is not ready
+[  361.023437] IPv6: ADDRCONF(NETDEV_CHANGE): veth_A-R2: link becomes ready
+[  361.301797] IPv6: ADDRCONF(NETDEV_UP): veth_B-R1: link is not ready
+[  361.334541] IPv6: ADDRCONF(NETDEV_CHANGE): veth_B-R1: link becomes ready
+[  361.598134] IPv6: ADDRCONF(NETDEV_UP): veth_B-R2: link is not ready
+[  361.643291] IPv6: ADDRCONF(NETDEV_CHANGE): veth_B-R2: link becomes ready
+[  364.065976] IPv6: ADDRCONF(NETDEV_UP): veth_A-R1: link is not ready
+[  364.102955] IPv6: ADDRCONF(NETDEV_CHANGE): veth_A-R1: link becomes ready
+[  364.345498] IPv6: ADDRCONF(NETDEV_UP): veth_A-R2: link is not ready
+[  364.383067] IPv6: ADDRCONF(NETDEV_CHANGE): veth_A-R2: link becomes ready

--- a/test/plugins/test_linux_log_parser.py
+++ b/test/plugins/test_linux_log_parser.py
@@ -2,6 +2,7 @@ import os
 from django.test import TestCase
 from squad.plugins.linux_log_parser import Plugin
 from squad.core.models import Group
+from squad.ci.models import TestJob, Backend
 
 
 def read_sample_file(name):
@@ -18,16 +19,30 @@ class TestLinuxLogParser(TestCase):
         self.build = self.project.builds.create(version='1')
         self.env = self.project.environments.create(slug='myenv')
         self.plugin = Plugin()
+        self.backend = Backend.objects.create(name='foobar')
 
-    def new_test_run(self, logfile):
+    def new_testjob(self, logfile, name='999'):
+        testjob = TestJob.objects.create(
+            backend=self.backend,
+            definition='',
+            target=self.project,
+            target_build=self.build,
+            environment=self.env.slug,
+            name=name
+        )
+
         log = read_sample_file(logfile)
-        return self.build.test_runs.create(environment=self.env, log_file=log)
+        testrun = self.build.test_runs.create(environment=self.env, log_file=log)
+        testjob.testrun = testrun
+        testjob.save()
+
+        return testjob
 
     def test_detects_oops(self):
-        testrun = self.new_test_run('oops.log')
-        self.plugin.postprocess_testrun(testrun)
+        testjob = self.new_testjob('oops.log')
+        self.plugin.postprocess_testjob(testjob)
 
-        test = testrun.tests.get(suite__slug='linux-log-parser', name='check-oops')
+        test = testjob.testrun.tests.get(suite__slug='linux-log-parser', name='check-kernel-oops-999')
         self.assertFalse(test.result)
         self.assertIsNotNone(test.log)
         self.assertNotIn('Linux version 4.4.89-01529-gb29bace', test.log)
@@ -35,20 +50,108 @@ class TestLinuxLogParser(TestCase):
         self.assertNotIn('Kernel panic', test.log)
 
     def test_detects_kernel_panic(self):
-        testrun = self.new_test_run('kernelpanic.log')
-        self.plugin.postprocess_testrun(testrun)
+        testjob = self.new_testjob('kernelpanic.log')
+        self.plugin.postprocess_testjob(testjob)
 
-        test = testrun.tests.get(suite__slug='linux-log-parser', name='check-kernel-panic')
+        test = testjob.testrun.tests.get(suite__slug='linux-log-parser', name='check-kernel-panic-999')
         self.assertFalse(test.result)
         self.assertIsNotNone(test.log)
         self.assertNotIn('Booting Linux', test.log)
         self.assertIn('Kernel panic - not syncing', test.log)
         self.assertNotIn('Internal error: Oops', test.log)
 
-    def test_pass_if_nothing_is_found(self):
-        testrun = self.new_test_run('/dev/null')
-        self.plugin.postprocess_testrun(testrun)
+    def test_detects_multiple(self):
+        testjob = self.new_testjob('multiple_issues_dmesg.log')
+        self.plugin.postprocess_testjob(testjob)
 
-        test = testrun.tests.get(suite__slug='linux-log-parser', name='check-oops')
-        test = testrun.tests.get(suite__slug='linux-log-parser', name='check-kernel-panic')
-        self.assertTrue(test.result)
+        tests = testjob.testrun.tests
+        test_trace = tests.get(suite__slug='linux-log-parser', name='check-kernel-trace-999')
+        test_panic = tests.get(suite__slug='linux-log-parser', name='check-kernel-panic-999')
+        test_exception = tests.get(suite__slug='linux-log-parser', name='check-kernel-exception-999')
+        test_warning = tests.get(suite__slug='linux-log-parser', name='check-kernel-warning-999')
+        test_oops = tests.get(suite__slug='linux-log-parser', name='check-kernel-oops-999')
+        test_fault = tests.get(suite__slug='linux-log-parser', name='check-kernel-fault-999')
+
+        self.assertTrue(test_trace.result)
+        self.assertEqual('', test_trace.log)
+
+        self.assertFalse(test_panic.result)
+        self.assertNotIn('Boot CPU', test_panic.log)
+        self.assertIn('Kernel panic - not syncing', test_panic.log)
+
+        self.assertFalse(test_exception.result)
+        self.assertNotIn('Boot CPU', test_exception.log)
+        self.assertIn('------------[ cut here ]------------', test_exception.log)
+
+        self.assertFalse(test_warning.result)
+        self.assertNotIn('Boot CPU', test_warning.log)
+        self.assertNotIn('Kernel panic - not syncing', test_warning.log)
+        self.assertNotIn('------------[ cut here ]------------', test_warning.log)
+        self.assertNotIn('Unhandled fault:', test_warning.log)
+        self.assertNotIn('Oops', test_warning.log)
+        self.assertIn('WARNING: CPU', test_warning.log)
+
+        self.assertFalse(test_oops.result)
+        self.assertNotIn('Boot CPU', test_oops.log)
+        self.assertNotIn('Kernel panic - not syncing', test_oops.log)
+        self.assertNotIn('------------[ cut here ]------------', test_oops.log)
+        self.assertNotIn('WARNING: CPU', test_oops.log)
+        self.assertNotIn('Unhandled fault:', test_oops.log)
+        self.assertIn('Oops', test_oops.log)
+
+        self.assertFalse(test_fault.result)
+        self.assertNotIn('Boot CPU', test_fault.log)
+        self.assertNotIn('Kernel panic - not syncing', test_fault.log)
+        self.assertNotIn('------------[ cut here ]------------', test_fault.log)
+        self.assertNotIn('WARNING: CPU', test_fault.log)
+        self.assertNotIn('Oops', test_fault.log)
+        self.assertIn('Unhandled fault:', test_fault.log)
+
+    def test_pass_if_nothing_is_found(self):
+        testjob = self.new_testjob('/dev/null')
+        self.plugin.postprocess_testjob(testjob)
+
+        tests = testjob.testrun.tests
+        test_trace = tests.get(suite__slug='linux-log-parser', name='check-kernel-trace-999')
+        test_panic = tests.get(suite__slug='linux-log-parser', name='check-kernel-panic-999')
+        test_exception = tests.get(suite__slug='linux-log-parser', name='check-kernel-exception-999')
+        test_warning = tests.get(suite__slug='linux-log-parser', name='check-kernel-warning-999')
+        test_oops = tests.get(suite__slug='linux-log-parser', name='check-kernel-oops-999')
+        test_fault = tests.get(suite__slug='linux-log-parser', name='check-kernel-fault-999')
+
+        self.assertTrue(test_trace.result)
+        self.assertTrue(test_panic.result)
+        self.assertTrue(test_exception.result)
+        self.assertTrue(test_warning.result)
+        self.assertTrue(test_oops.result)
+        self.assertTrue(test_fault.result)
+
+    def test_two_testruns_distinct_test_names(self):
+        testjob1 = self.new_testjob('/dev/null', 'job1')
+        testjob2 = self.new_testjob('/dev/null', 'job2')
+
+        self.plugin.postprocess_testjob(testjob1)
+        self.plugin.postprocess_testjob(testjob2)
+
+        self.assertNotEqual(testjob1.testrun.tests.all(), testjob2.testrun.tests.all())
+
+    def test_rcu_warning(self):
+        testjob = self.new_testjob('rcu_warning.log')
+        self.plugin.postprocess_testjob(testjob)
+
+        tests = testjob.testrun.tests
+        test_trace = tests.get(suite__slug='linux-log-parser', name='check-kernel-trace-999')
+        test_panic = tests.get(suite__slug='linux-log-parser', name='check-kernel-panic-999')
+        test_exception = tests.get(suite__slug='linux-log-parser', name='check-kernel-exception-999')
+        test_warning = tests.get(suite__slug='linux-log-parser', name='check-kernel-warning-999')
+        test_oops = tests.get(suite__slug='linux-log-parser', name='check-kernel-oops-999')
+        test_fault = tests.get(suite__slug='linux-log-parser', name='check-kernel-fault-999')
+
+        self.assertTrue(test_trace.result)
+        self.assertTrue(test_panic.result)
+        self.assertTrue(test_exception.result)
+        self.assertTrue(test_oops.result)
+        self.assertTrue(test_fault.result)
+        self.assertFalse(test_warning.result)
+
+        self.assertIn('WARNING: suspicious RCU usage', test_warning.log)

--- a/test/plugins/test_plugin.py
+++ b/test/plugins/test_plugin.py
@@ -6,9 +6,11 @@ from squad.core.plugins import Plugin, PluginNotFound
 class TestGetPluginsByFeature(TestCase):
 
     def test_basics(self):
-        plugins = get_plugins_by_feature([Plugin.postprocess_testrun])
-        self.assertNotIn('example', plugins)
-        self.assertIn('linux_log_parser', plugins)
+        testrun_plugins = get_plugins_by_feature([Plugin.postprocess_testrun])
+        testjob_plugins = get_plugins_by_feature([Plugin.postprocess_testjob])
+        self.assertNotIn('example', testrun_plugins)
+        self.assertNotIn('linux_log_parser', testrun_plugins)
+        self.assertIn('linux_log_parser', testjob_plugins)
 
     def test_feature_list_is_none(self):
         plugins = get_plugins_by_feature(None)


### PR DESCRIPTION
Closes https://github.com/Linaro/squad/issues/592 and https://github.com/Linaro/squadplugins/issues/3. This PR has been moved from https://github.com/Linaro/squadplugins/pull/13

I managed to put several regex'es together so that findall is called only once. Not sure if that has better performance than running each regex on its own. Also, there's a pre-regex that filters-out all non-kernel messages (that don't start with [number.number]), thus reducing log size considerably (specially in jobs with lots of target output).

By default, there are 6 tests, each represented by a regex, all under kernel-issues suite:

if a test has no match, result=True
if a test has at least one match, result=False
if a test matches more than once, all occurrences are concatenated and saved to its log. Meaning there will always be one test per build per testrun (2 Oopses == 1 test)

**NOTE:** It also addresses Dan's point of having multiple testsruns per environment. It appends `job_id` to the testname. Although helpful distinguishing tests across different test jobs, it won't be helpful finding regressions and fixes due to test name uniqueness.