### PR TITLE
api: rest: add filterset_class attribute to StatusViewSet

### DIFF
--- a/squad/api/rest.py
+++ b/squad/api/rest.py
@@ -1025,6 +1025,7 @@ class StatusViewSet(NestedViewSetMixin, viewsets.ReadOnlyModelViewSet):
     queryset = Status.objects
     serializer_class = StatusSerializer
     filterset_class = StatusFilter
+    filter_class = filterset_class  # TODO: remove when django-filters 1.x is not supported anymore
 
 
 class TestRunSerializer(serializers.HyperlinkedModelSerializer):

--- a/test/api/test_rest.py
+++ b/test/api/test_rest.py
@@ -585,6 +585,7 @@ class RestApiTest(APITestCase):
         self.assertEqual(0, data['results'][0]['tests_xfail'])
         self.assertEqual(0, data['results'][0]['tests_skip'])
         self.assertEqual(0, data['results'][0]['metrics_summary'])
+        self.assertEqual(1, data2['count'])
         self.assertEqual(None, data2['results'][0]['suite'])
 
     def test_testjob_definition(self):


### PR DESCRIPTION
This fixes the issue where "/api/testruns/2997715/status/?suite=54959" wouldn't filter correctly.