### PR TITLE
Faster comparison

### DIFF
--- a/squad/core/models.py
+++ b/squad/core/models.py
@@ -973,7 +973,6 @@ class ProjectStatus(models.Model, TestSummaryBase):
         returns it.
         """
 
-        build_finished, _ = build.finished
         test_summary = build.test_summary
         metrics_summary = MetricsSummary(build)
         now = timezone.now()
@@ -983,19 +982,19 @@ class ProjectStatus(models.Model, TestSummaryBase):
         regressions = None
         fixes = None
 
-        if build_finished:
-            previous_build = Build.objects.filter(
-                status__finished=True,
-                datetime__lt=build.datetime,
-                project=build.project,
-            ).order_by('datetime').last()
-            if previous_build is not None:
-                comparison = TestComparison(previous_build, build)
-                if comparison.regressions:
-                    regressions = yaml.dump(comparison.regressions)
-                if comparison.fixes:
-                    fixes = yaml.dump(comparison.fixes)
+        previous_build = Build.objects.filter(
+            status__finished=True,
+            datetime__lt=build.datetime,
+            project=build.project,
+        ).order_by('datetime').last()
+        if previous_build is not None:
+            comparison = TestComparison(previous_build, build)
+            if comparison.regressions:
+                regressions = yaml.dump(comparison.regressions)
+            if comparison.fixes:
+                fixes = yaml.dump(comparison.fixes)
 
+        finished, _ = build.finished
         data = {
             'tests_pass': test_summary.tests_pass,
             'tests_fail': test_summary.tests_fail,
@@ -1004,7 +1003,7 @@ class ProjectStatus(models.Model, TestSummaryBase):
             'metrics_summary': metrics_summary.value,
             'has_metrics': metrics_summary.has_metrics,
             'last_updated': now,
-            'finished': build_finished,
+            'finished': finished,
             'test_runs_total': test_runs_total,
             'test_runs_completed': test_runs_completed,
             'test_runs_incomplete': test_runs_incomplete,
@@ -1025,7 +1024,7 @@ class ProjectStatus(models.Model, TestSummaryBase):
             status.metrics_summary = metrics_summary.value
             status.has_metrics = metrics_summary.has_metrics
             status.last_updated = now
-            status.finished = build_finished
+            status.finished = finished
             status.build = build
             status.test_runs_total = test_runs_total
             status.test_runs_completed = test_runs_completed

--- a/test/core/test_project_status.py
+++ b/test/core/test_project_status.py
@@ -3,7 +3,6 @@ from django.test import TestCase
 from dateutil.relativedelta import relativedelta
 
 from squad.core.models import Group, ProjectStatus, MetricThreshold
-from squad.ci import models
 
 
 def h(n):
@@ -26,10 +25,6 @@ class ProjectStatusTest(TestCase):
         if create_test_run:
             build.test_runs.create(environment=self.environment)
         return build
-
-    def create_test_job(self, build):
-        backend = models.Backend.objects.create()
-        return build.test_jobs.create(target=build.project, target_build=build, backend=backend)
 
     def test_status_of_first_build(self):
         build = self.create_build('1')
@@ -231,43 +226,6 @@ class ProjectStatusTest(TestCase):
         self.assertIsNotNone(status2.regressions)
         self.assertIsNone(status2.fixes)
 
-    def test_no_regressions_when_build_not_finished(self):
-        build1 = self.create_build('1', datetime=h(10))
-        test_run1 = build1.test_runs.first()
-        test_run1.tests.create(name='foo', suite=self.suite, result=True)
-        ProjectStatus.create_or_update(build1)
-
-        build2 = self.create_build('2', datetime=h(9))
-        self.create_test_job(build2)
-        test_run2 = build2.test_runs.first()
-        test_run2.tests.create(name='foo', suite=self.suite, result=False)
-        status1 = ProjectStatus.create_or_update(build2)
-
-        self.assertIsNone(status1.regressions)
-        self.assertIsNone(status1.fixes)
-
-    def test_regressions_after_build_finished(self):
-        build1 = self.create_build('1', datetime=h(10))
-        test_run1 = build1.test_runs.first()
-        test_run1.tests.create(name='foo', suite=self.suite, result=True)
-        ProjectStatus.create_or_update(build1)
-
-        build2 = self.create_build('2', datetime=h(9))
-        testjob = self.create_test_job(build2)
-        test_run2 = build2.test_runs.first()
-        test_run2.tests.create(name='foo', suite=self.suite, result=False)
-        status1 = ProjectStatus.create_or_update(build2)
-
-        self.assertIsNone(status1.regressions)
-        self.assertIsNone(status1.fixes)
-
-        testjob.fetched = True
-        testjob.save()
-        status1 = ProjectStatus.create_or_update(build2)
-
-        self.assertIsNotNone(status1.regressions)
-        self.assertIsNone(status1.fixes)
-
     def test_cache_fixes(self):
         build1 = self.create_build('1', datetime=h(10))
         test_run1 = build1.test_runs.first()
@@ -303,42 +261,6 @@ class ProjectStatusTest(TestCase):
 
         self.assertIsNotNone(status2.fixes)
         self.assertIsNone(status2.regressions)
-
-    def test_no_fixes_when_build_not_finished(self):
-        build1 = self.create_build('1', datetime=h(10))
-        test_run1 = build1.test_runs.first()
-        test_run1.tests.create(name='foo', suite=self.suite, result=False)
-        ProjectStatus.create_or_update(build1)
-
-        build2 = self.create_build('2', datetime=h(9))
-        self.create_test_job(build2)
-        test_run2 = build2.test_runs.first()
-        test_run2.tests.create(name='foo', suite=self.suite, result=True)
-        status1 = ProjectStatus.create_or_update(build2)
-
-        self.assertIsNone(status1.regressions)
-        self.assertIsNone(status1.fixes)
-
-    def test_fixes_after_build_finished(self):
-        build1 = self.create_build('1', datetime=h(10))
-        test_run1 = build1.test_runs.first()
-        test_run1.tests.create(name='foo', suite=self.suite, result=False)
-        ProjectStatus.create_or_update(build1)
-
-        build2 = self.create_build('2', datetime=h(9))
-        testjob = self.create_test_job(build2)
-        test_run2 = build2.test_runs.first()
-        test_run2.tests.create(name='foo', suite=self.suite, result=True)
-        status1 = ProjectStatus.create_or_update(build2)
-
-        self.assertIsNone(status1.regressions)
-        self.assertIsNone(status1.fixes)
-
-        testjob.fetched = True
-        testjob.save()
-        status1 = ProjectStatus.create_or_update(build2)
-        self.assertIsNone(status1.regressions)
-        self.assertIsNotNone(status1.fixes)
 
     def test_get_exceeded_thresholds(self):
         build = self.create_build('1')


### PR DESCRIPTION
This PR reverts calculating fixes and regressions only at the end of the build, and it changes TestComparison to filter tests by testrun ids