### PR TITLE
frontend: fix test result url to point to history

### DIFF
--- a/squad/frontend/templates/squad/_results_table.jinja2
+++ b/squad/frontend/templates/squad/_results_table.jinja2
@@ -48,7 +48,7 @@
               {% if result %}
                 {% if comparison_type == 'test' %}
                   <td class='{{result|slugify}}'>
-                    <a href="{{url('test_history', args=[build.project.group.slug, build.project.slug, test])}}">
+                    <a href="{{url('legacy_test_history', args=[build.project.group.slug, build.project.slug, test])}}">
                       <strong>{{result}}</strong>
                     </a>
                   </td>


### PR DESCRIPTION
Fix hyberlinked url to point to test history in results table in
'Compare Builds' view.