### PR TITLE
api: rest: fix force-created reports

### DIFF
--- a/test/api/test_rest.py
+++ b/test/api/test_rest.py
@@ -451,7 +451,7 @@ class RestApiTest(APITestCase):
         prepare_report_mock.assert_called_once()
         prepare_report_mock.reset_mock()
         response2 = self.client.get('/api/builds/%d/report/?force=true' % self.build3.id)
-        self.assertEqual(response.json(), response2.json())
+        self.assertNotEqual(response.json()['url'], response2.json()['url'])
         prepare_report_mock.assert_called_once()
 
     def test_build_testruns(self):


### PR DESCRIPTION
For every call to `/api/builds/id/report/?force=true` a new report will be created.

Close https://github.com/Linaro/squad/issues/503