### PR TITLE
Gerrit support custom tags

### DIFF
--- a/doc/plugins.rst
+++ b/doc/plugins.rst
@@ -170,6 +170,25 @@ Where:
  - `patch_id` is a string in a form like "change-id/patchset" of the respective Gerrit
    repository.
 
+**NOTE**
+
+By default, the plugin will only apply "Code-Review -1" for builds that errored.
+Custom labels are supported if specified in project settings. Here is a example on how
+to specify custom labels for gerrit:
+
+    ...
+    plugins:
+      gerrit:
+        build_finished:
+          success:
+            Code-Review: "+1"
+            Validation-Bot-Review: "+1"
+          error:
+            Code-Review: "-1"
+            My-Custom-Bot-Review: "-1"
+    ...
+
+
 If everything was successfully submitted, you should see a notification in the Gerrit
 page for that Change. Subsequent tests on that build are going to be performed
 and as SQUAD detects that all tests are done, another notification should be sent out

--- a/squad/core/models.py
+++ b/squad/core/models.py
@@ -306,6 +306,13 @@ class Project(models.Model, DisplayName):
     def enabled_plugins(self):
         return self.enabled_plugins_list
 
+    __settings__ = None
+
+    def get_setting(self, key, default=None):
+        if self.__settings__ is None:
+            self.__settings__ = yaml.safe_load(self.project_settings or '') or {}
+        return self.__settings__.get(key, default)
+
 
 # URLField uses URLValidator which supports only http(s) and ftp(s)
 # ref: https://github.com/django/django/pull/1717#issuecomment-25830269

--- a/squad/plugins/gerrit.py
+++ b/squad/plugins/gerrit.py
@@ -75,8 +75,10 @@ class Plugin(BasePlugin):
             patchset=patchset,
         )
 
-        if payload.get('labels') and payload['labels'].get('Code-Review'):
-            cmd += ' --code-review %s' % (payload['labels']['Code-Review'])
+        labels = payload.get('labels', {})
+        for label in labels.keys():
+            value = labels[label]
+            cmd += ' --label %s=%s' % (label.lower(), value)
 
         ssh = ['ssh']
         ssh += DEFAULT_SSH_OPTIONS

--- a/test/core/test_project.py
+++ b/test/core/test_project.py
@@ -82,3 +82,9 @@ class ProjectTest(TestCase):
             p.full_clean()
         p.project_settings = 'foo: bar\n'
         p.full_clean()
+
+    def test_get_project_settings(self):
+        p = Project.objects.create(group=self.group, slug='foobar', project_settings='{"setting1": "value"}')
+        self.assertEqual("value", p.get_setting("setting1"))
+        self.assertEqual(None, p.get_setting("unkown_setting"))
+        self.assertEqual("default", p.get_setting("unkown_setting", "default"))


### PR DESCRIPTION
Fixes https://github.com/Linaro/squad/issues/867

Project settings should include:
```yaml
    ...
    plugins:
      gerrit:
        build_finished:
          success:
            Code-Review: "+1"
            Validation-Bot-Review: "+1"
          error:
            Code-Review: "-1"
            My-Custom-Bot-Review: "-1"
    ...
```