### PR TITLE
requirements.txt: top off django version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 celery
 coreapi
 django_crispy_forms
-Django>=2.2
+Django>=2.2,<3.0
 django-cors-headers
 django-simple-history
 django_filter>=2.0


### PR DESCRIPTION
This will prevent Django 3.0 from being installed thus prevent our builds in travis from failing