### PR TITLE
core: commands: add fill_test_metadata command

### DIFF
--- a/squad/core/management/commands/fill_test_metadata.py
+++ b/squad/core/management/commands/fill_test_metadata.py
@@ -1,0 +1,36 @@
+import logging
+
+from django.core.management.base import BaseCommand
+
+from squad.core.models import Test, SuiteMetadata
+
+
+logger = logging.getLogger()
+
+
+class Command(BaseCommand):
+
+    help = """Get or create SuiteMetadata objects to fill tests that have metadata == NULL"""
+
+    def add_arguments(self, parser):
+        parser.add_argument('--batch-size', type=int, help='How many tests to process at once. Use this to prevent OOM errors')
+        parser.add_argument('--show-progress', action='store_true', help='Prints out one dot every 1000 (one thousand) tests processed')
+
+    def handle(self, *args, **options):
+        show_progress = options['show_progress']
+        batch_size = options['batch_size']
+        logger.info("Filling metadata for %s tests" % (batch_size if batch_size else 'all'))
+        tests = Test.objects.filter(metadata__isnull=True).prefetch_related('suite')
+
+        if batch_size:
+            tests = tests[:batch_size]
+
+        count_processed = 0
+        for test in tests:
+            metadata, _ = SuiteMetadata.objects.get_or_create(suite=test.suite.slug, name=test.name, kind='test')
+            test.metadata = metadata
+            test.save()
+
+            count_processed += 1
+            if count_processed % 1000 == 0 and show_progress:
+                print('.', ending='', flush=True)

--- a/test/core/test_fill_test_metadata_command.py
+++ b/test/core/test_fill_test_metadata_command.py
@@ -1,0 +1,37 @@
+from django.core.management import call_command
+from django.test import TestCase
+
+from squad.core.models import Group, Test
+
+
+class ImportTest(TestCase):
+
+    def setUp(self):
+        group, _ = Group.objects.get_or_create(slug='foo')
+        project, _ = group.projects.get_or_create(slug='bar')
+        env, _ = project.environments.get_or_create(slug='env')
+        build, _ = project.builds.get_or_create(version='build')
+        self.testrun, _ = build.test_runs.get_or_create(environment=env)
+        self.suite, _ = project.suites.get_or_create(slug='suite')
+
+    def test_basics(self):
+        test, _ = self.testrun.tests.get_or_create(name='test_name', suite=self.suite)
+
+        self.assertIsNone(test.metadata)
+
+        call_command('fill_test_metadata')
+
+        test.refresh_from_db()
+        self.assertIsNotNone(test.metadata)
+
+    def test_batch(self):
+        test1, _ = self.testrun.tests.get_or_create(name='test_name1', suite=self.suite)
+        test2, _ = self.testrun.tests.get_or_create(name='test_name2', suite=self.suite)
+
+        self.assertIsNone(test1.metadata)
+        self.assertIsNone(test2.metadata)
+
+        call_command('fill_test_metadata', '--batch-size', '1')
+
+        tests = Test.objects.filter(metadata__isnull=True)
+        self.assertEqual(1, tests.count())


### PR DESCRIPTION
Closes https://github.com/Linaro/squad/issues/792

This will allow filling SuiteMetadata into tests which have metadata == NULL