### PR TITLE
api: rest: fix project filter

### DIFF
--- a/squad/api/rest.py
+++ b/squad/api/rest.py
@@ -75,7 +75,12 @@ class ProjectFilter(filters.FilterSet):
 
     def filter_full_name(self, queryset, field_name, value):
         if value:
-            queryset = queryset.annotate(fullname=Concat(F('group__slug'), V('/'), F('slug'),
+            group_slug = 'group__slug'
+            project_slug = 'slug'
+            if queryset.model is not Project:
+                group_slug = 'project__%s' % group_slug
+                project_slug = 'project__%s' % project_slug
+            queryset = queryset.annotate(fullname=Concat(F(group_slug), V('/'), F(project_slug),
                                          output_field=CharField())).filter(fullname__startswith=value)
         return queryset
 

--- a/test/api/test_rest.py
+++ b/test/api/test_rest.py
@@ -504,6 +504,11 @@ class RestApiTest(APITestCase):
         data = self.hit('/api/builds/?created_at=%s' % created_at)
         self.assertEqual(1, len(data['results']))
 
+    def test_build_filter_by_project(self):
+        project_full_name = self.build3.project.full_name
+        data = self.hit('/api/builds/?project__full_name=%s' % project_full_name)
+        self.assertEqual(6, len(data['results']))
+
     def test_testjob(self):
         data = self.hit('/api/testjobs/%d/' % self.testjob.id)
         self.assertEqual('myenv', data['environment'])


### PR DESCRIPTION
An update in django filters made ProjectFilter switch queryset from Build/Environment/etc and Project, crashing requests filtering builds by project's full_name.

This patch makes sure to use correct field name based on queryset model