### PR TITLE
ci: lava: add flag allowing to accept results from failed jobs

### DIFF
--- a/doc/ci.rst
+++ b/doc/ci.rst
@@ -146,6 +146,9 @@ LAVA backend supports the following settings:
    Before SQUAD 1.x series, the default behavior was to always process
    `auto-login-action` as boot. After 1.x, the default behavior has changed
    to do the opposite.
+ - CI_LAVA_WORK_AROUND_INFRA_ERRORS
+   boolean flag that allows to accept test results from 'Incomplete' jobs if the
+   failure was caused by infrastracture. **NOTE**: Use with caution!
 
 Example LAVA backend settings:
 

--- a/squad/ci/backend/lava.py
+++ b/squad/ci/backend/lava.py
@@ -336,10 +336,12 @@ class Backend(BaseBackend):
             handle_lava_suite = self.__resolve_setting__(ps, 'CI_LAVA_HANDLE_SUITE', False)
             handle_lava_boot = self.__resolve_setting__(ps, 'CI_LAVA_HANDLE_BOOT', False)
             clone_measurements_to_tests = self.__resolve_setting__(ps, 'CI_LAVA_CLONE_MEASUREMENTS', False)
+            ignore_infra_errors = self.__resolve_setting__(ps, 'CI_LAVA_WORK_AROUND_INFRA_ERRORS', False)
         else:
             handle_lava_suite = self.settings.get('CI_LAVA_HANDLE_SUITE', False)
             handle_lava_boot = self.settings.get('CI_LAVA_HANDLE_BOOT', False)
             clone_measurements_to_tests = self.settings.get('CI_LAVA_CLONE_MEASUREMENTS', False)
+            ignore_infra_errors = self.settings.get('CI_LAVA_WORK_AROUND_INFRA_ERRORS', False)
 
         definition = yaml.safe_load(data['definition'])
         test_job.name = definition['job_name'][:255]
@@ -401,7 +403,8 @@ class Backend(BaseBackend):
                     error_type = metadata.get('error_type', None)
                     # detect jobs failed because of infrastructure issues
                     if error_type in ['Infrastructure', 'Job', 'Lava']:
-                        completed = False
+                        if not ignore_infra_errors:
+                            completed = False
                     # automatically resubmit in some cases
                     if error_type in ['Infrastructure', 'Job', 'Test']:
                         self.__resubmit_job__(test_job, metadata)


### PR DESCRIPTION
If LAVA job fails with infrastructure error but before that produces
valid results, these results can be pulled to SQUAD. It is possible
using CI_LAVA_IGNORE_INFRA_ERRORS flag. It can be set in either backend
or a project.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>