### PR TITLE
plugins: linux_log_parser: run plugin for testruns

### DIFF
--- a/squad/plugins/linux_log_parser.py
+++ b/squad/plugins/linux_log_parser.py
@@ -61,11 +61,10 @@ class Plugin(BasePlugin):
             log='\n'.join(lines),
         )
 
-    def postprocess_testjob(self, testjob):
-        testrun = testjob.testrun
+    def postprocess_testrun(self, testrun):
         log = self.__kernel_msgs_only(testrun.log_file)
         suite, _ = testrun.build.project.suites.get_or_create(slug='linux-log-parser')
-        test_name_suffix = ('-%s' % testjob.name) if testjob.name else ''
+        test_name_suffix = '-%s' % testrun.job_id
 
         regex = self.__compile_regexes(REGEXES)
         matches = regex.findall(log)

--- a/test/plugins/test_plugin.py
+++ b/test/plugins/test_plugin.py
@@ -9,8 +9,8 @@ class TestGetPluginsByFeature(TestCase):
         testrun_plugins = get_plugins_by_feature([Plugin.postprocess_testrun])
         testjob_plugins = get_plugins_by_feature([Plugin.postprocess_testjob])
         self.assertNotIn('example', testrun_plugins)
-        self.assertNotIn('linux_log_parser', testrun_plugins)
-        self.assertIn('linux_log_parser', testjob_plugins)
+        self.assertNotIn('linux_log_parser', testjob_plugins)
+        self.assertIn('linux_log_parser', testrun_plugins)
 
     def test_feature_list_is_none(self):
         plugins = get_plugins_by_feature(None)


### PR DESCRIPTION
Run linux-log-parser plugin for testrun, instead of testjob. This will run the plugin even for results submitted via the api.

Screenshots available here: https://github.com/Linaro/squad/issues/658