### PR TITLE
Avoid sending emails when body >1MB

### DIFF
--- a/test/core/test_notification.py
+++ b/test/core/test_notification.py
@@ -283,7 +283,6 @@ class TestCustomEmailTemplate(TestCase):
 
     def test_custom_template(self):
         template = EmailTemplate.objects.create(plain_text='foo', html='bar')
-        self.project.use_custom_email_template = True
         self.project.custom_email_template = template
         self.project.save()
 
@@ -299,7 +298,6 @@ class TestCustomEmailTemplate(TestCase):
 
     def test_subject_from_custom_template(self):
         template = EmailTemplate.objects.create(subject='lalala', plain_text='foo', html='bar')
-        self.project.use_custom_email_template = True
         self.project.custom_email_template = template
         self.project.save()
 
@@ -315,7 +313,6 @@ class TestCustomEmailTemplate(TestCase):
             plain_text='foo: {{ notification.project.name }}',
             html='{% autoescape True %}bar: {{ notification.project.name }}{% endautoescape %}')
         self.project.name = "Project's name"
-        self.project.use_custom_email_template = True
         self.project.custom_email_template = template
         self.project.save()
 
@@ -349,7 +346,6 @@ class TestCustomEmailTemplate(TestCase):
             metrics={{metrics}}
         """
         template = EmailTemplate.objects.create(plain_text=expose_context_vars, html=expose_context_vars)
-        self.project.use_custom_email_template = True
         self.project.custom_email_template = template
         self.project.save()
 


### PR DESCRIPTION
This morning we got an error saying that one email got too big (>10MB) and wasn't able to deliver to recipients.

This patch checks if email content is >1MB and send a link to a build's email directly from the api. This email is a DelayedReport, and will be deleted in 1 day after its creation.