### PR TITLE
ci: lava: fetch jobs right away

### DIFF
--- a/squad/ci/backend/lava.py
+++ b/squad/ci/backend/lava.py
@@ -454,6 +454,4 @@ class Backend(BaseBackend):
         job.save()
         if job.job_status in self.complete_statuses:
             self.log_info("scheduling fetch for job %s" % job.job_id)
-            # introduce 2 min delay to allow LAVA for storing all results
-            # this workaround should be removed once LAVA issue is fixed
-            fetch.apply_async(args=[job.id], countdown=120)
+            fetch.apply_async(args=[job.id])

--- a/test/ci/backend/test_lava.py
+++ b/test/ci/backend/test_lava.py
@@ -744,11 +744,7 @@ class LavaTest(TestCase):
         )
 
         lava.receive_event('foo.com.testjob', {"job": '123', 'state': 'Finished', 'health': 'Complete'})
-        # this is workaround to LAVA issues
-        # it should be removed when LAVA bug is fixed
-        fetch.apply_async.assert_called_with(args=[testjob.id], countdown=120)
-        # proper solution below
-        # fetch.fetch.assert_called_with(testjob.id)
+        fetch.apply_async.assert_called_with(args=[testjob.id])
         self.assertEqual('Complete', TestJob.objects.get(pk=testjob.id).job_status)
 
     def test_receive_event_no_testjob(self):


### PR DESCRIPTION
Addresses https://github.com/Linaro/squad/issues/624 and removes workaround added in 50f694d965e5e19e46ae667ce99ff2e884c8d707
