### PR TITLE
frontend: add badge for build

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -384,11 +384,12 @@ More details about coreapi can be found on coreapi website and DRF website:
 Badges
 ------
 
-SQUAD offers project badges that can be used in the webpages
+SQUAD offers project and build badges that can be used in the webpages
 
 ::
 
   https://<squad_instance_tld>/group/project/badge
+  https://<squad_instance_tld>/group/project/build_version/badge
 
 The colour of the badge matches the passed/failed condition.
 Following colours are presented:

--- a/squad/frontend/urls.py
+++ b/squad/frontend/urls.py
@@ -36,6 +36,7 @@ urlpatterns = [
     url(r'^(%s)/(%s)/metrics/$' % group_and_project, views.metrics, name='metrics'),
     url(r'^(%s)/(%s)/builds/$' % group_and_project, views.builds, name='builds'),
     url(r'^(%s)/(%s)/build/([^/]+)/$' % group_and_project, views.build, name='build'),
+    url(r'^(%s)/(%s)/build/([^/]+)/badge$' % group_and_project, views.build_badge, name='build_badge'),
     url(r'^(%s)/(%s)/build/([^/]+)/tests/$' % group_and_project, tests.tests, name='tests'),
     url(r'^(%s)/(%s)/build/([^/]+)/testjobs/$' % group_and_project, ci.testjobs, name='testjobs'),
     url(r'^(%s)/(%s)/build/([^/]+)/metadata/$' % group_and_project, views.build_metadata, name='build_metadata'),

--- a/test/frontend/test_basics.py
+++ b/test/frontend/test_basics.py
@@ -85,6 +85,21 @@ class FrontendTest(TestCase):
     def test_build(self):
         self.hit('/mygroup/myproject/build/1.0/')
 
+    def test_build_badge(self):
+        self.hit('/mygroup/myproject/build/1.0/badge')
+
+    def test_build_badge_title(self):
+        self.hit('/mygroup/myproject/build/1.0/badge?title=abc')
+
+    def test_build_badge_passrate(self):
+        self.hit('/mygroup/myproject/build/1.0/badge?passrate')
+
+    def test_build_badge_metrics(self):
+        self.hit('/mygroup/myproject/build/1.0/badge?metrics')
+
+    def test_build_badge_invalid(self):
+        self.hit('/mygroup/myproject/build/1.0/badge?foo')
+
     def test_build_404(self):
         self.hit('/mygroup/myproject/build/999/', 404)
 


### PR DESCRIPTION
The concept of project badge was extended to build. With this commit
each build can produce a badge that can be included in your build
system.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>