### PR TITLE
frontend: compare: improve compare load times

### DIFF
--- a/test/api/test_rest.py
+++ b/test/api/test_rest.py
@@ -125,7 +125,8 @@ class RestApiTest(APITestCase):
                     s, t = test_name.split('/')
                     r = {'pass': True, 'fail': False}[result]
                     suite, _ = self.project.suites.get_or_create(slug=s)
-                    testrun.tests.create(suite=suite, name=t, result=r)
+                    metadata, _ = models.SuiteMetadata.objects.get_or_create(suite=s, name=t, kind='test')
+                    testrun.tests.create(suite=suite, name=t, result=r, metadata=metadata)
 
         self.emailtemplate = models.EmailTemplate.objects.create(
             name="fooTemplate",


### PR DESCRIPTION
OK This time I took a bit more time reading the code and removing unnecessary queries. Another change in this patch is that instead of sending parallel ajax requests to the backend, it's done one-by-one.

Sending all in parallel via ajax kinda killed performance. The first ajax request as lightning fast but the rest just hung there. The one-by-one approach looked much better in my local env. Also, given that that page is a bit long depending on the number of projects, loading projects one-by-one fills the page accordingly.