### PR TITLE
settings: add option to turn off admin error emails

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -196,6 +196,14 @@ __ https://docs.djangoproject.com/en/1.11/topics/email/
   use in exception notifications. Each address must be formatted as
   ``First Last <first.last@example.com>``.
 
+* ``SQUAD_SEND_ADMIN_ERROR_EMAIL``: Determines whether or not to send exception
+  notifications to administrators. Defaults to ``True``.
+
+* ``SENTRY_DSN``: Defines Sentry's DSN token, if defined SQUAD will attempt to 
+  import Sentry SDK and use it. Defaults to ``None``. If Sentry is configured
+  it's recommended to disable sending admin notifications by setting
+  ``SQUAD_SEND_ADMIN_ERROR_EMAIL = False``.
+
 * ``SQUAD_STATIC_DIR``: Directory where SQUAD will find it's preprocessed
   static assets. This usually does not need to be set manually, and exists
   mostly for use in the Docker image.

--- a/squad/settings.py
+++ b/squad/settings.py
@@ -242,8 +242,9 @@ SITE_NAME = os.getenv('SQUAD_SITE_NAME', 'SQUAD')
 SQUAD_ADMINS = os.getenv('SQUAD_ADMINS')
 ADMINS = SQUAD_ADMINS and [parseaddr(s.strip()) for s in SQUAD_ADMINS.split(',')] or []
 
+SEND_ADMIN_ERROR_EMAIL = os.getenv('SQUAD_SEND_ADMIN_ERROR_EMAIL', True)
 logging_handlers = ['console']
-if not DEBUG and ADMINS:
+if not DEBUG and ADMINS and SEND_ADMIN_ERROR_EMAIL:
     logging_handlers += ['mail_admins']
 
 LOGGING = {


### PR DESCRIPTION
In setups where Sentry is configured, error emails might no longer be necessary. This patch checks an environment variable to decide whether or not send error emails to admins.