### PR TITLE
frontend: fix URL reverse for test names with /

### DIFF
--- a/squad/frontend/templates/squad/tests.jinja2
+++ b/squad/frontend/templates/squad/tests.jinja2
@@ -29,7 +29,7 @@
         </thead>
         {% if results %}
             {% for test in results %}
-            {% set test_details_url = url('testrun_suite_test_details', args=[build.project.group.slug, build.project.slug, build.version, test.test_run.id, test.suite.slug.replace('/', '$'), test.name]) %}
+            {% set test_details_url = url('testrun_suite_test_details', args=[build.project.group.slug, build.project.slug, build.version, test.test_run.id, test.suite.slug.replace('/', '$'), test.name.replace('/', '$')]) %}
             <tr id='test-{{test.name|slugify}}' ng-show="match('test-{{test.name|slugify}}')">
                 <td><a href="{{ test_details_url }}">{{test.name}}</a></td>
                 {% for status in test %}

--- a/squad/frontend/templatetags/squad.py
+++ b/squad/frontend/templatetags/squad.py
@@ -10,6 +10,7 @@ from hashlib import md5
 from markdown import markdown as to_markdown
 
 from squad import version
+from squad.core.models import Test
 from squad.core.utils import format_metadata
 from squad.jinja2 import register_global_function, register_filter
 
@@ -81,7 +82,10 @@ def testrun_suite_or_test_url(group, project, build, status, kind, test=None):
         suite.slug.replace('/', '$'),
     )
     if test:
-        args = args + (test,)
+        if isinstance(test, Test):
+            args = args + (test.name.replace('/', '$'),)
+        else:
+            args = args + (test.replace('/', '$'),)
 
     return reverse(kind, args=args)
 

--- a/squad/frontend/views.py
+++ b/squad/frontend/views.py
@@ -412,6 +412,7 @@ def test_run_suite_test_details(request, group_slug, project_slug, build_version
         testrun,
         suite_slug
     )
+    test_name = test_name.replace("$", "/")
     test = get_object_or_404(context['test_run'].tests, suite=context['suite'], name=test_name)
     attachments = [
         (f['filename'], file_type(f['filename']), f['length'])


### PR DESCRIPTION
When test name contains / it's now converted on the fly to $ to make
regexes work properly. Down side is that $ can't be used in the test
names any more. This should be mentioned in the docs.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>