### PR TITLE
Test comparison

### DIFF
--- a/squad/core/comparison.py
+++ b/squad/core/comparison.py
@@ -5,7 +5,7 @@ from functools import reduce
 import statistics
 
 
-from squad.core.utils import parse_name, join_name
+from squad.core.utils import parse_name, join_name, split_dict
 from squad.core import models
 
 
@@ -187,7 +187,9 @@ class TestComparison(BaseComparison):
             if test_runs_ids.get(test_run.id, None) is None:
                 test_runs_ids[test_run.id] = (build, env)
 
-        self.__extract_test_results__(test_runs_ids)
+        for ids in split_dict(test_runs_ids, chunk_size=400):
+            self.__extract_test_results__(ids)
+
         self.results = OrderedDict(sorted(self.results.items()))
         for build in self.builds:
             self.environments[build] = sorted(self.environments[build])
@@ -195,7 +197,7 @@ class TestComparison(BaseComparison):
     def __extract_test_results__(self, test_runs_ids):
         tests = models.Test.objects.filter(test_run_id__in=test_runs_ids.keys()).annotate(
             suite_slug=F('suite__slug'),
-        )
+        ).defer('log', 'metadata')
         for test in tests.iterator():
             key = test_runs_ids.get(test.test_run_id)
             full_name = join_name(test.suite_slug, test.name)

--- a/squad/core/comparison.py
+++ b/squad/core/comparison.py
@@ -174,7 +174,7 @@ class TestComparison(BaseComparison):
         ).prefetch_related(
             'build',
             'environment',
-        )
+        ).only('id')
 
         test_runs_ids = {}
         for test_run in test_runs:

--- a/squad/core/utils.py
+++ b/squad/core/utils.py
@@ -97,3 +97,27 @@ def encrypt(text):
 def decrypt(crypted):
     key = repeat_to_length(settings.SECRET_KEY, len(crypted))
     return xor(crypted, key)
+
+
+def split_dict(_dict, chunk_size=1):
+    dict_size = len(_dict)
+
+    if dict_size <= chunk_size:
+        return [_dict]
+
+    chunks = []
+    chunk = {}
+    counter = 0
+
+    for key in _dict.keys():
+        chunk[key] = _dict[key]
+        counter += 1
+        if counter == chunk_size:
+            chunks.append(chunk)
+            counter = 0
+            chunk = {}
+
+    if len(chunk):
+        chunks.append(chunk)
+
+    return chunks

--- a/test/core/test_utils.py
+++ b/test/core/test_utils.py
@@ -1,5 +1,5 @@
 from django.test import TestCase
-from squad.core.utils import join_name, parse_name, xor, encrypt, decrypt, repeat_to_length
+from squad.core.utils import join_name, parse_name, xor, encrypt, decrypt, repeat_to_length, split_dict
 
 
 class TestParseName(TestCase):
@@ -64,3 +64,22 @@ class TestCrypto(TestCase):
         decrypted = decrypt(encrypted)
         self.assertEqual(msg, decrypted)
         self.assertEqual(msg, decrypt(encrypted))
+
+
+class TestSplitDict(TestCase):
+
+    def test_split_dict(self):
+        _dict = {'a': 1, 'b': 2, 'c': 3, 'd': 4, 'e': 5}
+
+        chunks = split_dict(_dict)
+
+        self.assertEqual(5, len(chunks))
+        self.assertEqual({'a': 1}, chunks[0])
+        self.assertEqual({'e': 5}, chunks[4])
+
+        chunks = split_dict(_dict, chunk_size=2)
+
+        self.assertEqual(3, len(chunks))
+        self.assertEqual({'a': 1, 'b': 2}, chunks[0])
+        self.assertEqual({'c': 3, 'd': 4}, chunks[1])
+        self.assertEqual({'e': 5}, chunks[2])


### PR DESCRIPTION
After https://github.com/Linaro/squad/pull/620, staging DB just took forever to calculate TestComparison for builds with over 1000 testruns. Postgres queries were taking an insane amount of time to return (10+ hours). This patch fetch tests using batch of 400 test runs ids at a time. I've run a few queries in staging and production and this number seems to be the sweet spot.