### PR TITLE
Fix timeout when deleting builds

### DIFF
--- a/squad/admin.py
+++ b/squad/admin.py
@@ -1,0 +1,28 @@
+from django.contrib.admin import ModelAdmin
+from django.utils.translation import ugettext as _
+
+
+class NoDeleteListingModelAdmin(ModelAdmin):
+    """
+    ModelAdmin without list of objects being deleted
+    """
+    def get_deleted_objects(self, objs, request):
+        """
+        Find all objects related to ``objs`` that should also be deleted. ``objs``
+        must be a homogeneous iterable of objects (e.g. a QuerySet).
+
+        Return a nested list of strings suitable for display in the
+        template with the ``unordered_list`` filter.
+
+        NOTE: this implementation just ignore generating a list of objects to be
+        deleted. In some objects, there are millions of records related, and this
+        wouldn't be practical to load a list of objects.
+
+        ref: https://github.com/django/django/blob/d6aff369ad33457ae2355b5b210faf1c4890ff35/django/contrib/admin/utils.py#L103
+        """
+        to_delete = [_('List of objects to be deleted is disabled')]
+        model_count = {}
+        perms_needed = set()
+        protected = []
+
+        return to_delete, model_count, perms_needed, protected

--- a/squad/ci/admin.py
+++ b/squad/ci/admin.py
@@ -2,6 +2,7 @@ from django.contrib import admin
 from django.utils.translation import ugettext_lazy as _
 from squad.ci.models import Backend, TestJob
 from squad.ci.tasks import submit, fetch, poll
+from squad.admin import NoDeleteListingModelAdmin
 
 
 def poll_backends(modeladmin, request, queryset):
@@ -12,7 +13,7 @@ def poll_backends(modeladmin, request, queryset):
 poll_backends.short_description = "Poll selected backends"
 
 
-class BackendAdmin(admin.ModelAdmin):
+class BackendAdmin(NoDeleteListingModelAdmin):
     list_display = ('name', 'url', 'implementation_type', 'listen_enabled', 'poll_enabled', 'poll_interval', 'max_fetch_attempts')
     actions = [poll_backends]
 

--- a/squad/core/admin.py
+++ b/squad/core/admin.py
@@ -1,5 +1,5 @@
-from django.contrib import admin
 from django import forms
+from django.contrib import admin
 from django.forms import ModelForm, ModelMultipleChoiceField, CheckboxSelectMultiple
 from simple_history.admin import SimpleHistoryAdmin
 
@@ -7,6 +7,7 @@ from simple_history.admin import SimpleHistoryAdmin
 from . import models
 from .tasks import postprocess_test_run
 from .tasks.notification import notify_project_status
+from squad.admin import NoDeleteListingModelAdmin
 
 
 class GroupMemberAdmin(admin.TabularInline):
@@ -18,7 +19,7 @@ class GroupMemberAdmin(admin.TabularInline):
     readonly_fields = ['member_since']
 
 
-class GroupAdmin(admin.ModelAdmin):
+class GroupAdmin(NoDeleteListingModelAdmin):
     """
     Handles groups
     """
@@ -47,7 +48,7 @@ class AdminSubscriptionInline(admin.StackedInline):
     extra = 0
 
 
-class ProjectAdmin(admin.ModelAdmin):
+class ProjectAdmin(NoDeleteListingModelAdmin):
     list_display = ['__str__', 'is_public', 'moderate_notifications', 'custom_email_template']
     list_filter = ['group', 'is_public', 'moderate_notifications', 'custom_email_template']
     inlines = [EnvironmentInline, SubscriptionInline, AdminSubscriptionInline]
@@ -94,7 +95,7 @@ class ProjectStatusAdmin(admin.ModelAdmin):
         return False
 
 
-class BuildAdmin(admin.ModelAdmin):
+class BuildAdmin(NoDeleteListingModelAdmin):
     model = models.Build
     ordering = ['-id']
     list_display = ['__str__', 'project']
@@ -136,7 +137,7 @@ def force_execute_plugins(modeladmin, request, queryset):
 force_execute_plugins.short_description = "Postprocess selected test runs"
 
 
-class TestRunAdmin(admin.ModelAdmin):
+class TestRunAdmin(NoDeleteListingModelAdmin):
     models = models.TestRun
     list_filter = [TestRunProjectFilter]
     actions = [force_execute_plugins]


### PR DESCRIPTION
The fix consists in not loading a list of objects to be deleted when Build gets deleted. Some builds have thousands of TestRuns with thousands of tests attached. Loading a list of objects is just not practical.