### PR TITLE
Add tests status summary to Testrun api

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update -q=2 && \
         python3-django-filters \
         python3-djangorestframework \
         python3-djangorestframework-filters \
+        python3-djangorestframework-extensions \
         python3-gunicorn \
         python3-jinja2 \
         python3-markdown \

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,11 +1,11 @@
 -r requirements.txt
 babel
-django_extensions
 flake8
 ipython
 pickleshare
 Werkzeug
 django-debug-toolbar
+django_extensions
 pytest
 pytest-django
 pytest-cov

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ django-simple-history
 django_filter>=2.0
 djangorestframework>=3.9.2
 djangorestframework-filters>=1.0.0.dev0
+drf-extensions
 gunicorn
 Jinja2
 Markdown

--- a/squad/compat.py
+++ b/squad/compat.py
@@ -1,6 +1,9 @@
 """
 SQUAD compatibity file
 """
+from rest_framework_extensions import __version__ as DRFE_VERSION_STR
+
+DRFE_VERSION = [int(n) for n in DRFE_VERSION_STR.split(".")]
 
 # Handles compatibility for django_restframework_filters
 try:
@@ -12,3 +15,15 @@ try:
     from rest_framework_filters.backends import ComplexFilterBackend # noqa
 except ImportError:
     from squad.api.filters import ComplexFilterBackend # noqa
+
+
+def drf_basename(name):
+    """
+    Handles compatibility with different versions of djangorestframework, in
+    terms of the deprecation of `base_name` when registering ViewSets on DRF >=
+    3.10.
+    """
+    if DRFE_VERSION >= [0, 6]:
+        return {"basename": name}
+    else:
+        return {"base_name": name}


### PR DESCRIPTION
core: api: add tests status totals to testrun endpoint to be readily
available for client calls.