### PR TITLE
Parse results always expects metadata as a dict.

### DIFF
--- a/squad/ci/backend/lava.py
+++ b/squad/ci/backend/lava.py
@@ -606,6 +606,8 @@ class Backend(BaseBackend):
                 # Handle failed lava jobs
                 if result['suite'] == 'lava' and result['name'] == 'job' and result['result'] == 'fail':
                     metadata = result['metadata']
+                    if isinstance(metadata, str):
+                        metadata = yaml.safe_load(metadata)
                     test_job.failure = str(metadata)
                     test_job.save()
                     error_type = metadata.get('error_type', None)

--- a/test/ci/backend/test_lava.py
+++ b/test/ci/backend/test_lava.py
@@ -115,6 +115,15 @@ TEST_RESULTS_INFRA_FAILURE = [
     },
 ]
 
+TEST_RESULTS_INFRA_FAILURE_STR = [
+    {
+        'suite': 'lava',
+        'name': 'job',
+        'result': 'fail',
+        'metadata': "{'error_type': 'Infrastructure', 'error_msg': 'foo-bar'}",
+    },
+]
+
 TEST_RESULT_FAILURE_CUSTOM = "Testing, testing... 123"
 TEST_RESULTS_INFRA_FAILURE_CUSTOM = [
     {
@@ -689,6 +698,18 @@ class LavaTest(TestCase):
     @patch("squad.ci.backend.lava.Backend.__get_job_details__", return_value=JOB_DETAILS)
     @patch("squad.ci.backend.lava.Backend.__get_testjob_results_yaml__", return_value=TEST_RESULTS_INFRA_FAILURE)
     def test_completed(self, get_results, get_details, get_logs):
+        lava = LAVABackend(None)
+        testjob = TestJob(
+            job_id='1234',
+            backend=self.backend,
+            target=self.project)
+        status, completed, metadata, results, metrics, logs = lava.fetch(testjob)
+        self.assertFalse(completed)
+
+    @patch("squad.ci.backend.lava.Backend.__download_full_log__", return_value=LOG_DATA)
+    @patch("squad.ci.backend.lava.Backend.__get_job_details__", return_value=JOB_DETAILS)
+    @patch("squad.ci.backend.lava.Backend.__get_testjob_results_yaml__", return_value=TEST_RESULTS_INFRA_FAILURE_STR)
+    def test_incomplete_string_results_metadata(self, get_results, get_details, get_logs):
         lava = LAVABackend(None)
         testjob = TestJob(
             job_id='1234',


### PR DESCRIPTION
The LAVA REST API returns the test result metadata as a string,
contrary to the XMLRPC. We need to yaml load if the metadata
is a string.