### PR TITLE
plugins: linux_log_parser: ignore empty logs

### DIFF
--- a/squad/plugins/linux_log_parser.py
+++ b/squad/plugins/linux_log_parser.py
@@ -62,6 +62,9 @@ class Plugin(BasePlugin):
         )
 
     def postprocess_testrun(self, testrun):
+        if testrun.log_file is None:
+            return
+
         log = self.__kernel_msgs_only(testrun.log_file)
         suite, _ = testrun.build.project.suites.get_or_create(slug='linux-log-parser')
         test_name_suffix = '-%s' % testrun.job_id

--- a/test/plugins/test_linux_log_parser.py
+++ b/test/plugins/test_linux_log_parser.py
@@ -152,3 +152,10 @@ class TestLinuxLogParser(TestCase):
         self.assertFalse(test_warning.result)
 
         self.assertIn('WARNING: suspicious RCU usage', test_warning.log)
+
+    def test_non_string(self):
+        testrun = self.build.test_runs.create(environment=self.env, job_id='1111')
+        self.plugin.postprocess_testrun(testrun)
+
+        tests = testrun.tests
+        self.assertEqual(0, tests.count())


### PR DESCRIPTION
Fix this error:
```
Plugin postprocessing error: expected string or bytes-like object
Traceback (most recent call last):
  File "/srv/qa-reports.linaro.org/lib/python3.5/site-packages/squad/core/tasks/__init__.py", line 259, in __call__
    self.__call_plugin__(plugin, testrun)
  File "/srv/qa-reports.linaro.org/lib/python3.5/site-packages/squad/core/tasks/__init__.py", line 264, in __call_plugin__
    plugin.postprocess_testrun(testrun)
  File "/srv/qa-reports.linaro.org/lib/python3.5/site-packages/squad/plugins/linux_log_parser.py", line 65, in postprocess_testrun
    log = self.__kernel_msgs_only(testrun.log_file)
  File "/srv/qa-reports.linaro.org/lib/python3.5/site-packages/squad/plugins/linux_log_parser.py", line 34, in __kernel_msgs_only
    kernel_msgs = re.findall(r'^\[[ \d]+\.[ \d]+\] .*?$', log, re.S | re.M)
  File "/srv/qa-reports.linaro.org/lib/python3.5/re.py", line 213, in findall
    return _compile(pattern, flags).findall(string)
TypeError: expected string or bytes-like objec
```