### PR TITLE
Add submit test results example with results

### DIFF
--- a/doc/ci.rst
+++ b/doc/ci.rst
@@ -61,7 +61,7 @@ Example (with test job definition as POST parameter)::
 
     $ DEFINITION="$(cat /path/to/definition.txt)"
     $ curl \
-        --header "Auth-Token: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" \
+        --header "Auth-Token: $SQUAD_TOKEN" \
         --form backend=lava \
         --form definition="$DEFINITION" \
         https://squad.example.com/api/submitjob/my-group/my-project/x.y.z/my-ci-env
@@ -69,7 +69,7 @@ Example (with test job definition as POST parameter)::
 Example (with test job definition as file upload)::
 
     $ curl \
-        --header "Auth-Token: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" \
+        --header "Auth-Token: $SQUAD_TOKEN" \
         --form backend=lava \
         --form definition=@/path/to/definition.txt \
         https://squad.example.com/api/submitjob/my-group/my-project/x.y.z/my-ci-env
@@ -99,7 +99,7 @@ the results and do post processing. The API is following:
 Example (with test job definition as POST parameter)::
 
     $ curl \
-        --header "Auth-Token: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" \
+        --header "Auth-Token: $SQUAD_TOKEN" \
         --form backend=lava \
         --form testjob_id=123456 \
         https://squad.example.com/api/watchjob/my-group/my-project/x.y.z/my-ci-env

--- a/doc/intro.rst
+++ b/doc/intro.rst
@@ -98,6 +98,26 @@ Example with test data as regular ``POST`` parameters::
         --form attachment=@/path/to/extra-info.txt \
         https://squad.example.com/api/submit/my-group/my-project/x.y.z/my-ci-env
 
+Example with test data using Python's requests library:
+
+.. code:: python
+    import json
+    import requests
+
+    tests = json.dumps({"test1": "pass", "test2": "fail"})
+    metrics = json.dumps({"metric1": 21, "metric2": 4})
+    metadata = json.dumps({"foo": "bar", "baz": "qux"})
+    log = 'log text ...'
+
+    headers = {"Auth-Token": 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'}
+    url = 'https://squad.example.com/api/submit/my-group/my-project/x.y.z/my-ci-env'
+    data = {"metadata": metadata, "log": log, "tests": tests_file}
+
+    result = requests.post(url, headers=headers, data=data)
+    if not result.ok:
+        print(f"Error submitting to qa-reports: {result.reason}: {result.text}")
+
+
 Since test results should always come from automation systems, the API
 is the only way to submit results into the system. Even manual testing
 should be automated with a driver program that asks for user input, and

--- a/doc/intro.rst
+++ b/doc/intro.rst
@@ -77,7 +77,7 @@ the format of the data files.
 Example with test data as file uploads::
 
     $ curl \
-        --header "Auth-Token: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" \
+        --header "Auth-Token: $SQUAD_TOKEN" \
         --form tests=@/path/to/test-results.json \
         --form metrics=@/path/to/metrics.json \
         --form metadata=@/path/to/metadata.json \
@@ -89,7 +89,7 @@ Example with test data as file uploads::
 Example with test data as regular ``POST`` parameters::
 
     $ curl \
-        --header "Auth-Token: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" \
+        --header "Auth-Token: $SQUAD_TOKEN" \
         --form tests='{"test1": "pass", "test2": "fail"}' \
         --form metrics='{"metric1": 21, "metric2": 4}' \
         --form metadata='{"foo": "bar", "baz": "qux"}' \
@@ -103,13 +103,14 @@ Example with test data using Python's requests library:
 .. code:: python
     import json
     import requests
+    import os
 
     tests = json.dumps({"test1": "pass", "test2": "fail"})
     metrics = json.dumps({"metric1": 21, "metric2": 4})
     metadata = json.dumps({"foo": "bar", "baz": "qux"})
     log = 'log text ...'
 
-    headers = {"Auth-Token": 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'}
+    headers = {"Auth-Token": os.getenv('SQUAD_TOKEN')}
     url = 'https://squad.example.com/api/submit/my-group/my-project/x.y.z/my-ci-env'
     data = {"metadata": metadata, "log": log, "tests": tests_file}
 

--- a/doc/lava_usecase.rst
+++ b/doc/lava_usecase.rst
@@ -67,7 +67,7 @@ api for submitting a new test job::
 
     wget https://validation.linaro.org/static/docs/v2/examples/test-jobs/qemu-pipeline-first-job.yaml
     curl localhost:8000/api/submitjob/<group-slug>/<project-slug>/<build-version>/<env> \
-         --header "Auth-Token: <squad-token>" \
+         --header "Auth-Token: $SQUAD_TOKEN" \
          --form "backend=<backend-name>" \
          --form "definition=@qemu-pipeline-first-job.yaml"
 

--- a/doc/plugins.rst
+++ b/doc/plugins.rst
@@ -118,7 +118,7 @@ by a freshly opened Github Pull Request::
 
     $ curl \
         -X POST \
-        --header "Auth-Token: xxxxxxxxxxxxxxxxx" \
+        --header "Auth-Token: $SQUAD_TOKEN" \
         --patch_source=your-github-patch-source \
         --patch_baseline=build-v1 \
         --patch_id=the_owner/the_repo/8223a534d7bf \
@@ -150,7 +150,7 @@ by a freshly created change::
 
     $ curl \
         -X POST \
-        --header "Auth-Token: xxxxxxxxxxxxxxxxx" \
+        --header "Auth-Token: $SQUAD_TOKEN" \
         --patch_source=your-gerrit-patch-source \
         --patch_baseline=build-v1 \
         --patch_id=change-id/patchset \

--- a/squad/core/tasks/__init__.py
+++ b/squad/core/tasks/__init__.py
@@ -73,6 +73,8 @@ class ValidateTestRun(object):
 
         if "job_id" not in metadata.keys():
             raise exceptions.InvalidMetadata("job_id is mandatory in metadata")
+        elif type(metadata['job_id']) not in [int, str]:
+            raise exceptions.InvalidMetadata('job_id should be an integer or a string')
         elif '/' in metadata['job_id']:
             raise exceptions.InvalidMetadata('job_id cannot contain the "/" character')
 

--- a/test/core/test_tasks.py
+++ b/test/core/test_tasks.py
@@ -613,6 +613,11 @@ class TestValidateTestRun(TestCase):
     def test_invalid_job_id(self):
         self.assertInvalidMetadata('{"job_id": "foo/bar"}')
 
+    def test_invalid_job_id_data_type(self):
+        self.assertInvalidMetadata('{"job_id": 1.2}')
+        self.assertInvalidMetadata('{"job_id": [1,2]}')
+        self.assertInvalidMetadata('{"job_id": {"a": 1}}')
+
     # ~~~~~~~~~~~~ TESTS FOR METRICS ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     def assertInvalidMetrics(self, metrics, exception=exceptions.InvalidMetricsData):
         validate = ValidateTestRun()


### PR DESCRIPTION
This PR adds an example of submitting test results through the api using Python's requests library. Also, it fixes a bug that happened when a float value was passed as job_id.

Closes #656 