### PR TITLE
Dockerfile: ignore version constraints from requirements.txt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN ln -sfT container_settings.py /app/squad/local_settings.py && \
     python3 -m squad.frontend && \
     ./manage.py collectstatic --noinput --verbosity 0 && \
     ./manage.py compilemessages && \
-    python3 setup.py develop --no-deps && \
+    REQ_IGNORE_VERSIONS=1 python3 setup.py develop --no-deps && \
     useradd --create-home squad && \
     mkdir -m 0755 /app/tmp && chown squad:squad /app/tmp
 

--- a/scripts/test-docker
+++ b/scripts/test-docker
@@ -4,3 +4,4 @@ set -exu
 
 docker build -t squad .
 docker run squad python3 manage.py test -v 3
+docker run squad squad-admin showmigrations

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,8 @@ def valid_requirement(req):
 
 requirements_txt = open('requirements.txt').read().splitlines()
 requirements = [req for req in requirements_txt if valid_requirement(req)]
+if os.getenv('REQ_IGNORE_VERSIONS'):
+    requirements = [req.split('>=')[0] for req in requirements]
 
 
 if len(sys.argv) > 1 and sys.argv[1] in ['sdist', 'bdist', 'bdist_wheel'] and not os.getenv('SQUAD_RELEASE'):


### PR DESCRIPTION
The version constraints in requirements.txt are needed when installing
from pypi, but when installing from Debian packages we can just trust
what's in the repository since we do run the tests against that.

The issue manifests when you call the installed commands (e.g.
squad-admin), but not when you call ./manage.py. So, also add an
explicit call to squad-admin to scripts/test-docker so we know if we
introduce a regression.