### PR TITLE
frontent: build: include test jobs with no status in Test jobs tab

### DIFF
--- a/squad/ci/templatetags/filter_jobs.py
+++ b/squad/ci/templatetags/filter_jobs.py
@@ -1,8 +1,12 @@
-from django.db.models import Count
+from collections import defaultdict
 from squad.jinja2 import register_filter
 
 
 @register_filter
 def filter_jobs(build):
-    filtered_jobs = build.test_jobs.values_list('job_status').annotate(Count('job_status'))
+    statuses = defaultdict(int)
+    for status in build.test_jobs.values_list('job_status'):
+        key = status[0] or 'Created'
+        statuses[key] += 1
+    filtered_jobs = [(status, statuses[status]) for status in statuses]
     return filtered_jobs

--- a/squad/frontend/templates/squad/build-nav.jinja2
+++ b/squad/frontend/templates/squad/build-nav.jinja2
@@ -42,7 +42,7 @@
         {{ _('Metadata') }}
         </a>
     </li>
-    {% if build.test_jobs.count %}
+    {% if build.test_jobs.count() %}
     <li role="presentation" {% if url_name == 'testjobs' %}class="active"{% endif %}>
         <a href="{{build_section_url(build, 'testjobs')}}">
             {{ _('Test jobs') }}


### PR DESCRIPTION
Users complained that the "Test jobs" tab in the build view showed zero jobs, but when clicked, it showed a list of jobs.

This happened due to the way that tab was being counted. It didn't count jobs which "job_status=null".

This patch changes it so that it includes all test jobs despite of their status