### PR TITLE
frontend: views: avoid loading attachment data

### DIFF
--- a/squad/frontend/views.py
+++ b/squad/frontend/views.py
@@ -10,7 +10,7 @@ from django.shortcuts import render, get_object_or_404, redirect
 
 from squad.ci.models import TestJob
 from squad.core.models import Group, Metric, ProjectStatus, Status, MetricThreshold, KnownIssue
-from squad.core.models import Build, Subscription, TestRun, Project, SuiteMetadata
+from squad.core.models import Build, Subscription, TestRun, Project, SuiteMetadata, Attachment
 from squad.core.queries import get_metric_data
 from squad.frontend.queries import get_metrics_list
 from squad.frontend.utils import file_type, alphanum_sort
@@ -358,9 +358,11 @@ def build(request, group_slug, project_slug, version):
     if failures_only == 'true':
         queryset = queryset.filter(tests_fail__gt=0)
 
+    prefetch_attachments = Prefetch('attachments', queryset=Attachment.objects.defer('data'))
+
     __statuses__ = queryset.prefetch_related(
         'suite',
-        Prefetch('test_run', queryset=TestRun.objects.prefetch_related('environment', 'attachments').all())
+        Prefetch('test_run', queryset=TestRun.objects.prefetch_related('environment', prefetch_attachments).all())
     ).order_by('-tests_fail', 'suite__slug', '-test_run__environment__slug')
 
     test_results = TestResultTable()


### PR DESCRIPTION
This commit https://github.com/Linaro/squad/commit/6ced55dd78fd61dd26827d8df24c1e990da7eb0f has introduced attachment downloads, it also makes the frontend prefetch attachments blindly, which contains `data` field where all data resides. This PR avoids loading this data, only attachment name is needed.