### PR TITLE
plugins: linux_log_parser: create metadata

### DIFF
--- a/squad/plugins/linux_log_parser.py
+++ b/squad/plugins/linux_log_parser.py
@@ -1,6 +1,7 @@
 import logging
 import re
 from squad.plugins import Plugin as BasePlugin
+from squad.core.models import SuiteMetadata
 
 
 logger = logging.getLogger()
@@ -55,11 +56,13 @@ class Plugin(BasePlugin):
         return snippets
 
     def __create_test(self, testrun, suite, test_name, lines):
+        metadata, _ = SuiteMetadata.objects.get_or_create(suite=suite.slug, name=test_name, kind='test')
         testrun.tests.create(
             suite=suite,
             name=test_name,
             result=(len(lines) == 0),
             log='\n'.join(lines),
+            metadata=metadata,
         )
 
     def postprocess_testrun(self, testrun):

--- a/test/plugins/test_linux_log_parser.py
+++ b/test/plugins/test_linux_log_parser.py
@@ -182,3 +182,10 @@ class TestLinuxLogParser(TestCase):
 
         tests = testrun.tests
         self.assertEqual(0, tests.count())
+
+    def test_metadata_creation(self):
+        testrun = self.build.test_runs.create(environment=self.env, log_file='Kernel panic - not syncing', job_id='999')
+        self.plugin.postprocess_testrun(testrun)
+
+        test = testrun.tests.get(suite__slug='linux-log-parser', name='check-kernel-panic-999')
+        self.assertIsNotNone(test.metadata)


### PR DESCRIPTION
This was the only spot in squad that wasn't creating a suitemetadata for tests.

I'm thinking about creating a migration to fill up all empty suitemetadata, but doing so would take a couple of hours (I've tested in testing db) 