### PR TITLE
core: tasks: notification: handle ETA in notification_timeout

### DIFF
--- a/squad/celery.py
+++ b/squad/celery.py
@@ -4,6 +4,7 @@ import logging
 import os
 import resource
 import sys
+import time
 
 from celery import Celery
 from celery import Task
@@ -40,6 +41,13 @@ class SquadCelery(Celery):
         kw = {'base': MemoryUseLoggingTask}
         kw.update(kwargs)
         return super(SquadCelery, self).task(*args, **kw)
+
+    def send_task(self, *args, **options):
+
+        if settings.CELERY_BROKER_URL.startswith('sqs'):
+            options['MessageGroupId'] = str(time.time())
+
+        return super(SquadCelery, self).send_task(*args, **options)
 
 
 app = SquadCelery('squad')


### PR DESCRIPTION
If task-A has an ETA of 10 minutes gets picked by a worker, a given task-B with an ETA of 1 minute wouldn't be delivered to any worker because of the FIFO strategy. Only after 10 minutes, task-B would've been delivered to workers.

To prevent that behavior, the SQS documentation [1] says that the `MessageGroupId` should be set to different values. This attribute is used in case where tasks order are crucial, but that's not the case of SQUAD when processing notifications.                                                                                                                                                                                   

ref:
[1] https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/using-messagegroupid-property.html
