### PR TITLE
Allow users to switch test results table layout

### DIFF
--- a/squad/frontend/static/main.css
+++ b/squad/frontend/static/main.css
@@ -354,3 +354,33 @@ a[ng-click] {
 ul#compare-menu {
   z-index: 2000;
 }
+
+.results-layout-icon, .results-layout-icon:hover {
+    color: black;
+    cursor: pointer;
+    font-size: 25px;
+    margin: 5px;
+}
+
+.fa-disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+table.test-results-box {
+    margin-left: 5px;
+}
+
+table.test-results-box thead tr:first-child {
+    background-color: #DDD;
+}
+
+a.toggle-test-results {
+    display: inline;
+    margin-left: 5px;
+    background-color: #777;
+    padding: 2px;
+    padding-left: 5px;
+    padding-right: 5px;
+    color: white;
+}

--- a/squad/frontend/templates/squad/_test_results_envbox.jinja2
+++ b/squad/frontend/templates/squad/_test_results_envbox.jinja2
@@ -1,0 +1,32 @@
+        {% for environment in test_results.environments %}
+        <table id='test-results-{{ environment.slug }}' class='test-results-box table table-bordered'>
+            <thead>
+                <tr>
+                    <th colspan="2">
+                        {{ environment }}
+                        {% set hide_env = 'hide_' + environment.slug.replace('-', '_') -%}
+                        <a ng-click="{{ hide_env }} = !{{ hide_env }}" class="toggle-test-results">
+                            <i ng-hide="!{{ hide_env }}" class="fa fa-minus"></i>
+                            <i ng-hide="{{ hide_env }}" class="fa fa-plus"></i>
+                        </a>
+                    </th>
+                </tr>
+            </thead>
+            <tbody ng-hide="!{{ hide_env }}" aria-hidden="false">
+                <tr>
+                    <th>{{ _('Suite') }}</th>
+                    <th>{{ _('Test Results') }}</th>
+                </tr>
+                {% for suite, statuses in environment.suites %}
+                <tr>
+                    <td>{{ suite }}</td>
+                    <td>
+                        {% for status in statuses %}
+                        <a href="{{testrun_suite_tests_url(project.group, project, build, status)}}">{{ status.test_run.id }} {% include "squad/_test_results_summary.jinja2" %}</a><br />
+                        {% endfor %}
+                    </td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+        {% endfor %}

--- a/squad/frontend/templates/squad/_test_results_suitebox.jinja2
+++ b/squad/frontend/templates/squad/_test_results_suitebox.jinja2
@@ -1,0 +1,32 @@
+        {% for suite in test_results.suites %}
+        <table id='test-results-{{ suite.slug }}' class='test-results-box table table-bordered'>
+            <thead>
+                <tr>
+                    <th colspan="2">
+                        {{ suite }}
+                        {% set hide_suite = 'hide_' + suite.slug.replace('-', '_') -%}
+                        <a ng-click="{{ hide_suite }} = !{{ hide_suite }}" class="toggle-test-results">
+                            <i ng-hide="!{{ hide_suite }}" class="fa fa-minus"></i>
+                            <i ng-hide="{{ hide_suite }}" class="fa fa-plus"></i>
+                        </a>
+                    </th>
+                </tr>
+            </thead>
+            <tbody ng-hide="!{{ hide_suite }}" aria-hidden="false">
+                <tr>
+                    <th>{{ _('Environment') }}</th>
+                    <th>{{ _('Test Results') }}</th>
+                </tr>
+                {% for environment, statuses in suite.environments %}
+                <tr>
+                    <td>{{ environment }}</td>
+                    <td>
+                        {% for status in statuses %}
+                        <a href="{{testrun_suite_tests_url(project.group, project, build, status)}}">{{ status.test_run.id }} {% include "squad/_test_results_summary.jinja2" %}</a><br />
+                        {% endfor %}
+                    </td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+        {% endfor %}

--- a/squad/frontend/templates/squad/_test_results_table.jinja2
+++ b/squad/frontend/templates/squad/_test_results_table.jinja2
@@ -1,0 +1,75 @@
+        <table class='test-results'>
+            <thead>
+                <tr>
+                    <th style='width: 150px'>{{ _('Suite') }}</th>
+                    {% for environment in test_results.environments  %}
+                    <th>{{environment}}</th>
+                    {% endfor %}
+                </tr>
+            </thead>
+            {% for suite, results in test_results.data.items() %}
+	        <tr id='tests-{{suite.id}}' ng-show='match("tests-{{suite.id}}") || match("details-{{suite.id}}")'>
+                <td ng-click='toggle_details("details-{{suite.id}}")'>
+		            {{suite}}
+		            <small>
+		                <i class='fa fa-chevron-down pull-right' ng-show='!details_visible["details-{{suite.id}}"]'></i>
+		                <i class='fa fa-chevron-up pull-right' ng-show='details_visible["details-{{suite.id}}"]'></i>
+		            </small>
+		        </td>
+                {% for environment in test_results.environments %}
+                    {% with entry=results[environment] %}
+                        {% if entry %}
+                            {% if entry.has_failures %}
+                            <td class='fail'><a class='fa fa-times text-danger' href='#' onclick='return false' ng-click='toggle_details("details-{{suite.id}}")'></a></td>
+                            {% elif entry.has_known_failures %}
+                            <td class='xfail'><a class='fa fa-bug text-info' href='#' onclick='return false' ng-click='toggle_details("details-{{suite.id}}")'></a></td>
+                            {% else %}
+                            <td class='pass'><a class='fa fa-check text-success' href='#' onclick='return false' ng-click='toggle_details("details-{{suite.id}}")'></a></td>
+                            {% endif %}
+                        {% else %}
+                        <td></td>
+                        {% endif %}
+                    {% endwith %}
+                {% endfor %}
+            </tr>
+	        <tr id='details-{{suite.id}}' ng-show='details_visible["details-{{suite.id}}"]'>
+                <td></td>
+                <td colspan="{{test_results.environments|length}}">
+		            {% with entries=results.values() %}
+                    <table class='test-results-details'>
+                        <tr>
+                            <th>
+				                <i class='fa fa-microchip'></i>{{ _('Test Run') }}
+				            </th>
+                            <th>
+				                <i class='fa fa-cog'></i>{{ _('Environment') }}
+				            </th>
+                            <th>
+				                <i class='fa fa-check-square-o'></i>{{ _('Test Results') }}
+				            </th>
+                        </tr>
+                        {% for entry in entries %}
+                            {% for status in entry.statuses %}
+                                <tr id='details-row-{{status.id}}' ng-show='details_visible["details-{{suite.id}}"]'>
+                                    <td>
+                                        <a href="{{url("testrun", args=[project.group.slug, project.slug, build.version, status.test_run.job_id])}}">{{status.test_run.job_id}}</a>
+                                    </td>
+                                    <td>
+                                        <a href="{{url("testrun", args=[project.group.slug, project.slug, build.version, status.test_run.job_id])}}">{{status.environment}}</a>
+                                    </td>
+                                    <td>
+                                        <a href="{{testrun_suite_tests_url(project.group, project, build, status)}}">{% include "squad/_test_results_summary.jinja2" %}</a>
+                                    </td>
+                                </tr>
+                            {% endfor %}
+                        {% endfor %}
+                    </table>
+                    {% endwith %}
+                </td>
+            </tr>
+            {% endfor %}
+        </table>
+
+        {% block javascript %}
+        <script type="module" src='{{static("squad/table.js")}}'></script>
+        {% endblock %}

--- a/squad/frontend/templates/squad/build.jinja2
+++ b/squad/frontend/templates/squad/build.jinja2
@@ -25,7 +25,21 @@
 </div>
 
 <div ng-controller='FilterController' data-param="filter-tests">
-<h2>{{ _('Test results') }}</h2>
+<h2 id="test-results">
+    <span class="pull-left">{{ _('Test results') }}</span>
+    <div class="dropdown" style="z-index: 1002;">
+        &nbsp;
+        <button class="btn btn-default dropdown-toggle" type="button" id="test_results_dropdown_menu" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            {{ _('by environments') if results_layout == 'envbox' else _('by suites') if results_layout == 'suitebox' else _('suites x evironments') }}
+            <span class="caret"></span>
+        </button>
+        <ul class="dropdown-menu" aria-labelledby="test_results_dropdown_menu">
+            <li{% if results_layout == 'envbox' %} class="disabled"{% endif %}><a class="dropdown-item" href="?results_layout=envbox#test-results">by environments</a></li>
+            <li{% if results_layout == 'suitebox' %} class="disabled"{% endif %}><a class="dropdown-item" href="?results_layout=suitebox#test-results">by suites</a></li>
+            <li{% if results_layout == 'table' %} class="disabled"{% endif %}><a class="dropdown-item" href="?results_layout=table#test-results">suites x environments</a></li>
+        </ul>
+    </div>
+</h2>
 <div class='row row-bordered'>
     <div class='col-md-12 col-sm-12'>
         <form class='filter'>
@@ -36,86 +50,14 @@
 </div>
 <div class="row" id="test-results">
     <div class='col-md-12 col-sm-12'>
-        <table class='test-results'>
-            <thead>
-                <tr>
-                    <th style='width: 150px'>{{ _('Suite') }}</th>
-                    {% for environment in test_results.environments  %}
-                    <th>{{environment}}</th>
-                    {% endfor %}
-                </tr>
-            </thead>
-            {% for suite, results in test_results.data.items() %}
-	    <tr id='tests-{{suite.id}}' ng-show='match("tests-{{suite.id}}") || match("details-{{suite.id}}")'>
-                <td ng-click='toggle_details("details-{{suite.id}}")'>
-		    {{suite}}
-		    <small>
-		    <i class='fa fa-chevron-down pull-right' ng-show='!details_visible["details-{{suite.id}}"]'></i>
-		    <i class='fa fa-chevron-up pull-right' ng-show='details_visible["details-{{suite.id}}"]'></i>
-		    </small>
-		</td>
-                {% for environment in test_results.environments %}
-                    {% with entry=results[environment] %}
-                        {% if entry %}
-                            {% if entry.has_failures %}
-                            <td class='fail'><a class='fa fa-times text-danger' href='#' onclick='return false' ng-click='toggle_details("details-{{suite.id}}")'></a></td>
-                            {% elif entry.has_known_failures %}
-                            <td class='xfail'><a class='fa fa-bug text-info' href='#' onclick='return false' ng-click='toggle_details("details-{{suite.id}}")'></a></td>
-                            {% else %}
-                            <td class='pass'><a class='fa fa-check text-success' href='#' onclick='return false' ng-click='toggle_details("details-{{suite.id}}")'></a></td>
-                            {% endif %}
-                        {% else %}
-                        <td></td>
-                        {% endif %}
-                    {% endwith %}
-                {% endfor %}
-            </tr>
-	    <tr id='details-{{suite.id}}' ng-show='details_visible["details-{{suite.id}}"]'>
-                <td></td>
-                <td colspan="{{test_results.environments|length}}">
-		    {% with entries=results.values() %}
-                        <table class='test-results-details'>
-                            <tr>
-                                <th>
-				    <i class='fa fa-microchip'></i>
-				    {{ _('Test Run') }}
-				</th>
-                                <th>
-				    <i class='fa fa-cog'></i>
-				    {{ _('Environment') }}
-				</th>
-                                <th>
-				    <i class='fa fa-check-square-o'></i>
-				    {{ _('Test Results') }}
-				</th>
-                            </tr>
-                        {% for entry in entries %}
-                            {% for status in entry.statuses %}
-			    <tr id='details-row-{{status.id}}' ng-show='details_visible["details-{{suite.id}}"]'>
-                                    <td>
-					<a href="{{url("testrun", args=[project.group.slug, project.slug, build.version, status.test_run.job_id])}}">
-                                            {{status.test_run.job_id}}
-                                        </a>
-                                    </td>
-                                    <td>
-					<a href="{{url("testrun", args=[project.group.slug, project.slug, build.version, status.test_run.job_id])}}">
-					    {{status.environment}}
-					</a>
-                                    </td>
-                                    <td>
-					<a href="{{testrun_suite_tests_url(project.group, project, build, status)}}">
-                                        {% include "squad/_test_results_summary.jinja2" %}
-                                        </a>
-                                    </td>
-                                </tr>
-                            {% endfor %}
-                        {% endfor %}
-                        </table>
-                    {% endwith %}
-                </td>
-            </tr>
-            {% endfor %}
-        </table>
+        <br />
+        {% if results_layout == 'suitebox' %}
+            {% include "squad/_test_results_suitebox.jinja2" %}
+        {% elif results_layout == 'envbox' %}
+            {% include "squad/_test_results_envbox.jinja2" %}
+        {% else %}
+            {% include "squad/_test_results_table.jinja2" %}
+        {% endif %}
     </div>
 </div>
 </div> <!-- ng-controller=FilterController -->
@@ -205,7 +147,6 @@
 {% block javascript %}
 <script type="text/javascript" src='{{static("select2.js/select2.min.js")}}'></script>
 <script type="module" src='{{static("squad/build.js")}}'></script>
-<script type="module" src='{{static("squad/table.js")}}'></script>
 {% endblock %}
 
 {% block styles %}

--- a/squad/frontend/views.py
+++ b/squad/frontend/views.py
@@ -248,6 +248,8 @@ def build(request, group_slug, project_slug, version):
     for status in __statuses__:
         test_results.add_status(status)
 
+    test_results.environments = sorted(test_results.environments, key=lambda e: e.slug)
+
     context = {
         'project': project,
         'build': build,


### PR DESCRIPTION
This was asked by @danrue and @mwasilew when the number of environments is too big (I'm assuming a number > 8) viewing suites in the build view gets hard.

I added an option so that the user can toggle the layout to this one below:
![Screenshot from 2020-01-30 02-17-03](https://user-images.githubusercontent.com/2254825/73422454-c9eff600-4307-11ea-97f8-44b3eeb81164.png)

Clicking '+' a table like the one below is shown:
![Screenshot from 2020-01-30 02-17-25](https://user-images.githubusercontent.com/2254825/73422476-dbd19900-4307-11ea-90d7-78229651fb25.png)

**NOTE 1** for builds with number of environments less than 8, the default behavior won't change. If that's more than 8, the 'box' view will kick in, but users can still click on the table layout to have the old style back. The opposite is valid, meaning if a build has less than 8 environments, users can simply click on 'box' view.

**NOTE 2** as requested by @danrue and @mrchapp , environments are now sorted in alphabetical order.