### PR TITLE
Enabled filtering on created_at date for builds in api

### DIFF
--- a/squad/api/rest.py
+++ b/squad/api/rest.py
@@ -82,7 +82,9 @@ class BuildFilter(filters.FilterSet):
     class Meta:
         model = Build
         fields = {'version': ['exact', 'in', 'startswith'],
-                  'id': ['exact']}
+                  'id': ['exact'],
+                  'created_at': ['exact', 'lt', 'lte', 'gt', 'gte'],
+                  }
 
 
 def unordered_build_queryset(request):

--- a/test/api/test_rest.py
+++ b/test/api/test_rest.py
@@ -446,6 +446,11 @@ class RestApiTest(APITestCase):
         data = self.hit('/api/builds/%d/testjobs/' % self.build.id)
         self.assertEqual(1, len(data['results']))
 
+    def test_build_filter(self):
+        created_at = str(self.build3.created_at.isoformat()).replace('+00:00', 'Z')
+        data = self.hit('/api/builds/?created_at=%s' % created_at)
+        self.assertEqual(1, len(data['results']))
+
     def test_testjob(self):
         data = self.hit('/api/testjobs/%d/' % self.testjob.id)
         self.assertEqual('myenv', data['environment'])


### PR DESCRIPTION
Enabled filtering on created date for builds in rest api. This will be required for pulling specific builds from the client side reporting tool.