### PR TITLE
frontend: test_history: improve load time

### DIFF
--- a/squad/core/history.py
+++ b/squad/core/history.py
@@ -1,25 +1,32 @@
 from collections import OrderedDict
 from django.core.paginator import Paginator
+from django.db.models import Prefetch
+from django.db.models.query import prefetch_related_objects
 
-
-from squad.core.utils import parse_name
-from squad.core.models import Test
+from squad.core.utils import parse_name, split_list
+from squad.core.models import Test, SuiteMetadata, TestRun, KnownIssue
 
 
 class TestResult(object):
 
     __test__ = False
 
-    def __init__(self, test):
+    class TestRunStatus(object):
+        def __init__(self, test_run, suite):
+            self.test_run = test_run
+            self.suite = suite
+
+    def __init__(self, test, suite, metadata, known_issues):
         self.test = test
-        self.suite = test.suite
-        self.known_issues = test.known_issues.all()
+        self.suite = suite
+        self.known_issues = known_issues
         self.status = test.status
         self.test_run = test.test_run
+        self.test_run_status = self.TestRunStatus(self.test_run, self.suite)
         self.info = {
-            "test_description": test.metadata.description if test.metadata else '',
-            "suite_instructions": test.suite.metadata.instructions_to_reproduce if test.suite.metadata else '',
-            "test_instructions": test.metadata.instructions_to_reproduce if test.metadata else '',
+            "test_description": metadata.description if metadata else '',
+            "test_instructions": metadata.instructions_to_reproduce if metadata else '',
+            "suite_instructions": self.suite.metadata.instructions_to_reproduce if self.suite.metadata else '',
             "test_log": test.log
         }
 
@@ -28,11 +35,24 @@ class TestHistory(object):
 
     __test__ = False
 
+    def __get_tests__(self, builds, metadata):
+        test_runs = []
+        for build in builds:
+            for test_run in build.test_runs.all():
+                test_runs.append(test_run)
+
+        tests = []
+        for test_runs_batch in split_list(test_runs, chunk_size=100):
+            prefetch_related_objects(test_runs_batch, Prefetch('tests', queryset=Test.objects.filter(metadata=metadata).order_by()))
+            for test_run in test_runs_batch:
+                tests += test_run.tests.all()
+        return tests
+
     def __init__(self, project, full_test_name, top=None, page=1, per_page=20):
-        suite, test_name = parse_name(full_test_name)
+        suite_slug, test_name = parse_name(full_test_name)
         self.test = full_test_name
 
-        self.paginator = Paginator(project.builds.reverse(), per_page)
+        self.paginator = Paginator(project.builds.prefetch_related(Prefetch('test_runs', queryset=TestRun.objects.prefetch_related('environment').all())).reverse(), per_page)
         if top:
             self.number = 0
             builds = project.builds.filter(datetime__lte=top.datetime).reverse()[0:per_page - 1]
@@ -40,27 +60,31 @@ class TestHistory(object):
             self.number = page
             builds = self.paginator.page(page)
 
-        suite = project.suites.get(slug=suite)
-
-        tests = Test.objects.filter(
-            suite=suite,
-            name=test_name,
-            test_run__build__in=builds,
-        )
-        Test.prefetch_related(tests)
+        self.top = builds[0]
 
         environments = OrderedDict()
         results = OrderedDict()
         for build in builds:
             results[build] = {}
-        self.top = builds[0]
 
+        issues_by_env = {}
+        for issue in KnownIssue.active_by_project_and_test(project, full_test_name).all():
+            for env in issue.environments.all():
+                if env.id not in issues_by_env:
+                    issues_by_env[env.id] = []
+                issues_by_env[env.id].append(issue)
+
+        suite = project.suites.prefetch_related('metadata').get(slug=suite_slug)
+        metadata = SuiteMetadata.objects.get(kind='test', suite=suite_slug, name=test_name)
+        tests = self.__get_tests__(builds, metadata)
         for test in tests:
             build = test.test_run.build
             environment = test.test_run.environment
 
             environments[environment] = True
-            results[build][environment] = TestResult(test)
+            known_issues = issues_by_env.get(environment.id)
+
+            results[build][environment] = TestResult(test, suite, metadata, known_issues)
 
         self.environments = sorted(environments.keys(), key=lambda env: env.slug)
         self.results = results

--- a/squad/core/models.py
+++ b/squad/core/models.py
@@ -756,19 +756,6 @@ class Test(models.Model):
     def full_name(self):
         return join_name(self.suite.slug, self.name)
 
-    @staticmethod
-    def prefetch_related(tests):
-        prefetch_related_objects(
-            tests,
-            'known_issues',
-            'test_run',
-            'test_run__environment',
-            'test_run__build',
-            'test_run__build__project',
-            'test_run__build__project__group',
-            'test_run__status',
-        )
-
     class History(object):
         def __init__(self, since, count, last_different):
             self.since = since

--- a/squad/frontend/templates/squad/test_history.jinja2
+++ b/squad/frontend/templates/squad/test_history.jinja2
@@ -43,7 +43,7 @@
           {% if result %}
             {% with known_issues=result.known_issues %}
               <td class='{{result.status|slugify}}'>
-                <a href="{{testrun_suite_test_details_url(project.group, project, build, result.test_run.status.get(test_run=result.test_run, suite=result.suite), result.test)}}">{{result.status}}</a>
+                <a href="{{testrun_suite_test_details_url(project.group, project, build, result.test_run_status, result.test)}}">{{result.status}}</a>
                 {% if result.info['test_description'] or result.info['suite_instructions'] or result.info['test_instructions'] or result.info['test_log'] %}
                   <a href='#' data-toggle="modal" data-target="#info_modal" data-info="{{ to_json(result.info) }}"><span data-toggle="tooltip" data-placement="right" title="{{ _('Show info') }}" class='fa fa-info-circle'></span></a>
                 {% endif %}

--- a/test/core/test_history.py
+++ b/test/core/test_history.py
@@ -107,7 +107,9 @@ class TestHistoryTest(TestCase):
     def test_no_metadata(self):
         testrun = self.project1.builds.last().test_runs.last()
         suite = testrun.tests.last().suite
-        testrun.tests.create(name='no_metadata_test', result=False, suite=suite)
-        history = TestHistory(self.project1, 'no_metadata_test')
+        test_name = 'no_metadata_test'
+        metadata = models.SuiteMetadata.objects.create(kind='test', suite=suite.slug, name=test_name)
+        testrun.tests.create(name=test_name, result=False, suite=suite, metadata=metadata)
+        history = TestHistory(self.project1, test_name)
 
         self.assertIsNotNone(history.results)

--- a/test/frontend/test_history.py
+++ b/test/frontend/test_history.py
@@ -1,6 +1,6 @@
 from django.test import Client
 from django.test import TestCase
-from squad.core.models import Group
+from squad.core.models import Group, SuiteMetadata
 
 
 class TestHistoryTest(TestCase):
@@ -12,8 +12,10 @@ class TestHistoryTest(TestCase):
         env = project.environments.create(slug='myenv')
         suite = project.suites.create(slug='mysuite')
         build = project.builds.create(version='mybuild')
+        test_name = 'mytest'
+        metadata = SuiteMetadata.objects.create(kind='test', suite=suite.slug, name=test_name)
         self.testrun = build.test_runs.create(job_id='123', environment=env)
-        self.testrun.tests.create(name='mytest', suite=suite)
+        self.testrun.tests.create(name=test_name, suite=suite, metadata=metadata)
         self.testrun.status.create(test_run=self.testrun, suite=suite)
 
     def test_tests_history_with_empty_suite_metadata(self):


### PR DESCRIPTION
This does improve load time but increases the number of queries depending on how many test runs. Although it seems silly, doing so will prevent production from spending too much time joining tests x test_runs x builds