### PR TITLE
core: tasks: fix job_id as integer

### DIFF
--- a/squad/core/tasks/__init__.py
+++ b/squad/core/tasks/__init__.py
@@ -74,7 +74,7 @@ class ValidateTestRun(object):
         if "job_id" in metadata.keys():
             if type(metadata['job_id']) not in [int, str]:
                 raise exceptions.InvalidMetadata('job_id should be an integer or a string')
-            if '/' in metadata['job_id']:
+            if type(metadata['job_id']) is str and '/' in metadata['job_id']:
                 raise exceptions.InvalidMetadata('job_id cannot contain the "/" character')
 
     def __validate_metrics(self, metrics_file):

--- a/test/api/tests.py
+++ b/test/api/tests.py
@@ -338,6 +338,10 @@ class CreateTestRunApiTest(ApiTest):
         self.assertEqual(201, first.status_code)
         self.assertEqual(400, second.status_code)
 
+    def test_reject_submission_with_int_job_id(self):
+        response = self.client.post('/api/submit/mygroup/myproject/1.0.0/myenvironment', {'metadata': '{"job_id": 123}'})
+        self.assertEqual(201, response.status_code)
+
     def test_accepts_uppercase_in_slug(self):
         self.group.slug = 'MyGroup'
         self.group.save()


### PR DESCRIPTION
I introduced this bug back when made job_id optional. Now it's fixed for real