### PR TITLE
Fix fetch race condition

### DIFF
--- a/squad/ci/management/commands/testfetch.py
+++ b/squad/ci/management/commands/testfetch.py
@@ -47,4 +47,4 @@ class Command(BaseCommand):
         if options.get("background"):
             fetch.delay(testjob.id)
         else:
-            backend.fetch(testjob)
+            backend.fetch(testjob.id)

--- a/squad/ci/models.py
+++ b/squad/ci/models.py
@@ -12,6 +12,7 @@ from squad.core.tasks import ReceiveTestRun, UpdateProjectStatus
 from squad.core.models import Project, Build, TestRun, slug_validator
 from squad.core.plugins import apply_plugins
 from squad.core.tasks.exceptions import InvalidMetadata, DuplicatedTestJob
+from squad.ci.exceptions import FetchIssue, TemporaryFetchIssue
 from squad.core.utils import yaml_validator
 
 
@@ -64,18 +65,29 @@ class Backend(models.Model):
             else:
                 yield test_job
 
-    def fetch(self, test_job):
-        if not test_job.fetched:
-            self.really_fetch(test_job)
+    def fetch(self, job_id):
+        test_job = TestJob.objects.get(pk=job_id)
+        if test_job.fetched or test_job.fetch_attempts >= test_job.backend.max_fetch_attempts:
+            return
 
-    def really_fetch(self, test_job):
         test_job.last_fetch_attempt = timezone.now()
-
         implementation = self.get_implementation()
-        results = implementation.fetch(test_job)
-        if not results:
+
+        try:
+            results = implementation.fetch(test_job)
+            if results is None:
+                raise TemporaryFetchIssue('Unexpected behavior')
+        except FetchIssue as issue:
+            logger.warning("error fetching job %s: %s" % (test_job.id, str(issue)))
+            test_job.failure = str(issue)
+            test_job.fetched = not issue.retry
+            test_job.fetch_attempts += 1
             test_job.save()
             return
+
+        test_job.fetched = True
+        test_job.fetched_at = timezone.now()
+        test_job.save()
 
         status, completed, metadata, tests, metrics, logs = results
 
@@ -97,7 +109,6 @@ class Backend(models.Model):
             metadata['job_url'] = test_job.url
 
         try:
-            # create TestRun
             receive = ReceiveTestRun(test_job.target, update_project_status=False)
             testrun = receive(
                 version=test_job.target_build.version,
@@ -114,10 +125,6 @@ class Backend(models.Model):
         except DuplicatedTestJob as exception:
             logger.error('Failed to fetch test_job(%d): "%s"' % (test_job.id, str(exception)))
 
-        # mark test job as fetched to prevent resubmission
-        # on next fetch attempt
-        test_job.fetched = True
-        test_job.fetched_at = timezone.now()
         test_job.save()
 
         if test_job.testrun:

--- a/test/ci/backend/test_lava.py
+++ b/test/ci/backend/test_lava.py
@@ -368,13 +368,15 @@ class LavaTest(TestCase):
     @patch("squad.ci.backend.lava.Backend.__get_testjob_results_yaml__", return_value=TEST_RESULTS)
     def test_parse_results_ignore_lava_suite_backend_settings(self, get_results, get_details, test_log):
         self.backend.backend_settings = 'CI_LAVA_HANDLE_SUITE: true'
+        self.backend.save()
         lava = self.backend
-        testjob = TestJob(
+        testjob = TestJob.objects.create(
             job_id='1234',
             backend=self.backend,
             target=self.project,
             target_build=self.build)
-        lava.fetch(testjob)
+        lava.fetch(testjob.id)
+        testjob.refresh_from_db()
         results = testjob.testrun.tests
         metrics = testjob.testrun.metrics
 
@@ -393,13 +395,15 @@ class LavaTest(TestCase):
     @patch("squad.ci.backend.lava.Backend.__get_testjob_results_yaml__", return_value=TEST_RESULTS)
     def test_parse_results_ignore_lava_suite_project_settings(self, get_results, get_details, test_log):
         self.project.project_settings = 'CI_LAVA_HANDLE_SUITE: true'
+        self.project.save()
         lava = self.backend
-        testjob = TestJob(
+        testjob = TestJob.objects.create(
             job_id='1234',
             backend=self.backend,
             target=self.project,
             target_build=self.build)
-        lava.fetch(testjob)
+        lava.fetch(testjob.id)
+        testjob.refresh_from_db()
         results = testjob.testrun.tests
         metrics = testjob.testrun.metrics
 
@@ -419,12 +423,13 @@ class LavaTest(TestCase):
     def test_parse_results_ignore_lava_suite_empty_project_settings(self, get_results, get_details, test_log):
         self.project.project_settings = ''
         lava = self.backend
-        testjob = TestJob(
+        testjob = TestJob.objects.create(
             job_id='1234',
             backend=self.backend,
             target=self.project,
             target_build=self.build)
-        lava.fetch(testjob)
+        lava.fetch(testjob.id)
+        testjob.refresh_from_db()
         results = testjob.testrun.tests
         metrics = testjob.testrun.metrics
 
@@ -444,16 +449,19 @@ class LavaTest(TestCase):
     @patch("squad.ci.backend.lava.Backend.__get_testjob_results_yaml__", return_value=TEST_RESULTS)
     def test_parse_results_ignore_lava_suite_project_settings_overwrites_backend(self, get_results, get_details, test_log):
         self.backend.backend_settings = 'CI_LAVA_HANDLE_SUITE: true'
+        self.backend.save()
         lava = self.backend
 
         # Project settings has higher priority than backend settings
         self.project.project_settings = 'CI_LAVA_HANDLE_SUITE: false'
-        testjob = TestJob(
+        self.project.save()
+        testjob = TestJob.objects.create(
             job_id='1234',
             backend=self.backend,
             target=self.project,
             target_build=self.build)
-        lava.fetch(testjob)
+        lava.fetch(testjob.id)
+        testjob.refresh_from_db()
         results = testjob.testrun.tests
         metrics = testjob.testrun.metrics
 
@@ -475,12 +483,13 @@ class LavaTest(TestCase):
         self.backend.backend_settings = ''
         lava = self.backend
 
-        testjob = TestJob(
+        testjob = TestJob.objects.create(
             job_id='1234',
             backend=self.backend,
             target=self.project,
             target_build=self.build)
-        lava.fetch(testjob)
+        lava.fetch(testjob.id)
+        testjob.refresh_from_db()
         results = testjob.testrun.tests
         metrics = testjob.testrun.metrics
 
@@ -497,13 +506,15 @@ class LavaTest(TestCase):
     @patch("squad.ci.backend.lava.Backend.__get_testjob_results_yaml__", return_value=TEST_RESULTS)
     def test_parse_results_handle_lava_suite_and_ignore_lava_boot(self, get_results, get_details, download_test_log):
         self.backend.backend_settings = '{"CI_LAVA_HANDLE_SUITE": true, "CI_LAVA_HANDLE_BOOT": false}'
+        self.backend.save()
         lava = self.backend
-        testjob = TestJob(
+        testjob = TestJob.objects.create(
             job_id='1234',
             backend=self.backend,
             target=self.project,
             target_build=self.build)
-        lava.fetch(testjob)
+        lava.fetch(testjob.id)
+        testjob.refresh_from_db()
         results = testjob.testrun.tests
         metrics = testjob.testrun.metrics
 

--- a/test/ci/test_tasks.py
+++ b/test/ci/test_tasks.py
@@ -1,5 +1,8 @@
-from django.test import TestCase
+from django.test import TestCase, TransactionTestCase, tag
+from django.db import connection
 from test.mock import patch
+import time
+import threading
 
 
 from celery.exceptions import Retry
@@ -84,6 +87,48 @@ class FetchTest(TestCase):
 
         self.test_job.refresh_from_db()
         self.assertEqual(attemps + 1, self.test_job.fetch_attempts)
+
+
+class FetchTestRaceCondition(TransactionTestCase):
+
+    def setUp(self):
+        group = core_models.Group.objects.create(slug='test')
+        project = group.projects.create(slug='test')
+        build = project.builds.create(version='test-build')
+        backend = models.Backend.objects.create()
+        self.testjob = models.TestJob.objects.create(
+            backend=backend,
+            target=project,
+            target_build=build,
+        )
+
+    def mock_backend_fetch(test_job):
+        time.sleep(1)
+        status = ''
+        completed = True
+        metadata = {}
+        tests = []
+        metrics = []
+        logs = ''
+        return status, completed, metadata, tests, metrics, logs
+
+    @tag('skip_sqlite')
+    @patch('squad.ci.backend.null.Backend.fetch', side_effect=mock_backend_fetch)
+    def test_race_condition_on_fetch(self, fetch_method):
+
+        def thread(testjob_id):
+            fetch(testjob_id)
+            connection.close()
+
+        parallel_task_1 = threading.Thread(target=thread, args=(self.testjob.id,))
+        parallel_task_2 = threading.Thread(target=thread, args=(self.testjob.id,))
+
+        parallel_task_1.start()
+        parallel_task_2.start()
+
+        parallel_task_1.join()
+        parallel_task_2.join()
+        self.assertEqual(1, fetch_method.call_count)
 
 
 class SubmitTest(TestCase):

--- a/test/ci/test_tasks.py
+++ b/test/ci/test_tasks.py
@@ -56,14 +56,9 @@ class FetchTest(TestCase):
     @patch('squad.ci.models.Backend.fetch')
     def test_fetch(self, fetch_method):
         fetch.apply(args=[self.test_job.id])
-        fetch_method.assert_called_with(self.test_job)
+        fetch_method.assert_called_with(self.test_job.id)
 
-    @patch('squad.ci.models.Backend.really_fetch')
-    def test_really_fetch(self, really_fetch_method):
-        fetch.apply(args=[self.test_job.id])
-        really_fetch_method.assert_called_with(self.test_job)
-
-    @patch('squad.ci.models.Backend.fetch')
+    @patch('squad.ci.backend.null.Backend.fetch')
     def test_exception_when_fetching(self, fetch_method):
         fetch_method.side_effect = FetchIssue("ERROR")
         fetch.apply(args=[self.test_job.id])
@@ -72,7 +67,7 @@ class FetchTest(TestCase):
         self.assertEqual("ERROR", self.test_job.failure)
         self.assertTrue(self.test_job.fetched)
 
-    @patch('squad.ci.models.Backend.fetch')
+    @patch('squad.ci.backend.null.Backend.fetch')
     def test_temporary_exception_when_fetching(self, fetch_method):
         fetch_method.side_effect = TemporaryFetchIssue("ERROR")
         fetch.apply(args=[self.test_job.id])
@@ -81,7 +76,7 @@ class FetchTest(TestCase):
         self.assertEqual("ERROR", self.test_job.failure)
         self.assertFalse(self.test_job.fetched)
 
-    @patch('squad.ci.models.Backend.fetch')
+    @patch('squad.ci.backend.null.Backend.fetch')
     def test_counts_attempts_with_temporary_exceptions(self, fetch_method):
         attemps = self.test_job.fetch_attempts
         fetch_method.side_effect = TemporaryFetchIssue("ERROR")

--- a/test/core/test_build.py
+++ b/test/core/test_build.py
@@ -158,7 +158,7 @@ class BuildTest(TestCase):
             submitted=True,
             fetched=False,
         )
-        t1.backend.fetch(t1)
+        t1.backend.fetch(t1.id)
 
         t2 = TestJob.objects.create(
             job_id='2',
@@ -173,7 +173,7 @@ class BuildTest(TestCase):
         finished, _ = build.finished
         self.assertFalse(finished)
 
-        t2.backend.fetch(t2)
+        t2.backend.fetch(t2.id)
         finished, _ = build.finished
         self.assertTrue(finished)
 
@@ -196,7 +196,7 @@ class BuildTest(TestCase):
             submitted=True,
             fetched=False,
         )
-        t1.backend.fetch(t1)
+        t1.backend.fetch(t1.id)
 
         # expect 2, only 1 received
         finished, _ = build.finished

--- a/test/integration/test_build_notification_from_ci.py
+++ b/test/integration/test_build_notification_from_ci.py
@@ -38,7 +38,7 @@ class BuildNotificationFromCI(TestCase):
             job_id='123',
             environment='myenv',
         )
-        backend.fetch(testjob)
+        backend.fetch(testjob.id)
         status = build.status
         status.refresh_from_db()
         notify.delay.assert_called_with(status.id)


### PR DESCRIPTION
Close https://github.com/Linaro/squad/issues/674

This PR is separated in two commits:
* first merges `Backend.really_fetch` into `Backend.fetch` so that we can query a TestJob, fetch it and mark it as fetched or not. Also, it brings a check for `maximum_number_of_attempts` to within fetch as well.
* second wraps the block that query - check - update TestJob with a `transaction.atomic` statement along with `select_for_update()` to prevent race condition.