### PR TITLE
scripts/upload: remove build leftover files

### DIFF
--- a/scripts/upload
+++ b/scripts/upload
@@ -16,3 +16,4 @@ git push --tags
 
 rm -rf build/
 rm -rf dist/
+rm -rf *.egg-info/


### PR DESCRIPTION
This just removes a leftover folder `squad.egg-info`, it's already being removed before release anyways: https://github.com/Linaro/squad/blob/master/scripts/release#L54