### PR TITLE
ci: tasks: avoid multiple submissions

### DIFF
--- a/test/ci/test_tasks.py
+++ b/test/ci/test_tasks.py
@@ -126,3 +126,10 @@ class SubmitTest(TestCase):
         retry.assert_called_with(exc=exception, countdown=3600)
         self.test_job.refresh_from_db()
         self.assertEqual(self.test_job.failure, "TEMPORARY ERROR")
+
+    @patch('squad.ci.models.Backend.submit')
+    def test_avoid_multiple_submissions(self, submit_method):
+        self.test_job.submitted = True
+        self.test_job.save()
+        submit.apply(args=[self.test_job.id])
+        self.assertFalse(submit_method.called)


### PR DESCRIPTION
Because of the lab outage this morning, failed attempts to `submit` tasks are kept in the workers to be retried in one hour, which is the exact time for SQS to re-queue them (due to visibility timeout is also 1 hour). Several tasks got picked by multiple workers, thus submitting exact same tasks multiple times to labs.

This PR makes sure to not submit tasks if the testjob has already been submitted. 