### PR TITLE
Improve load times for project and builds page

### DIFF
--- a/squad/core/models.py
+++ b/squad/core/models.py
@@ -398,7 +398,7 @@ class Build(models.Model):
         """
         if self.__metadata__ is None:
             metadata = {}
-            for test_run in self.test_runs.defer(None).all():
+            for test_run in self.test_runs.only('metadata_file', 'build_id'):
                 for key, value in test_run.metadata.items():
                     metadata.setdefault(key, [])
                     if value not in metadata[key]:
@@ -471,7 +471,7 @@ class Build(models.Model):
             for e in self.project.environments.all()
         }
 
-        for t in self.test_runs.filter(completed=True).all():
+        for t in self.test_runs.filter(completed=True).only('build_id', 'environment_id').all():
             testruns[t.environment_id]['received'] += 1
 
         for env, count in testruns.items():
@@ -592,7 +592,6 @@ class TestRunManager(models.Manager):
             "tests_file",
             "metrics_file",
             "log_file",
-            "metadata_file",
         )
 
 

--- a/squad/frontend/templates/squad/_builds_table.jinja2
+++ b/squad/frontend/templates/squad/_builds_table.jinja2
@@ -4,8 +4,8 @@
   <input type="hidden" ng-init="invalid_number_of_builds_msg='{{_('Two builds need to be selected!')}}'" />
   <input type="hidden" ng-init="invalid_selected_builds_msg='{{_('Selected builds must be different!')}}'" />
   <input type="button" ng-value="compare_button_label" class="btn btn-default" ng-click="compareBuilds('{{project.full_name}}')" />
-{% for status in statuses %}
-{% with build=status.build %}
+{% for build in builds %}
+{% with status=build.status %}
 <div class="row row-bordered build">
     <div class="col-md-1 col-sm-1">
         <input type="radio" name="baseline_build" ng-value="'{{build.version}}'" ng-model="baseline_build" />&nbsp;

--- a/squad/frontend/templates/squad/builds.jinja2
+++ b/squad/frontend/templates/squad/builds.jinja2
@@ -7,7 +7,7 @@
 {% endwith %}
 <div style='margin-top: 20px'></div>
 
-{% with items=statuses %}
+{% with items=builds %}
   {% include "squad/_pagination.jinja2" %}
 {% endwith %}
 
@@ -15,7 +15,7 @@
 {% include "squad/_builds_table.jinja2" %}
 </div>
 
-{% with items=statuses %}
+{% with items=builds %}
   {% include "squad/_pagination.jinja2" %}
 {% endwith %}
 

--- a/squad/frontend/templates/squad/project.jinja2
+++ b/squad/frontend/templates/squad/project.jinja2
@@ -2,8 +2,6 @@
 
 {% block content %}
 
-{% with status=project.status %}
-
 {% include "squad/project-nav.jinja2" %}
 
 {% if last_build %}
@@ -23,5 +21,4 @@
 </div>
 {% endif %}
 
-{% endwith %}
 {% endblock %}


### PR DESCRIPTION
This reduces a few queries in project and builds pages:

before:
project home page: 15 queries take ~90ms, page takes ~500ms
builds page: 14 queries takes ~10ms, page takes ~300ms

after

project home page: 8 queries take ~8ms, page takes ~200ms, about 50% faster
builds page: 12 queries takes ~8ms, page takes ~250ms, about 30% faster