### PR TITLE
core: history: check for empty suite metadata

### DIFF
--- a/squad/core/history.py
+++ b/squad/core/history.py
@@ -16,7 +16,7 @@ class TestResult(object):
         self.test_run = test.test_run
         self.info = {
             "test_description": test.metadata.description if test.metadata else '',
-            "suite_instructions": test.suite.metadata.instructions_to_reproduce,
+            "suite_instructions": test.suite.metadata.instructions_to_reproduce if test.suite.metadata else '',
             "test_instructions": test.metadata.instructions_to_reproduce if test.metadata else '',
             "test_log": test.log
         }

--- a/test/frontend/test_history.py
+++ b/test/frontend/test_history.py
@@ -21,3 +21,20 @@ class TestHistoryWithNoData(TestCase):
     def test_history_with_unexisting_suite_name(self):
         response = self.client.get('/mygroup/myproject/tests/foo/bar')
         self.assertEqual(404, response.status_code)
+
+
+class TestHistoryTest(TestCase):
+
+    def setUp(self):
+        self.client = Client()
+        group = Group.objects.create(slug='mygroup')
+        project = group.projects.create(slug='myproject')
+        env = project.environments.create(slug='myenv')
+        suite = project.suites.create(slug='mysuite')
+        build = project.builds.create(version='mybuild')
+        testrun = build.test_runs.create(job_id='123', environment=env)
+        testrun.tests.create(name='mytest', suite=suite)
+
+    def test_tests_history_with_empty_suite_metadata(self):
+        response = self.client.get('/mygroup/myproject/tests/mysuite/mytest')
+        self.assertEqual(200, response.status_code)


### PR DESCRIPTION
Fix this error:

```
AttributeError at /lkft/linux-stable-rc-5.5-oe/tests/linux-log-parser/check-kernel-warning-1360505
'NoneType' object has no attribute 'instructions_to_reproduce'
```