### PR TITLE
settings: init sentry plugin with squad release

### DIFF
--- a/squad/settings.py
+++ b/squad/settings.py
@@ -365,10 +365,11 @@ if SENTRY_DSN:
     try:
         import sentry_sdk
         from sentry_sdk.integrations.django import DjangoIntegration
+        from squad.version import __version__ as squad_version
         sentry_sdk.init(
             dsn=SENTRY_DSN,
             integrations=[DjangoIntegration()],
-            release=os.getenv('ENV', 'squad'),
+            release='%s@%s' % (os.getenv('ENV', 'squad'), squad_version),
         )
     except ImportError:
         pass


### PR DESCRIPTION
This apparently make easier to identify when bugs got introduced depending on the release: https://docs.sentry.io/workflow/releases/