### PR TITLE
core: admin: enable `save as new` option for projects

### DIFF
--- a/squad/core/admin.py
+++ b/squad/core/admin.py
@@ -51,6 +51,7 @@ class ProjectAdmin(admin.ModelAdmin):
     list_display = ['__str__', 'is_public', 'moderate_notifications', 'custom_email_template']
     list_filter = ['group', 'is_public', 'moderate_notifications', 'custom_email_template']
     inlines = [EnvironmentInline, SubscriptionInline, AdminSubscriptionInline]
+    save_as = True
 
 
 def __resend__notification__(queryset, approve):


### PR DESCRIPTION
This one-liner will allow users to duplicate projects with a "Save As New" option (asked by @danrue):
It'll go from that:
![Screenshot from 2020-01-28 00-20-57](https://user-images.githubusercontent.com/2254825/73233320-e3a50800-4164-11ea-98e6-72f7910263fd.png)

to this:
![Screenshot from 2020-01-28 00-21-18](https://user-images.githubusercontent.com/2254825/73233327-ea337f80-4164-11ea-8b7c-53e22a9c1a77.png)

Ref: https://stackoverflow.com/questions/180809/in-the-django-admin-interface-is-there-a-way-to-duplicate-an-item