### PR TITLE
frontend: comparison: fix transitions

### DIFF
--- a/squad/frontend/comparison.py
+++ b/squad/frontend/comparison.py
@@ -39,6 +39,8 @@ def __get_transitions(request):
 
     if len(marked_transitions) > 0:
         for t in marked_transitions:
+            if t is None or t == 'None':
+                continue
             _from, _to = t.split(':')
             if _from in RESULT_STATES and _to in RESULT_STATES:
                 transitions[(_from, _to)] = True

--- a/squad/frontend/templatetags/squad.py
+++ b/squad/frontend/templatetags/squad.py
@@ -167,7 +167,7 @@ def get_page_list(items):
 def update_get_parameters(context, parameters):
     query_string = context['request'].GET.copy()
     for p in parameters.keys():
-        if parameters[p] is None and query_string.get(p) is not None:
+        if parameters[p] is None and p in query_string.keys():
             del query_string[p]
         else:
             query_string[p] = parameters[p]

--- a/test/frontend/test_template_tags.py
+++ b/test/frontend/test_template_tags.py
@@ -29,6 +29,9 @@ class FakeGet():
     def get(self, key):
         return self.__getitem__(key)
 
+    def keys(self):
+        return self.params.keys()
+
     def copy(self):
         return self
 


### PR DESCRIPTION
There was a bug tha caused 500 errors when new transitions were selected. This was due to how we update querystring parameteres. This patch fixes that.