### PR TITLE
core: migrations: "rebased" migration to make test name nullable

### DIFF
--- a/squad/core/migrations/0139_nullable_test_name.py
+++ b/squad/core/migrations/0139_nullable_test_name.py
@@ -6,7 +6,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('core', '0137_patchsource_token_null'),
+        ('core', '0138_metric_unit'),
     ]
 
     operations = [


### PR DESCRIPTION
Fixes
```
CommandError: Conflicting migrations detected; multiple leaf nodes in the migration graph: (0138_nullable_test_name, 0138_metric_unit in core).
To fix them run 'python manage.py makemigrations --merge'
```