### PR TITLE
core: models: finish builds status earlier

### DIFF
--- a/squad/core/models.py
+++ b/squad/core/models.py
@@ -470,18 +470,17 @@ class Build(models.Model):
             expected = count['expected']
             received = count['received']
             env_name = count['name']
-            if expected == 0:
-                continue
-            if received == 0:
-                reasons.append("No test runs for %s received so far" % env_name)
-            if expected and received < expected:
-                reasons.append(
-                    "%d test runs expected for %s, but only %d received so far" % (
-                        expected,
-                        env_name,
-                        received,
+            if expected and expected > 0:
+                if received == 0:
+                    reasons.append("No test runs for %s received so far" % env_name)
+                elif received < expected:
+                    reasons.append(
+                        "%d test runs expected for %s, but only %d received so far" % (
+                            expected,
+                            env_name,
+                            received,
+                        )
                     )
-                )
         return (len(reasons) == 0, reasons)
 
     @property

--- a/test/core/test_build.py
+++ b/test/core/test_build.py
@@ -90,13 +90,13 @@ class BuildTest(TestCase):
 
         self.assertEqual(metadata1, metadata2)
 
-    def test_not_finished_empty_expected_test_runs(self):
+    def test_finished_empty_expected_test_runs(self):
         env1 = self.project.environments.create(slug='env1', expected_test_runs=None)
         self.project.environments.create(slug='env2', expected_test_runs=None)
         build = self.project.builds.create(version='1')
         build.test_runs.create(environment=env1)
         finished, _ = build.finished
-        self.assertFalse(finished)
+        self.assertTrue(finished)
 
     def test_finished(self):
         env1 = self.project.environments.create(slug='env1')


### PR DESCRIPTION
This PR makes builds finish earlier by ignoring `expected_test_runs` when set to None or 0 (zero)