### PR TITLE
settings: turn on debug only when needed

### DIFF
--- a/squad/settings.py
+++ b/squad/settings.py
@@ -45,7 +45,7 @@ if not os.path.exists(secret_key_file):
 
 SECRET_KEY = open(secret_key_file).read()
 
-DEBUG = os.getenv('ENV') != 'production'
+DEBUG = os.getenv('ENV') not in ['production', 'staging']
 
 ALLOWED_HOSTS = ['*']
 


### PR DESCRIPTION
This will turn `DEBUG` only when `ENV` is not production or staging.

`ENV` was hard coded to "production" in both production and staging deployments: https://github.com/Linaro/qa-reports.linaro.org/blob/master/ansible/roles/squad/templates/environment#L13

I fixed that in the PR https://github.com/Linaro/qa-reports.linaro.org/commit/2f2cf904c022afae557e63754d1db242bf27b220#diff-818648361d20d54acf2e16ac713065d7R14 so that it is set to their correct environment accordingly.