### PR TITLE
api: log user actions as LogEntry

### DIFF
--- a/squad/ci/models.py
+++ b/squad/ci/models.py
@@ -116,7 +116,7 @@ class Backend(models.Model):
 
         try:
             receive = ReceiveTestRun(test_job.target, update_project_status=False)
-            testrun = receive(
+            testrun, _ = receive(
                 version=test_job.target_build.version,
                 environment_slug=test_job.environment,
                 metadata_file=json.dumps(metadata),

--- a/squad/core/admin.py
+++ b/squad/core/admin.py
@@ -2,6 +2,10 @@ from django import forms
 from django.contrib import admin
 from django.forms import ModelForm, ModelMultipleChoiceField, CheckboxSelectMultiple
 from simple_history.admin import SimpleHistoryAdmin
+from django.contrib.admin.models import LogEntry, DELETION
+from django.utils.html import escape
+from django.urls import reverse
+from django.utils.safestring import mark_safe
 
 
 from . import models
@@ -205,6 +209,55 @@ class KnownIssueAdmin(admin.ModelAdmin):
     list_display = ['title', 'url', 'active', 'intermittent']
     list_filter = [KnownIssueGroupFilter]
     form = KnownIssueAdminForm
+
+
+@admin.register(LogEntry)
+class LogEntryAdmin(admin.ModelAdmin):
+    date_hierarchy = 'action_time'
+
+    list_filter = [
+        'user',
+        'content_type',
+        'action_flag'
+    ]
+
+    search_fields = [
+        'object_repr',
+        'change_message'
+    ]
+
+    list_display = [
+        'action_time',
+        'user',
+        'content_type',
+        'object_link',
+        'action_flag',
+    ]
+
+    def has_add_permission(self, request):
+        return False
+
+    def has_change_permission(self, request, obj=None):
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        return False
+
+    def has_view_permission(self, request, obj=None):
+        return request.user.is_superuser
+
+    def object_link(self, obj):
+        if obj.action_flag == DELETION:
+            link = escape(obj.object_repr)
+        else:
+            ct = obj.content_type
+            link = '<a href="%s">%s</a>' % (
+                reverse('admin:%s_%s_change' % (ct.app_label, ct.model), args=[obj.object_id]),
+                escape(obj.object_repr),
+            )
+        return mark_safe(link)
+    object_link.admin_order_field = "object_repr"
+    object_link.short_description = "object"
 
 
 admin.site.register(models.Group, GroupAdmin)

--- a/test/ci/test_models.py
+++ b/test/ci/test_models.py
@@ -415,7 +415,7 @@ class BackendFetchTest(BackendTestBase):
         backend_fetch.return_value = ('Completed', True, {}, {}, {}, None)
 
         env = self.project.environments.create(slug='foo')
-        receive.return_value = self.build.test_runs.create(environment=env)
+        receive.return_value = (self.build.test_runs.create(environment=env), None)
 
         test_job = self.create_test_job(
             backend=self.backend,
@@ -435,7 +435,7 @@ class BackendFetchTest(BackendTestBase):
         backend_fetch.return_value = ('Completed', True, {}, {}, {}, None)
 
         env = self.project.environments.create(slug='foo')
-        receive.return_value = self.build.test_runs.create(environment=env)
+        receive.return_value = (self.build.test_runs.create(environment=env), None)
 
         test_job = self.create_test_job(
             backend=self.backend,

--- a/test/core/test_tasks.py
+++ b/test/core/test_tasks.py
@@ -671,8 +671,8 @@ class CreateBuildTest(TestCase):
 
     def test_basics(self):
         create_build = CreateBuild(self.project)
-        baseline = create_build('0.0')
-        build = create_build(
+        baseline, created = create_build('0.0')
+        build, created = create_build(
             version='1.0',
             patch_source=self.patch_source,
             patch_id='111',
@@ -685,7 +685,7 @@ class CreateBuildTest(TestCase):
     @patch('squad.core.tasks.notify_patch_build_created')
     def test_notify_patch_source(self, notify_patch_build_created):
         create_build = CreateBuild(self.project)
-        build = create_build('1.0', patch_source=self.patch_source, patch_id='111')
+        build, created = create_build('1.0', patch_source=self.patch_source, patch_id='111')
         notify_patch_build_created.delay.assert_called_with(build.id)
 
     @patch('squad.core.tasks.notify_patch_build_created')


### PR DESCRIPTION
When user creates/changes/deletes an object using API new LogEntry
object is created. LogEntry objects are available in the admin view.

Fixes: #202, #473

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>