### PR TITLE
frontend: project_settings: add advanced settings tab

### DIFF
--- a/squad/frontend/project_settings.py
+++ b/squad/frontend/project_settings.py
@@ -17,6 +17,12 @@ class ProjectForm(forms.ModelForm):
                   'notification_timeout', 'data_retention_days']
 
 
+class ProjectFormAdvanced(forms.ModelForm):
+    class Meta:
+        model = Project
+        fields = ['project_settings']
+
+
 @auth_write
 def settings(request, group, project):
     if request.method == "POST":
@@ -33,6 +39,24 @@ def settings(request, group, project):
         'form': form,
     }
     return render(request, 'squad/project_settings/index.jinja2', context)
+
+
+@auth_write
+def advanced_settings(request, group, project):
+    if request.method == "POST":
+        form = ProjectFormAdvanced(request.POST, instance=request.project)
+        if form.is_valid():
+            form.save()
+            return redirect(request.path)
+    else:
+        form = ProjectFormAdvanced(instance=request.project)
+
+    context = {
+        'group': request.group,
+        'project': request.project,
+        'form': form,
+    }
+    return render(request, 'squad/project_settings/advanced.jinja2', context)
 
 
 @auth_write
@@ -81,5 +105,6 @@ def delete(request, group_slug, project_slug):
 urls = [
     url('^$', settings, name='project-settings'),
     url(r'^thresholds/$', thresholds, name='project-settings-thresholds'),
+    url(r'^advanced/$', advanced_settings, name='project-advanced-settings'),
     url(r'^delete/$', delete, name='project-settings-delete'),
 ]

--- a/squad/frontend/templates/squad/project_settings/advanced.jinja2
+++ b/squad/frontend/templates/squad/project_settings/advanced.jinja2
@@ -1,0 +1,10 @@
+{% extends "squad/project_settings/base.jinja2" %}
+
+{% block settings %}
+    <h1>{{ _('Advanced settings') }}</h1>
+    
+    <form method="POST">
+        {{crispy(form)}}
+        <input class='btn btn-primary' type="submit" value="{{ _('Save') }}" />
+    </form>
+{% endblock %}

--- a/squad/frontend/templates/squad/project_settings/base.jinja2
+++ b/squad/frontend/templates/squad/project_settings/base.jinja2
@@ -18,6 +18,7 @@
         {% with url_name=request.resolver_match.url_name %}
         <li class="list-group-item {% if url_name == "project-settings" %}active{% endif %}"><a href="{{project_section_url(project, 'project-settings')}}">{{ _('Basics') }}</a></li>
         <li class="list-group-item {% if url_name == "project-settings-thresholds" %}active{% endif %}"><a href="{{project_section_url(project, 'project-settings-thresholds')}}">{{ _('Metric thresholds') }}</a></li>
+        <li class="list-group-item {% if url_name == "project-advanced-settings" %}active{% endif %}"><a href="{{project_section_url(project, 'project-advanced-settings')}}">{{ _('Advanced') }}</a></li>
         <li class="list-group-item {% if url_name == "project-settings-delete" %}active{% endif %}"><a href="{{project_section_url(project, 'project-settings-delete')}}">{{ _('Delete project') }}</a></li>
         {% endwith %}
       </ul>


### PR DESCRIPTION
This will allow project admins to edit `project_settings` field in the self service menu, without having to go to Django admin page