### PR TITLE
frontend: reduce query time fetching metric names

### DIFF
--- a/squad/frontend/queries.py
+++ b/squad/frontend/queries.py
@@ -1,16 +1,22 @@
 from django.utils.translation import ugettext as _
-from squad.core.models import Metric
-from squad.core.utils import join_name
+from squad.core.models import Metric, TestRun
+from squad.core.utils import join_name, split_list
 
 
 def get_metrics_list(project):
+    unique_names = set()
 
-    metric_set = Metric.objects.filter(
-        test_run__environment__project=project
-    ).values('suite__slug', 'name').order_by('suite__slug', 'name').distinct()
+    testruns = TestRun.objects.filter(environment__project=project).values('id').order_by('id')
+    test_runs_ids = [tr['id'] for tr in testruns]
+    for chunk in split_list(test_runs_ids, chunk_size=100):
+        metric_set = Metric.objects.filter(test_run_id__in=chunk).values('suite__slug', 'name')
+        for m in metric_set:
+            unique_names.add(join_name(m['suite__slug'], m['name']))
+
+    metric_names = [{"name": name} for name in sorted(unique_names)]
 
     metrics = [{"name": ":summary:", "label": _("Summary of all metrics per build")}]
     metrics += [{"name": ":dynamic_summary:", "label": _("Summary of selected metrics"), "dynamic": "yes"}]
     metrics += [{"name": ":tests:", "label": _("Test pass %"), "max": 100, "min": 0}]
-    metrics += [{"name": join_name(m['suite__slug'], m['name'])} for m in metric_set]
+    metrics += metric_names
     return metrics


### PR DESCRIPTION
From https://projects.linaro.org/browse/LSS-1059

> The loading time for the main art-metrics page is around 5-10s:
> https://qa-reports.linaro.org/art/master-baseline/metrics/
> 
> I was wondering if some things could be optimized to load faster, or show a progress bar.
> Due to varying server load, this can sometimes be up to 15 seconds.

This happens because querying the metric names was a bit too slow. I changed it so it uses similar strategy when querying tests using testrun ids. It improved locally.