### PR TITLE
ci: improve TestJob.cancel()

### DIFF
--- a/squad/api/rest.py
+++ b/squad/api/rest.py
@@ -1259,10 +1259,7 @@ class TestJobViewSet(ModelViewSet):
     @action(detail=True, methods=['post'], suffix='cancel')
     def cancel(self, request, **kwargs):
         testjob = self.get_object()
-        if testjob.cancel():
-            # this is faking job status as real status will only be updated
-            # after fetch operation is complete
-            return Response({'job_id': testjob.job_id, 'status': 'Canceled'}, status=status.HTTP_200_OK)
+        testjob.cancel()
         return Response({'job_id': testjob.job_id, 'status': testjob.job_status}, status=status.HTTP_200_OK)
 
 

--- a/squad/ci/models.py
+++ b/squad/ci/models.py
@@ -257,6 +257,12 @@ class TestJob(models.Model):
     def cancel(self):
         if self.job_id is not None:
             return self.backend.get_implementation().cancel(self)
+        else:
+            self.fetched = True
+            self.submitted = True
+            self.job_status = "Canceled"
+            self.failure = "Cancelled before submission"
+            self.save()
         return self.fetched
 
     def __str__(self):

--- a/test/api/test_rest.py
+++ b/test/api/test_rest.py
@@ -57,7 +57,7 @@ class RestApiTest(APITestCase):
             target=self.project,
             target_build=self.build2,
             environment='myenv',
-            testrun=self.testrun2
+            testrun=self.testrun2,
         )
         self.testjob3 = ci_models.TestJob.objects.create(
             definition="foo: bar",
@@ -593,13 +593,13 @@ class RestApiTest(APITestCase):
         data = self.post('/api/testjobs/%d/cancel/' % self.testjob5.id, {})
         self.assertEqual(data.status_code, 200)
         self.assertEqual(data.json()['job_id'], self.testjob5.job_id)
-        self.assertEqual(data.json()['status'], 'Canceled')
+        self.assertEqual(data.json()['status'], self.testjob5.job_status)
 
     def test_testjob_cancel_fail(self):
         data = self.post('/api/testjobs/%d/cancel/' % self.testjob2.id, {})
         self.assertEqual(data.status_code, 200)
         self.assertEqual(data.json()['job_id'], self.testjob2.job_id)
-        self.assertEqual(data.json()['status'], self.testjob2.job_status)
+        self.assertEqual(data.json()['status'], 'Canceled')
 
     def test_backends(self):
         data = self.hit('/api/backends/')


### PR DESCRIPTION
When test job is not yet submitted cancel() marks it as submitted and
fetched and sets failure message.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>