### PR TITLE
Clear testjob failure

### DIFF
--- a/squad/ci/tasks.py
+++ b/squad/ci/tasks.py
@@ -43,6 +43,7 @@ def submit(self, job_id):
     if not test_job.submitted:
         try:
             test_job.backend.submit(test_job)
+            test_job.failure = None
             test_job.save()
         except SubmissionIssue as issue:
             logger.error("submitting job %s to %s: %s" % (test_job.id, test_job.backend.name, str(issue)))


### PR DESCRIPTION
If a test job submission fails, the error message is saved in `failure` attribute. But in a successful retry afterwards, the failure message was still going to show up.

This PR clears `failure` whenever a test job submission was successful.

Also, I changed the criteria do display the successful and error icons in the test job page. People would get confused to see the image below:

![Screenshot from 2020-02-13 21-39-50](https://user-images.githubusercontent.com/2254825/74491115-79e96580-4ea9-11ea-985d-a9c8e4d2610f.png)

The two test jobs at the bottom had their submission failed in the first attempt, but they were successful later on, but the error icon would still be displayed, which is confusing.