### PR TITLE
settings: add support to prefix-named queues

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -206,6 +206,10 @@ __ https://docs.djangoproject.com/en/1.11/topics/email/
   Useful when multiple environments share the same broker.
   Defaults to ``''``.
 
+* ``SQUAD_CELERY_POLL_INTERVAL``: Number of seconds a worker will sleep
+  after an empty answer from SQS before the next polling attempt.
+  Defaults to ``1``.
+
 User management
 ---------------
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -133,6 +133,10 @@ useful::
 
 By default, workers listen to all queues.
 
+For message brokers that support prefixed-queue names, SQUAD has the optional
+environment variable `SQUAD_CELERY_QUEUE_NAME_PREFIX`, that, if set, will
+prepend it before all queues.
+
 Further configuration
 ---------------------
 
@@ -198,6 +202,9 @@ __ https://docs.djangoproject.com/en/1.11/topics/email/
 * ``SQUAD_CELERY_BROKER_URL``: URL to the broker to be used by Celery for
   background jobs. Defaults to ``amqp://localhost:5672``.
 
+* ``SQUAD_CELERY_QUEUE_NAME_PREFIX``: Name to prefix all queues in Celery.
+  Useful when multiple environments share the same broker.
+  Defaults to ``''``.
 
 User management
 ---------------

--- a/squad/settings.py
+++ b/squad/settings.py
@@ -271,6 +271,7 @@ CELERY_BROKER_URL = os.getenv('SQUAD_CELERY_BROKER_URL')
 CELERY_BROKER_TRANSPORT_OPTIONS = {
     'max_retries': 5,
     'queue_name_prefix': os.getenv('SQUAD_CELERY_QUEUE_NAME_PREFIX', ''),
+    'polling_interval': os.getenv('SQUAD_CELERY_POLL_INTERVAL', 1),
 }
 CELERY_ACCEPT_CONTENT = ['json', 'msgpack', 'yaml']
 CELERY_TASK_SERIALIZER = 'msgpack'

--- a/squad/settings.py
+++ b/squad/settings.py
@@ -270,6 +270,7 @@ SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 CELERY_BROKER_URL = os.getenv('SQUAD_CELERY_BROKER_URL')
 CELERY_BROKER_TRANSPORT_OPTIONS = {
     'max_retries': 5,
+    'queue_name_prefix': os.getenv('SQUAD_CELERY_QUEUE_NAME_PREFIX', ''),
 }
 CELERY_ACCEPT_CONTENT = ['json', 'msgpack', 'yaml']
 CELERY_TASK_SERIALIZER = 'msgpack'


### PR DESCRIPTION
This allows celery to create queues with user defined prefix names
ref: http://docs.celeryproject.org/en/latest/getting-started/brokers/sqs.html#queue-prefix