### PR TITLE
Reduce number of queries

### DIFF
--- a/squad/core/comparison.py
+++ b/squad/core/comparison.py
@@ -187,7 +187,7 @@ class TestComparison(BaseComparison):
             if test_runs_ids.get(test_run.id, None) is None:
                 test_runs_ids[test_run.id] = (build, env)
 
-        for ids in split_dict(test_runs_ids, chunk_size=400):
+        for ids in split_dict(test_runs_ids, chunk_size=100):
             self.__extract_test_results__(ids)
 
         self.results = OrderedDict(sorted(self.results.items()))

--- a/squad/core/comparison.py
+++ b/squad/core/comparison.py
@@ -174,7 +174,7 @@ class TestComparison(BaseComparison):
         ).prefetch_related(
             'build',
             'environment',
-        ).only('id')
+        ).only('build', 'environment')
 
         test_runs_ids = {}
         for test_run in test_runs:

--- a/squad/core/comparison.py
+++ b/squad/core/comparison.py
@@ -167,6 +167,7 @@ class TestComparison(BaseComparison):
     def __init__(self, *builds):
         self.__intermittent__ = {}
         self.tests_with_issues = {}
+        self.__failures__ = OrderedDict()
         BaseComparison.__init__(self, *builds)
 
     def __extract_results__(self):
@@ -180,7 +181,7 @@ class TestComparison(BaseComparison):
         test_runs_ids = {}
         for test_run in test_runs:
             build = test_run.build
-            env = str(test_run.environment)
+            env = test_run.environment.slug
 
             self.all_environments.add(env)
             self.environments[build].add(env)
@@ -203,13 +204,22 @@ class TestComparison(BaseComparison):
         ).defer('log', 'metadata')
 
         for test in tests:
-            key = test_runs_ids.get(test.test_run_id)
+            build, env = test_runs_ids.get(test.test_run_id)
+
             full_name = join_name(test.suite_slug, test.name)
             if full_name not in self.results:
                 self.results[full_name] = OrderedDict()
+
+            key = (build, env)
             self.results[full_name][key] = test.status
+
             if test.has_known_issues:
-                self.tests_with_issues[test.id] = (full_name, key[1])
+                self.tests_with_issues[test.id] = (full_name, env)
+
+            if test.status == 'fail' and build.id == self.builds[-1].id:
+                if env not in self.__failures__:
+                    self.__failures__[env] = []
+                self.__failures__[env].append(test)
 
     def __resolve_intermittent_tests__(self):
         if len(self.tests_with_issues) == 0:
@@ -243,6 +253,10 @@ class TestComparison(BaseComparison):
                 predicate=lambda test, env: (test, env) not in self.__intermittent__
             )
         return self.__fixes__
+
+    @property
+    def failures(self):
+        return self.__failures__
 
     def apply_transitions(self, transitions):
         if transitions is None or len(transitions) == 0:

--- a/squad/core/notification.py
+++ b/squad/core/notification.py
@@ -58,7 +58,9 @@ class Notification(object):
 
     @property
     def summary(self):
-        return self.build.test_summary
+        summary = self.build.test_summary
+        summary.failures = self.comparison.failures
+        return summary
 
     @property
     def recipients(self):

--- a/squad/core/utils.py
+++ b/squad/core/utils.py
@@ -108,9 +108,10 @@ def split_dict(_dict, chunk_size=1):
     chunks = []
     chunk = {}
     counter = 0
+    keys = list(_dict.keys())
 
-    for key in _dict.keys():
-        chunk[key] = _dict[key]
+    for key in keys:
+        chunk[key] = _dict.pop(key)
         counter += 1
         if counter == chunk_size:
             chunks.append(chunk)
@@ -120,4 +121,12 @@ def split_dict(_dict, chunk_size=1):
     if len(chunk):
         chunks.append(chunk)
 
+    return chunks
+
+
+def split_list(_list, chunk_size=1):
+    chunks = []
+    while _list:
+        chunks.append(_list[:chunk_size])
+        _list = _list[chunk_size:]
     return chunks

--- a/test/core/test_build_summary.py
+++ b/test/core/test_build_summary.py
@@ -1,8 +1,9 @@
 from django.test import TestCase
 
 
-from squad.core.models import Group, BuildSummary
+from squad.core.models import Group, BuildSummary, KnownIssue
 from squad.core.statistics import geomean
+from squad.core.tasks import ReceiveTestRun
 
 
 PRECISION_ERROR = 10e-9
@@ -29,19 +30,36 @@ class BuildSummaryTest(TestCase):
         test_run1.metrics.create(name='bar', suite=self.suite1, result=2)
         test_run1.metrics.create(name='baz', suite=self.suite2, result=3)
         test_run1.metrics.create(name='qux', suite=self.suite2, result=4)
-        test_run1.tests.create(name='foo', suite=self.suite1, result=True)
-        test_run1.tests.create(name='bar', suite=self.suite1, result=False)
-        test_run1.tests.create(name='baz', suite=self.suite2, result=None)
-        test_run1.tests.create(name='qux', suite=self.suite2, result=False, has_known_issues=True)
 
         test_run2 = self.build1.test_runs.create(environment=self.env2)
         test_run2.metrics.create(name='foo', suite=self.suite1, result=2)
         test_run2.metrics.create(name='bar', suite=self.suite1, result=4)
         test_run2.metrics.create(name='baz', suite=self.suite2, result=6)
         test_run2.metrics.create(name='qux', suite=self.suite2, result=8)
-        test_run2.tests.create(name='foo', suite=self.suite1, result=True)
-        test_run2.tests.create(name='bar', suite=self.suite1, result=False)
-        test_run2.tests.create(name='baz', suite=self.suite2, result=None)
+
+        known_issue = KnownIssue.objects.create(title='dummy_issue', test_name='suite2/qux')
+        known_issue.environments.add(self.env1)
+        known_issue.save()
+
+        tests_json = """
+            {
+                "suite1/foo": "pass",
+                "suite1/bar": "fail",
+                "suite2/baz": "none",
+                "suite2/qux": "fail"
+            }
+        """
+        self.receive_testrun = ReceiveTestRun(self.project, update_project_status=False)
+        self.receive_testrun(self.build1.version, self.env1.slug, tests_file=tests_json)
+
+        tests_json = """
+            {
+                "suite1/foo": "pass",
+                "suite1/bar": "fail",
+                "suite2/baz": "none"
+            }
+        """
+        self.receive_testrun(self.build1.version, self.env2.slug, tests_file=tests_json)
 
     def test_build_with_empty_metrics(self):
         summary = BuildSummary.create_or_update(self.build2, self.env1)
@@ -75,7 +93,8 @@ class BuildSummaryTest(TestCase):
         values2 = [2, 4, 6, 8]
         new_test_run = self.build1.test_runs.create(environment=self.env1)
         new_test_run.metrics.create(name='new_foo', suite=self.suite1, result=5)
-        new_test_run.tests.create(name='new_foo', suite=self.suite1, result=True)
+
+        self.receive_testrun(self.build1.version, self.env1.slug, tests_file='{"suite1/new_foo": "pass"}')
 
         summary1 = BuildSummary.create_or_update(self.build1, self.env1)
         summary2 = BuildSummary.create_or_update(self.build1, self.env2)

--- a/test/core/test_test_comparison.py
+++ b/test/core/test_test_comparison.py
@@ -134,6 +134,15 @@ class TestComparisonTest(TestCase):
         fixes = comparison.fixes
         self.assertEqual(['c'], fixes['myenv'])
 
+    def test_failures(self):
+        # Check if failures are ok
+        comparison = TestComparison(self.build1)
+        self.assertEqual(['c'], sorted([t.full_name for t in comparison.failures['myenv']]))
+
+        self.receive_test_run(self.project1, '1', 'myenv', {'tests/another': 'fail'})
+        comparison = TestComparison(self.build1)
+        self.assertEqual(['c', 'tests/another'], sorted([t.full_name for t in comparison.failures['myenv']]))
+
     def test_regressions_no_previous_build(self):
         comparison = TestComparison.compare_builds(self.build1, None)
         regressions = comparison.regressions

--- a/test/core/test_test_summary.py
+++ b/test/core/test_test_summary.py
@@ -1,6 +1,7 @@
 from django.test import TestCase
 
-from squad.core.models import Group, Build, TestSummary
+from squad.core.models import Group, Build, TestSummary, KnownIssue
+from squad.core.tasks import ReceiveTestRun
 
 
 class TestSummaryTest(TestCase):
@@ -8,17 +9,26 @@ class TestSummaryTest(TestCase):
     def setUp(self):
         self.group = Group.objects.create(slug='mygroup')
         self.project = self.group.projects.create(slug='myproject')
+        self.receive_testrun = ReceiveTestRun(self.project, update_project_status=False)
 
     def test_basics(self):
         build = self.project.builds.create(version='1')
         env = self.project.environments.create(slug='env')
-        suite = self.project.suites.create(slug='tests')
-        test_run = build.test_runs.create(environment=env)
-        test_run.tests.create(name='foo', suite=suite, result=True)
-        test_run.tests.create(name='bar', suite=suite, result=False)
-        test_run.tests.create(name='baz', suite=suite, result=None)
-        test_run.tests.create(name='qux', suite=suite, result=False)
-        test_run.tests.create(name='pla', suite=suite, result=False, has_known_issues=True)
+
+        known_issue = KnownIssue.objects.create(title='dummy_issue', test_name='tests/pla')
+        known_issue.environments.add(env)
+        known_issue.save()
+
+        tests_json = """
+            {
+                "tests/foo": "pass",
+                "tests/bar": "fail",
+                "tests/baz": "none",
+                "tests/qux": "fail",
+                "tests/pla": "fail"
+            }
+        """
+        self.receive_testrun(build.version, env.slug, tests_file=tests_json)
 
         summary = TestSummary(build)
         self.assertEqual(5, summary.tests_total)
@@ -26,47 +36,37 @@ class TestSummaryTest(TestCase):
         self.assertEqual(2, summary.tests_fail)
         self.assertEqual(1, summary.tests_skip)
         self.assertEqual(1, summary.tests_xfail)
-        self.assertEqual(['tests/bar', 'tests/qux'], sorted([t.full_name for t in summary.failures['env']]))
 
     def test_test_summary_retried_tests(self):
         build = Build.objects.create(project=self.project, version='1.1')
         env = self.project.environments.create(slug='env')
-        suite = self.project.suites.create(slug='tests')
-        test_run1 = build.test_runs.create(environment=env)
-        test_run2 = build.test_runs.create(environment=env)
 
-        test_run1.tests.create(name='foo', suite=suite, result=True)
-        test_run2.tests.create(name='foo', suite=suite, result=True)
+        self.receive_testrun(build.version, env.slug, tests_file='{"tests/foo": "pass"}')
+        self.receive_testrun(build.version, env.slug, tests_file='{"tests/foo": "pass"}')
 
         summary = build.test_summary
-        self.assertEqual(1, summary.tests_total)
-        self.assertEqual(1, summary.tests_pass)
+        self.assertEqual(2, summary.tests_total)
+        self.assertEqual(2, summary.tests_pass)
 
-    def test_later_test_prevails(self):
+    def test_later_test_does_not_prevails(self):
         build = Build.objects.create(project=self.project, version='1.1')
         env = self.project.environments.create(slug='env')
-        suite = self.project.suites.create(slug='tests')
-        test_run1 = build.test_runs.create(environment=env)
-        test_run2 = build.test_runs.create(environment=env)
 
-        test_run1.tests.create(name='foo', suite=suite, result=True)
-        test_run2.tests.create(name='foo', suite=suite, result=False)
+        self.receive_testrun(build.version, env.slug, tests_file='{"tests/foo": "pass"}')
+        self.receive_testrun(build.version, env.slug, tests_file='{"tests/foo": "fail"}')
 
         summary = build.test_summary
-        self.assertEqual(1, summary.tests_total)
-        self.assertEqual(0, summary.tests_pass)
+        self.assertEqual(2, summary.tests_total)
+        self.assertEqual(1, summary.tests_pass)
         self.assertEqual(1, summary.tests_fail)
 
-    def test_counts_separate_environments_separately(self):
+    def test_count_separate_environments_separately(self):
         build = Build.objects.create(project=self.project, version='1.1')
         env1 = self.project.environments.create(slug='env1')
         env2 = self.project.environments.create(slug='env2')
-        suite = self.project.suites.create(slug='tests')
-        test_run_env1 = build.test_runs.create(environment=env1)
-        test_run_env2 = build.test_runs.create(environment=env2)
 
-        test_run_env1.tests.create(name='foo', suite=suite, result=True)
-        test_run_env2.tests.create(name='foo', suite=suite, result=False)
+        self.receive_testrun(build.version, env1.slug, tests_file='{"tests/foo": "pass"}')
+        self.receive_testrun(build.version, env2.slug, tests_file='{"tests/foo": "fail"}')
 
         summary = build.test_summary
         self.assertEqual(2, summary.tests_total)
@@ -77,12 +77,9 @@ class TestSummaryTest(TestCase):
         build = Build.objects.create(project=self.project, version='1.1')
         env1 = self.project.environments.create(slug='env1')
         env2 = self.project.environments.create(slug='env2')
-        suite = self.project.suites.create(slug='tests')
-        test_run_env1 = build.test_runs.create(environment=env1)
-        test_run_env2 = build.test_runs.create(environment=env2)
 
-        test_run_env1.tests.create(name='foo', suite=suite, result=True)
-        test_run_env2.tests.create(name='foo', suite=suite, result=False)
+        self.receive_testrun(build.version, env1.slug, tests_file='{"tests/foo": "pass"}')
+        self.receive_testrun(build.version, env2.slug, tests_file='{"tests/foo": "fail"}')
 
         summary = TestSummary(build, env1)
         self.assertEqual(1, summary.tests_total)

--- a/test/core/test_utils.py
+++ b/test/core/test_utils.py
@@ -1,5 +1,5 @@
 from django.test import TestCase
-from squad.core.utils import join_name, parse_name, xor, encrypt, decrypt, repeat_to_length, split_dict
+from squad.core.utils import join_name, parse_name, xor, encrypt, decrypt, repeat_to_length, split_dict, split_list
 
 
 class TestParseName(TestCase):
@@ -77,9 +77,31 @@ class TestSplitDict(TestCase):
         self.assertEqual({'a': 1}, chunks[0])
         self.assertEqual({'e': 5}, chunks[4])
 
+        _dict = {'a': 1, 'b': 2, 'c': 3, 'd': 4, 'e': 5}
         chunks = split_dict(_dict, chunk_size=2)
 
         self.assertEqual(3, len(chunks))
         self.assertEqual({'a': 1, 'b': 2}, chunks[0])
         self.assertEqual({'c': 3, 'd': 4}, chunks[1])
         self.assertEqual({'e': 5}, chunks[2])
+
+
+class TestSplitList(TestCase):
+
+    def test_split_list(self):
+        _list = [1, 2, 3, 4, 5, 6, 7]
+
+        chunks = split_list(_list)
+
+        self.assertEqual(7, len(chunks))
+        self.assertEqual([1], chunks[0])
+        self.assertEqual([7], chunks[6])
+
+        _list = [1, 2, 3, 4, 5, 6, 7]
+        chunks = split_list(_list, chunk_size=2)
+
+        self.assertEqual(4, len(chunks))
+        self.assertEqual([1, 2], chunks[0])
+        self.assertEqual([3, 4], chunks[1])
+        self.assertEqual([5, 6], chunks[2])
+        self.assertEqual([7], chunks[3])


### PR DESCRIPTION
This PR changes several snippets in the code, trying to minimize the number of trips to db, applying less load on it too:

1. Re-adjust [chunk size](https://github.com/Linaro/squad/blob/master/squad/core/comparison.py#L190) from 400 to 100. In a single threaded architecture (dev), 400 testrun-ids at a time proved to be the sweet spot, but on a multi-threaded one (staging and production), having multiple calls to that snippet makes things slow again.

2. Prefetch known_issues from failing tests. If a testrun contains 1000 tests with known_issues, this would result on 1000 extra queries in the DB. I just moved them to a separate method to be called after tests are processed

3. Simplify calculations for TestSummary using States instead of summing test-by-test. I also added what @terceiro asked in https://github.com/Linaro/squad/pull/619#discussion_r339012500. 