### PR TITLE
Allow equal sign in settings variable value.

### DIFF
--- a/squad/settings.py
+++ b/squad/settings.py
@@ -170,7 +170,7 @@ DATABASES = {
 }
 database_config = os.getenv('DATABASE')
 if database_config:
-    db_from_env = dict(x.split('=') for x in database_config.split(':'))
+    db_from_env = dict(x.split('=', 1) for x in database_config.split(';'))
     DATABASES['default'].update(db_from_env)
 
 


### PR DESCRIPTION
This will allow having i.e. django db options as part of the
database settings. Example {'options': '-c statement_timeout=5000'}.