### PR TITLE
Improve test api performace

### DIFF
--- a/squad/api/rest.py
+++ b/squad/api/rest.py
@@ -223,15 +223,14 @@ class APIRouter(routers.DefaultRouter):
 
 class ModelViewSet(viewsets.ModelViewSet):
 
-    def get_project_ids(self):
+    def get_projects(self):
         """
         Determines which projects the current user is allowed to visualize.
         Returns a list of project ids to be used in get_queryset() for
         filtering.
         """
         user = self.request.user
-        projects = Project.objects.accessible_to(user).values('id')
-        return [p['id'] for p in projects]
+        return Project.objects.accessible_to(user).only('id')
 
 
 class GroupSerializer(serializers.HyperlinkedModelSerializer):
@@ -595,7 +594,7 @@ class BuildViewSet(ModelViewSet):
     ordering_fields = ('id', 'version', 'created_at', 'datetime')
 
     def get_queryset(self):
-        return self.queryset.filter(project__in=self.get_project_ids())
+        return self.queryset.filter(project__in=self.get_projects())
 
     @action(detail=True, methods=['get'], suffix='metadata')
     def metadata(self, request, pk=None):
@@ -745,7 +744,7 @@ class EnvironmentViewSet(ModelViewSet):
     ordering_fields = ('id', 'slug', 'name')
 
     def get_queryset(self):
-        return self.queryset.filter(project__in=self.get_project_ids())
+        return self.queryset.filter(project__in=self.get_projects())
 
 
 class TestRunSerializer(serializers.HyperlinkedModelSerializer):
@@ -807,7 +806,7 @@ class TestViewSet(ModelViewSet):
     ordering = ('id',)
 
     def get_queryset(self):
-        return self.queryset.filter(test_run__build__project__in=self.get_project_ids()) \
+        return self.queryset.filter(test_run__build__project__in=self.get_projects()) \
                    .prefetch_related('suite', 'known_issues')
 
 
@@ -847,7 +846,7 @@ class TestRunViewSet(ModelViewSet):
     ordering = ('created_at',)
 
     def get_queryset(self):
-        return self.queryset.filter(build__project__in=self.get_project_ids())
+        return self.queryset.filter(build__project__in=self.get_projects())
 
     @action(detail=True, methods=['get'])
     def tests_file(self, request, pk=None):
@@ -953,7 +952,7 @@ class TestJobViewSet(ModelViewSet):
     ordering = ('id',)
 
     def get_queryset(self):
-        return self.queryset.filter(target_build__project__in=self.get_project_ids())
+        return self.queryset.filter(target_build__project__in=self.get_projects())
 
     @action(detail=True, methods=['get'], suffix='definition')
     def definition(self, request, pk=None):

--- a/squad/api/rest.py
+++ b/squad/api/rest.py
@@ -807,7 +807,8 @@ class TestViewSet(ModelViewSet):
     ordering = ('id',)
 
     def get_queryset(self):
-        return self.queryset.filter(test_run__build__project__in=self.get_project_ids())
+        return self.queryset.filter(test_run__build__project__in=self.get_project_ids()) \
+                   .prefetch_related('suite', 'known_issues')
 
 
 class MetricSerializer(serializers.ModelSerializer):

--- a/squad/api/utils.py
+++ b/squad/api/utils.py
@@ -1,8 +1,8 @@
-from django_filters.rest_framework import DjangoFilterBackend
+from squad.compat import RestFrameworkFilterBackend
 from rest_framework.pagination import CursorPagination
 
 
-class DisabledHTMLFilterBackend(DjangoFilterBackend):
+class DisabledHTMLFilterBackend(RestFrameworkFilterBackend):
 
     def to_html(self, request, queryset, view):
         return ""

--- a/squad/api/utils.py
+++ b/squad/api/utils.py
@@ -1,5 +1,6 @@
 from squad.compat import RestFrameworkFilterBackend
 from rest_framework.pagination import CursorPagination
+from rest_framework.renderers import BrowsableAPIRenderer
 
 
 class DisabledHTMLFilterBackend(RestFrameworkFilterBackend):
@@ -10,3 +11,23 @@ class DisabledHTMLFilterBackend(RestFrameworkFilterBackend):
 
 class CursorPaginationWithPageSize(CursorPagination):
     page_size_query_param = 'limit'
+
+
+# ref: https://bradmontgomery.net/blog/disabling-forms-django-rest-frameworks-browsable-api/
+class BrowsableAPIRendererWithoutForms(BrowsableAPIRenderer):
+    """Renders the browsable api, but excludes the forms."""
+
+    def get_context(self, *args, **kwargs):
+        ctx = super().get_context(*args, **kwargs)
+        ctx['display_edit_forms'] = False
+        return ctx
+
+    def show_form_for_method(self, view, method, request, obj):
+        """We never want to do this! So just return False."""
+        return False
+
+    def get_rendered_html_form(self, data, view, method, request):
+        """Why render _any_ forms at all. This method should return
+        rendered HTML, so let's simply return an empty string.
+        """
+        return ""

--- a/squad/core/models.py
+++ b/squad/core/models.py
@@ -177,9 +177,8 @@ class ProjectManager(models.Manager):
         if user.is_superuser or user.is_staff:
             return self.all()
         else:
-            groups = Group.objects.filter(members__id=user.id)
-            group_ids = [g['id'] for g in groups.values('id')]
-            return self.filter(Q(group_id__in=group_ids) | Q(is_public=True))
+            groups = Group.objects.filter(members__id=user.id).only('id')
+            return self.filter(Q(group__in=groups) | Q(is_public=True))
 
 
 class EmailTemplate(models.Model):

--- a/squad/settings.py
+++ b/squad/settings.py
@@ -313,7 +313,6 @@ REST_FRAMEWORK = {
     ],
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
     'DEFAULT_FILTER_BACKENDS': (
-        'squad.compat.RestFrameworkFilterBackend',
         'rest_framework.filters.OrderingFilter',
         'rest_framework.filters.SearchFilter',
         'squad.api.utils.DisabledHTMLFilterBackend',

--- a/squad/settings.py
+++ b/squad/settings.py
@@ -321,7 +321,11 @@ REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'rest_framework.authentication.SessionAuthentication',
         'rest_framework.authentication.TokenAuthentication',
-    )
+    ),
+    'DEFAULT_RENDERER_CLASSES': (
+        'rest_framework.renderers.JSONRenderer',
+        'squad.api.utils.BrowsableAPIRendererWithoutForms',
+    ),
 }
 
 # CORS setup


### PR DESCRIPTION
This PR does several things:
* remove duplicate call to DjangoFilterBackend in settings (this caused a huge drag on the api, more details in this commit https://github.com/Linaro/squad/commit/cbea9f44acdf9da3842eb931f5836dd290a736af )
* disable API POST forms completely
* in TestRunFilter, use Build's queryset without ordering (query runs much faster)
* avoid passing a query like `SELECT id FROM core_project` when user is admin or staff (they already have permission to see everything anyways)
* exclude "metadata" from TestSerializer
* prefetch "suite" and "known_issues" in TestViewSet
* prefetch "environments" in KnownIssuesViewSet

After these changes, I noticed a huge improvement in snappiness of the API. 

Running ` time wget 'http://localhost:8000/api/tests/?test_run__build__project__slug=linux-mainline-oe&test_run__environment__slug=juno-r2&suite__slug__startswith=ltp'` took 3 seconds with these changes whereas it took 7+ minutes on master.

Also, running tests against master branch got the following:
```
DATABASE PERFORMANCE IMPROVEMENTS
---------------------------------
Unit: number of database queries

url:/api/builds/54/testjobs/: 9 -> 5
url:/api/builds/57/testruns/: 9 -> 5
url:/api/builds/: 8 -> 4
url:/api/builds/65/email/: 45 -> 39
url:/api/builds/89/status/: 7 -> 3
url:/api/environments/: 6 -> 2
url:/api/groups/: 6 -> 4
url:/api/projects/85/builds/: 9 -> 7
url:/api/projects/: 6 -> 4
url:/api/testjobs/124/: 6 -> 2
url:/api/testjobs/127/definition/: 6 -> 2
url:/api/testruns/246/: 5 -> 1
url:/api/testruns/252/metrics/: 6 -> 2
url:/api/testruns/258/tests/: 26 -> 22
url:/api/tests/: 105 -> 3
url:/api/tests/?limit=2: 9 -> 3
url:/mygroup/: 9 -> 8
url:/: 5 -> 4
```  