### PR TITLE
api: improve testrun tests load times

### DIFF
--- a/squad/api/rest.py
+++ b/squad/api/rest.py
@@ -42,7 +42,6 @@ from rest_framework.decorators import action
 from rest_framework.exceptions import NotFound
 from rest_framework.response import Response
 from rest_framework.reverse import reverse as rest_reverse
-from rest_framework.pagination import PageNumberPagination
 from rest_framework.permissions import AllowAny
 from squad.compat import ComplexFilterBackend
 from squad.api.utils import CursorPaginationWithPageSize
@@ -1088,7 +1087,7 @@ class SuiteViewSet(viewsets.ModelViewSet):
     def tests(self, request, pk=None):
         suite = self.get_object()
         tests = Test.objects.filter(suite=suite).prefetch_related('metadata', 'suite', 'known_issues').order_by('id')
-        paginator = PageNumberPagination()
+        paginator = CursorPaginationWithPageSize()
         page = paginator.paginate_queryset(tests, request)
         serializer = TestSerializer(page, many=True, context={'request': request}, remove_fields=['suite'])
         return paginator.get_paginated_response(serializer.data)
@@ -1240,8 +1239,8 @@ class TestRunViewSet(ModelViewSet):
     @action(detail=True, methods=['get'], suffix='tests')
     def tests(self, request, pk=None):
         testrun = self.get_object()
-        tests = testrun.tests.prefetch_related('suite').order_by('id')
-        paginator = PageNumberPagination()
+        tests = testrun.tests.prefetch_related('suite', 'known_issues', 'metadata').order_by('id')
+        paginator = CursorPaginationWithPageSize()
         page = paginator.paginate_queryset(tests, request)
         serializer = TestSerializer(page, many=True, context={'request': request}, remove_fields=['test_run'])
         return paginator.get_paginated_response(serializer.data)
@@ -1250,7 +1249,7 @@ class TestRunViewSet(ModelViewSet):
     def metrics(self, request, pk=None):
         testrun = self.get_object()
         metrics = testrun.metrics.prefetch_related('suite').order_by('id')
-        paginator = PageNumberPagination()
+        paginator = CursorPaginationWithPageSize()
         page = paginator.paginate_queryset(metrics, request)
         serializer = MetricSerializer(page, many=True, context={'request': request}, remove_fields=['test_run', 'id', 'suite'])
         return paginator.get_paginated_response(serializer.data)

--- a/squad/api/utils.py
+++ b/squad/api/utils.py
@@ -11,6 +11,7 @@ class DisabledHTMLFilterBackend(RestFrameworkFilterBackend):
 
 class CursorPaginationWithPageSize(CursorPagination):
     page_size_query_param = 'limit'
+    ordering = '-id'
 
 
 # ref: https://bradmontgomery.net/blog/disabling-forms-django-rest-frameworks-browsable-api/

--- a/test/api/test_rest.py
+++ b/test/api/test_rest.py
@@ -848,5 +848,5 @@ class RestApiTest(APITestCase):
 
     def test_suite_tests(self):
         foo_suite = self.project.suites.get(slug='foo')
-        data = self.hit('/api/suites/%d/tests/' % foo_suite.id)
-        self.assertEqual(54, data['count'])
+        data = self.hit('/api/suites/%d/tests/?limit=1000' % foo_suite.id)
+        self.assertEqual(54, len(data['results']))


### PR DESCRIPTION
This times out: https://qa-reports.linaro.org/api/testruns/3202175/tests/