### PR TITLE
(very)WIP: Paginate comparison to improve performance

### DIFF
--- a/squad/settings.py
+++ b/squad/settings.py
@@ -64,7 +64,7 @@ except ImportError:
 
 django_toolbar = None
 django_toolbar_middleware = None
-if DEBUG:
+if DEBUG and False:
     try:
 
         DEBUG_TOOLBAR_CONFIG = {


### PR DESCRIPTION
Fixes https://github.com/Linaro/squad/issues/846

This is an early WIP that attempts to improve load times for comparison operations.

### Problem
Here's what currently happens (with very ugly pseudo code summarized from real code):
```python3
1. builds = [baseline_build, target_build]
2. testruns = TestRun.filter(builds)
3.
4. # take batches of 100 testruns
5. tests = []
6. for split_testruns in split_dict(testruns, 100):
7.    tests.append(Test.filter(split_testruns))
8.
9. results_table = apply_transitions(tests, [('pass', 'fail'), ('fail', 'pass'))])
10. page = Paginate(results_table, page=request.GET.get('page'), per_page=50)
```

Problem starts on lines `5-7`, where all tests are loaded into memory. A while ago I changed this so we could fetch tests without applying `JOIN` between Test and TestRun by fetching tests using batches of testruns. This solved an issue that was slowing down the DB.

With android-lkft testruns containing millions of tests, this snippet no longer perform well. This query runs really slow!

There's a second problem on lines `9-10`. It does a full comparison across all tests and all builds to just then display a teensy-weensy portion of it.

### Idea

The perfect solution was to get a list of the tests to be displayed prior to run full comparison. The problem is there's no easy way to get that without either loading all tests in memory (bad) or JOIN Test and Build ON TestRun (really bad).

The idea of this PR is a best effort torwards that idea. We can get a smaller/per-page list of tests from the DB if we restrict filtering to use one Suite and one (or a few) TestRuns.

Here's what I'm suggesting

```python3
1. suite = Suite.filter(request.GET.get('suite_slug'))
2. page = request.GET.get('page')
3. per_page = 50
4.
5. builds = [baseline_build, target_build]
6. testruns = TestRun.filter(builds)
7. statuses = Status.filter(testruns, suite)
8.
9. # Now testruns contains only the ones with suite_slug in it
10. testruns = [s.test_run for s in statuses]
11.
12. # testruns should be 1 or a small number
13. tests = Test.filter(testruns, suite).order_by('metadata__name')[page:page + per_page]
14.
15. page = apply_transitions(tests, [('pass', 'fail'), ('fail', 'pass'))])
```

The biggest difference is that we'd be fetching paginated tests from the DB, so instead of loading millions of tests, only `per_page=50` is loaded. 

I've pulled the build with 1M+ tests and run a comparison against a build with much less tests and it loaded almost instantaneously. I guess DB is OK with applying `OFFSET` and `LIMIT` on a dataset with millions of tests, it just doesn't like to make joins on a half a billion records table.

I still need to figure out what to do if the number of items in `page` is less than `per_page` after `apply_transitions`. Maybe a new trip to DB can be done, I dunno yet.

Thoughts? @mwasilew @stevanradakovic 