### PR TITLE
setup: make postgres optional

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -11,11 +11,22 @@ Make sure you have the ``pip`` Python package manager installed on your Python 3
 environment, and the C library for YAML development. On Debian/Ubuntu,
 the easiest way to do that is::
 
-    apt-get install python3-pip libyaml-dev libpq-dev
+    apt-get install python3-pip libyaml-dev
 
 Install squad::
 
     pip3 install squad
+
+
+By default, SQUAD works with sqlite, but if Postgres is required, then specific
+binaries are needed::
+
+    apt-get install python3-pip libyaml-dev libpq-dev
+
+Install squad with Postgres support::
+
+    pip3 install squad[postgres]
+
 
 Message broker
 --------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,6 @@ gunicorn
 Jinja2
 Markdown
 msgpack>=0.5.0
-psycopg2
 python_dateutil
 PyYAML>=5.1
 pyzmq

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,10 @@ requirements = [req for req in requirements_txt if valid_requirement(req)]
 if os.getenv('REQ_IGNORE_VERSIONS'):
     requirements = [req.split('>=')[0] for req in requirements]
 
+extras_require = {
+    'postgres': 'psycopg2',
+}
+
 
 if len(sys.argv) > 1 and sys.argv[1] in ['sdist', 'bdist', 'bdist_wheel'] and not os.getenv('SQUAD_RELEASE'):
     raise RuntimeError('Please use scripts/release to make releases!')
@@ -39,6 +43,7 @@ setup(
         ]
     },
     install_requires=requirements,
+    extras_require=extras_require,
     license='AGPLv3+',
     description="Software Quality Dashboard",
     long_description="Software Quality Dashboard",  # FIXME


### PR DESCRIPTION
Fixes https://github.com/Linaro/squad/issues/878
Installing SQUAD requires psycopg2 even if the setup is used with sqlite only. This patch makes installing squad avoid installing
postgres drivers. Run `pip install squad[postgres]` to have pip download psycopg2.