### PR TITLE
ci: fix Backend.fetch() implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ env:
   - SCRIPT="./dev-docker ./manage.py test" 
   - SCRIPT="./scripts/test-docker"
   - SCRIPT="./manage.py compilemessages" INSTALLPIP=yes
-  - SCRIPT="docker run -v $(pwd):/squad --workdir /squad fsfe/reuse reuse lint"
+  - SCRIPT="docker run -v $(pwd):/squad --workdir /squad fsfe/reuse lint"
   - SCRIPT="python3 -m pytest" DATABASE=ENGINE=django.db.backends.postgresql_psycopg2:NAME=squad:USER=postgres:PASSWORD=squad:HOST=127.0.0.1:PORT=5432 INSTALLPIP=yes
 
 before_install:


### PR DESCRIPTION
In case the job is still in the queue or is in progress, fetch() raises
TemporaryFetchIssue from within block that catches FetchIssue. Since
TemporaryFetchIssue derives from FetchIssue, the exception is
immediately consumed and fetch_attempts counter is increased. This leads
to maxing out fetch_counter for jobs that stay in the queue for a long
time. This patch removes the exception and instead returns from the
fetch() function without an error. This doesn't result in increasing
fetch_attempt counter.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>