### PR TITLE
core: templates, notification. Fix broken links

### DIFF
--- a/squad/core/templates/squad/notification/diff.html.jinja2
+++ b/squad/core/templates/squad/notification/diff.html.jinja2
@@ -44,9 +44,9 @@
         <ul>
           {% for test in tests %}
           <li>
-            <a href="{{settings.BASE_URL}}/{{build.project}}/build/{{build.version}}/testrun/{{test.test_run.job_id}}">{{test.full_name}}</a>
+            <a href="{{settings.BASE_URL}}/{{build.project}}/build/{{build.version}}/testrun/{{test.test_run.id}}/suite/{{test.suite}}/test/{{test.name}}/details">{{test.full_name}}</a>
             {% if test.test_run.log_file %}
-            <a href="{{settings.BASE_URL}}/{{build.project}}/build/{{build.version}}/testrun/{{test.test_run.job_id}}/log">(log)</a>
+            <a href="{{settings.BASE_URL}}/{{build.project}}/build/{{build.version}}/testrun/{{test.test_run.id}}/suite/{{test.suite}}/test/{{test.name}}/log">(log)</a>
             {% endif %}
             {% for issue in known_issues %}
                 {% if issue.test_name == test.full_name %}


### PR DESCRIPTION
Fix broken testrun logs links in html notification.
Fixes: #864 