### PR TITLE
frontend: home: separate groups by active, inactive and usernamespaces

### DIFF
--- a/squad/frontend/templates/squad/index.jinja2
+++ b/squad/frontend/templates/squad/index.jinja2
@@ -1,34 +1,58 @@
 {% extends "squad/base.jinja2" %}
 
 {% block content %}
-<h2 class="page-header well">{{ _('All groups') }}</h2>
 
 {% if user.is_authenticated %}
 <div style='margin-top: 2em; margin-bottom: 2em;'>
     <a class='btn btn-default' href="{{url("new-group")}}">{{ _('New group') }}</a>
 </div>
-
 {% endif %}
-<div class='highlight-row'>
-{% for group in groups %}
-<div class="row row-bordered project">
-    <a href="{{group_url(group)}}">
-    <div class="col-md-3 col-sm-3">
-        <strong>
-            {{group.display_name}}
-        </strong>
-    </div>
-    <div class="col-md-6 col-sm-6">
-        <p>
-        {{group.description|default("")|truncatechars_html(250)}}
-        </p>
-    </div>
-    <div class="col-md-3 col-sm-3">
-        {{ (_('%s projects') % ('<span class="badge" data-toggle="tooltip" data-placement="top" title="">%d</span>' % group.project_count)) | safe}}
-    </div>
-    </a>
-</div>
-{% endfor %}
-</div>
 
+
+{% set all_groups = {_('All groups'): all_groups, _('User spaces'): user_spaces} %}
+{% for title, groups in all_groups.items()  %}
+    <h2 class="page-header well">{{ title  }}</h2>
+    <div>
+        <form action="/" method="GET">
+            <label class="form-check-label" for="order">{{ _('Order by') }}:</label>
+            <input
+              name="order"
+              value="last_updated"
+              type="radio"
+              onchange="$(this.form).submit()"
+              {{ 'checked' if request.GET.get('order') != 'by_name' else ''}}
+            />
+            <span>{{ _('last updated') }}</span>&nbsp;
+            <input
+              name="order"
+              value="by_name"
+              type="radio"
+              onchange="$(this.form).submit()"
+              {{ 'checked' if request.GET.get('order') == 'by_name' else ''}}
+            />
+            <span>{{ _('name') }}</span>
+        </form>
+    </div>
+    <div class='highlight-row'>
+    {% for group in groups %}
+    <div class="row row-bordered project">
+        <a href="{{group_url(group)}}">
+        <div class="col-md-3 col-sm-3">
+            <strong>
+                {{group.display_name}}
+            </strong>
+        </div>
+        <div class="col-md-6 col-sm-6">
+            <p>
+            {{group.description|default("")|truncatechars_html(250)}}
+            </p>
+        </div>
+        <div class="col-md-3 col-sm-3">
+            {{ (_('%s projects') % ('<span class="badge" data-toggle="tooltip" data-placement="top" title="">%d</span>' % group.project_count)) | safe}}
+        </div>
+        </a>
+    </div>
+    {% endfor %}
+    </div>
+{% endfor %}
 {% endblock %}


### PR DESCRIPTION
Closes https://github.com/Linaro/squad/issues/798

This will split groups into three categories:
- active groups
- inactive groups (don't know if the term is too strong)
- user groups (groups starting with '~')

and it looks like this:

![Screenshot from 2020-08-03 17-12-50](https://user-images.githubusercontent.com/2254825/89223174-b8d0bc00-d5ac-11ea-9cc4-c95cc209787e.png)
