### PR TITLE
core: tasks: make "job_id" optional

### DIFF
--- a/test/api/tests.py
+++ b/test/api/tests.py
@@ -321,7 +321,7 @@ class CreateTestRunApiTest(ApiTest):
                 'metadata': StringIO('{"datetime": "2016-09-01T00:00:00+00:00"}'),
             }
         )
-        self.assertEqual(400, response.status_code)
+        self.assertEqual(201, response.status_code)
 
     def test_reject_submission_with_existing_job_id(self):
         def post():


### PR DESCRIPTION
This kinda undo this commit: https://github.com/Linaro/squad/commit/8a4ef7edb00916a49dcbec6dbbf83f1ccd1e2fb4

"job_id" is mandatory only if metadata is present in submission, but if no metadata is passed, then it's generated. I'm making it optional even if it's passed in metadata. Duplicate check still happens when job_id is present in metadata though