### PR TITLE
core: test_history: handle tests with no metadata

### DIFF
--- a/squad/core/history.py
+++ b/squad/core/history.py
@@ -15,9 +15,9 @@ class TestResult(object):
         self.status = test.status
         self.test_run = test.test_run
         self.info = {
-            "test_description": test.metadata.description,
+            "test_description": test.metadata.description if test.metadata else '',
             "suite_instructions": test.suite.metadata.instructions_to_reproduce,
-            "test_instructions": test.metadata.instructions_to_reproduce,
+            "test_instructions": test.metadata.instructions_to_reproduce if test.metadata else '',
             "test_log": test.log
         }
 

--- a/test/core/test_history.py
+++ b/test/core/test_history.py
@@ -103,3 +103,11 @@ class TestHistoryTest(TestCase):
         self.assertNotIn(build2, history.results.keys())
 
         self.assertEqual(build1, history.top)
+
+    def test_no_metadata(self):
+        testrun = self.project1.builds.last().test_runs.last()
+        suite = testrun.tests.last().suite
+        testrun.tests.create(name='no_metadata_test', result=False, suite=suite)
+        history = TestHistory(self.project1, 'no_metadata_test')
+
+        self.assertIsNotNone(history.results)


### PR DESCRIPTION
This fixes hitting a situation like 

```
AttributeError at /lkft/linux-next-oe/build/next-20191024/tests/
'NoneType' object has no attribute 'description'
```

due to tests created in a way that do not have associated metadata (in plugins)