### PR TITLE
settings: django-toolbar: use squad jquery

### DIFF
--- a/squad/settings.py
+++ b/squad/settings.py
@@ -63,6 +63,11 @@ django_toolbar = None
 django_toolbar_middleware = None
 if DEBUG:
     try:
+
+        DEBUG_TOOLBAR_CONFIG = {
+            'JQUERY_URL': ''
+        }
+
         import imp
         imp.find_module('debug_toolbar')
         django_toolbar = 'debug_toolbar'


### PR DESCRIPTION
This fixes django toolbar in online instances, like in testing.

Ref: https://django-debug-toolbar.readthedocs.io/en/1.2/configuration.html