### PR TITLE
ci: lava: handle unicode errors gracefully

### DIFF
--- a/squad/ci/backend/lava.py
+++ b/squad/ci/backend/lava.py
@@ -220,6 +220,7 @@ class Backend(BaseBackend):
     def __download_test_log__(self, raw_log, log_start, log_end):
         if not log_start:
             return ""
+
         return_lines = StringIO()
         log_start_line = int(log_start)
         log_end_line = None
@@ -233,7 +234,10 @@ class Backend(BaseBackend):
             counter += 1
             if counter < log_start_line:
                 continue
-            return_lines.write(line.decode("utf-8"))
+            try:
+                return_lines.write(line.decode("utf-8"))
+            except UnicodeDecodeError:
+                return_lines.write(line.decode("iso-8859-1"))
             return_lines.write("\n")
             if counter >= log_end_line:
                 break

--- a/test/ci/backend/test_lava.py
+++ b/test/ci/backend/test_lava.py
@@ -799,6 +799,12 @@ class LavaTest(TestCase):
         log = lava.__parse_log__(log_data)
         self.assertEqual(0, len(log))
 
+    def test_test_log_unicode_error(self):
+        lava = LAVABackend(self.backend)
+        log_data = BytesIO(b'a non-decodable unicode char: \xb1\n')
+        test_log = lava.__download_test_log__(log_data, 1, 3)
+        self.assertIn("a non-decodable unicode char:", test_log)
+
     @patch("squad.ci.backend.lava.Backend.__resubmit__", side_effect=HTTP_500)
     def test_resubmit_deleted_job(self, __resubmit__):
         lava = LAVABackend(None)


### PR DESCRIPTION
This prevents the whole fetch from breaking due to a single bad character in a test log. Ex:

```
[2019-10-31 13:22:53,972: INFO/ForkPoolWorker-1] squad.ci.tasks.fetch[21d67bd5-6032-4195-8d31-5f012bbe3382]: fetching validation.linaro.org/1920041
[2019-10-31 13:25:41 +0000] [ERROR] Task squad.ci.tasks.fetch[21d67bd5-6032-4195-8d31-5f012bbe3382] raised unexpected: UnicodeDecodeError('utf-8', b'AYd\xb19R\xa3\xf7\xb8K\xbfw\xb9\x08\xd5/+\xd9>t_\xcdU\xcb\xd3\xd3\xfb\xa5=p=\xff\xe4l$?\x94\x12~\xcdyV\xd6\x0e\x95S\xdeFNp\x83%\x04\x1c\x00P\x9bs=d"\xe3\x93\xcb!D\xc1t2\xd0\x8d\xd8\x1c\x89)\x943g\xcc\x1e\x85\x05?\xd1 "X\x99\xe5;\x17\xc95fnq/\x18\xdb\x17\\b\xc2\xa2,\xec\x95\x9a\x15\xde\x03I\xb8\x10\x1a\x9b\x86gQW\\i\x18Qo\xd6\xecj\xe5\x16R]\x97f\xc8ZjQ\xa45\x07\xe0\x88\xde\x9a)x\xcc\xc1:\xba\x9b\xb2Xi+\x18\x83\xb8y\xdfu_\xec0=\x9bU\xf5\xb9l\xd4\xf7\x8a*\xf5\x00Y\x8d\xaf\\^\xff\xbe\x93{\xe4\xdb\xa8$\xfd\x04\xe1\xfd\x8b8G\xce\xf9\xa8\x89\x95\x1d\xdfy]%\x94\xc8Hv\xbb\xc2\xd2\x83y[\x10\xab\x08\x8d\x96\x00e\n', 3, 4, 'invalid start byte')
Traceback (most recent call last):
  File "/srv/staging-qa-reports.linaro.org/lib/python3.5/site-packages/celery/app/trace.py", line 385, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/srv/staging-qa-reports.linaro.org/lib/python3.5/site-packages/squad/celery.py", line 27, in __call__
    return super(MemoryUseLoggingTask, self).__call__(*args, **kwargs)
  File "/srv/staging-qa-reports.linaro.org/lib/python3.5/site-packages/celery/app/trace.py", line 648, in __protected_call__
    return self.run(*args, **kwargs)
  File "/srv/staging-qa-reports.linaro.org/lib/python3.5/site-packages/squad/ci/tasks.py", line 31, in fetch
    test_job.backend.fetch(test_job)
  File "/srv/staging-qa-reports.linaro.org/lib/python3.5/site-packages/squad/ci/models.py", line 69, in fetch
    self.really_fetch(test_job)
  File "/srv/staging-qa-reports.linaro.org/lib/python3.5/site-packages/squad/ci/models.py", line 77, in really_fetch
    results = implementation.fetch(test_job)
  File "/srv/staging-qa-reports.linaro.org/lib/python3.5/site-packages/squad/ci/backend/lava.py", line 56, in fetch
    return self.__parse_results__(data, test_job, raw_logs)
  File "/srv/staging-qa-reports.linaro.org/lib/python3.5/site-packages/squad/ci/backend/lava.py", line 365, in __parse_results__
    res_log = self.__download_test_log__(raw_logs, result['log_start_line'], result['log_end_line'])
  File "/srv/staging-qa-reports.linaro.org/lib/python3.5/site-packages/squad/ci/backend/lava.py", line 236, in __download_test_log__
    return_lines.write(line.decode("utf-8"))
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xb1 in position 3: invalid start byte
```