### PR TITLE
core: models fix metricthreshold unqiue contraint

### DIFF
--- a/squad/core/migrations/0126_metricthreshold_environment.py
+++ b/squad/core/migrations/0126_metricthreshold_environment.py
@@ -16,4 +16,8 @@ class Migration(migrations.Migration):
             name='environment',
             field=models.ForeignKey(null=True, on_delete=django.db.models.deletion.CASCADE, to='core.Environment'),
         ),
+        migrations.AlterUniqueTogether(
+            name='metricthreshold',
+            unique_together=set(),
+        ),
     ]

--- a/squad/core/models.py
+++ b/squad/core/models.py
@@ -917,9 +917,6 @@ class Status(models.Model, TestSummaryBase):
 
 class MetricThreshold(models.Model):
 
-    class Meta:
-        unique_together = ('project', 'name',)
-
     environment = models.ForeignKey(Environment, null=True, on_delete=models.CASCADE)
     project = models.ForeignKey(Project, on_delete=models.CASCADE)
     name = models.CharField(max_length=1024)


### PR DESCRIPTION
This is to fix unique together constraint in MetricThreshold model. Env should replace project to avoid duplicate ids when inserting two envs for a project.