### PR TITLE
Use storage

### DIFF
--- a/squad/core/management/commands/migrate_attachments.py
+++ b/squad/core/management/commands/migrate_attachments.py
@@ -1,8 +1,58 @@
-from io import BytesIO, StringIO
-from django.core.files import File
+import math
+import multiprocessing
+import threading
+
+from django.core.files.base import ContentFile
 from django.core.management.base import BaseCommand
+from django.db.models import Q
 
 from squad.core.models import Attachment, TestRun
+from squad.core.utils import split_list
+
+
+STEP = 1000
+
+
+class TestRunFileExporterThread(threading.Thread):
+    def __init__(self, thread_id, testrun_ids, show_progress=False):
+        threading.Thread.__init__(self)
+        self.thread_id = thread_id
+        self.testrun_ids = testrun_ids
+        self.show_progress = show_progress
+
+    def run(self):
+        count = len(self.testrun_ids)
+        print('[thread-%s] processing %d testruns' % (self.thread_id, count))
+        for offset in range(0, count, STEP):
+            ids = self.testrun_ids[offset:offset + STEP]
+            for testrun in TestRun.objects.filter(id__in=ids).prefetch_related('attachments').all():
+                export_testrun_files(testrun)
+
+            if self.show_progress:
+                print('.', end='', flush=True)
+        print('[thread-%s] done' % self.thread_id)
+
+
+def export_testrun_files(testrun):
+    if not testrun.tests_file_storage:
+        storage_save(testrun, testrun.tests_file_storage, 'tests_file', testrun.tests_file)
+
+    if not testrun.metrics_file_storage:
+        storage_save(testrun, testrun.metrics_file_storage, 'metrics_file', testrun.metrics_file)
+
+    if not testrun.log_file_storage:
+        storage_save(testrun, testrun.log_file_storage, 'log_file', testrun.log_file)
+
+    for attachment in testrun.attachments.all():
+        storage_save(attachment, attachment.storage, attachment.filename, attachment.data)
+
+
+def storage_save(obj, storage_field, filename, content):
+    content_bytes = content or ''
+    if type(content_bytes) == str:
+        content_bytes = content_bytes.encode()
+    filename = '%s/%s/%s' % (obj.__class__.__name__.lower(), obj.pk, filename)
+    storage_field.save(filename, ContentFile(content_bytes))
 
 
 class Command(BaseCommand):
@@ -15,46 +65,41 @@ class Command(BaseCommand):
         parser.add_argument(
             '--show-progress',
             action='store_true',
-            help='Prints out one dot every 1000 (one thousand) attachments/testruns processed'
+            help='Prints out one dot every 1000 (one thousand) testruns processed'
         )
 
     def handle(self, *args, **options):
         show_progress = options['show_progress']
-        attachment_index = 0
-        for attachment in Attachment.objects.all():
-            if not attachment.storage:
-                contents = BytesIO(bytes(attachment.data))
-                contents_file = File(contents)
-                storage_filename = "%s/%s/%s" % (
-                    attachment.__class__.__name__.lower(),
-                    attachment.id,
-                    attachment.filename
-                )
-                attachment.storage.save(storage_filename, contents_file)
-            attachment_index += 1
-            if attachment_index % 1000 == 0 and show_progress:
-                print('.', end='', flush=True)
 
-        testrun_index = 0
-        for testrun in TestRun.objects.all():
-            if not testrun.tests_file_storage:
-                tests_file_contents = StringIO(testrun.tests_file)
-                tests_file = File(tests_file_contents)
-                storage_filename = "testrun/%s/tests_file" % (testrun.id)
-                testrun.tests_file_storage.save(storage_filename, tests_file)
+        null_storage_files = Q(tests_file_storage__isnull=True) | Q(metrics_file_storage__isnull=True) | Q(log_file_storage__isnull=True)
+        testrun_ids = TestRun.objects.filter(null_storage_files).order_by('id').values_list('id', flat=True)
 
-            if not testrun.metrics_file_storage:
-                metrics_file_contents = StringIO(testrun.metrics_file)
-                metrics_file = File(metrics_file_contents)
-                storage_filename = "testrun/%s/metrics_file" % (testrun.id)
-                testrun.metrics_file_storage.save(storage_filename, metrics_file)
+        if len(testrun_ids) == 0:
+            print('Nothing to do!')
+            return
 
-            if not testrun.log_file_storage:
-                log_file_contents = StringIO(testrun.log_file)
-                log_file = File(log_file_contents)
-                storage_filename = "testrun/%s/log_file" % (testrun.id)
-                testrun.log_file_storage.save(storage_filename, log_file)
+        num_threads = multiprocessing.cpu_count() * 2
+        chunk_size = math.floor(len(testrun_ids) / num_threads) + 1
+        chunks = split_list(testrun_ids, chunk_size=chunk_size)
 
-            testrun_index += 1
-            if testrun_index % 1000 == 0 and show_progress:
-                print('.', end='', flush=True)
+        threads = []
+        for chunk in chunks:
+            thread = TestRunFileExporterThread(len(threads), chunk, show_progress=show_progress)
+            thread.start()
+            threads.append(thread)
+
+        for thread in threads:
+            thread.join()
+
+        # Check that everything worked as expected
+        count = TestRun.objects.filter(null_storage_files).count()
+        if count > 0:
+            print('Something went wrong! %d test runs still do not have files exported' % count)
+            return
+
+        count = Attachment.objects.filter(storage__isnull=True).count()
+        if count > 0:
+            print('Something went wrong! %d attachments still do not have files exported' % count)
+            return
+
+        print('Done!')

--- a/squad/core/tasks/__init__.py
+++ b/squad/core/tasks/__init__.py
@@ -1,4 +1,5 @@
 from django.core.exceptions import MultipleObjectsReturned
+from django.core.files.base import ContentFile
 from django.utils import timezone
 from collections import defaultdict
 import json
@@ -162,8 +163,18 @@ class ReceiveTestRun(object):
             **metadata_fields
         )
 
+        if tests_file is not None:
+            testrun.tests_file_storage.save("testrun/%s/tests_file" % testrun.pk, ContentFile(tests_file.encode()))
+
+        if metrics_file is not None:
+            testrun.metrics_file_storage.save("testrun/%s/metrics_file" % testrun.pk, ContentFile(metrics_file.encode()))
+
+        if log_file is not None:
+            testrun.log_file_storage.save("testrun/%s/log_file" % testrun.pk, ContentFile(log_file.encode()))
+
         for f, data in attachments.items():
-            testrun.attachments.create(filename=f, data=data, length=len(data))
+            attachment = testrun.attachments.create(filename=f, data=data, length=len(data))
+            attachment.storage.save("attachment/%s/%s" % (attachment.pk, f), ContentFile(data))
 
         testrun.refresh_from_db()
 

--- a/test/core/test_tasks.py
+++ b/test/core/test_tasks.py
@@ -522,6 +522,7 @@ class ReceiveTestRunTest(TestCase):
         testrun = TestRun.objects.last()
 
         self.assertEqual(LOG_FILE_CONTENT, testrun.log_file)
+        self.assertEqual(LOG_FILE_CONTENT, testrun.log_file_storage.read().decode())
 
     def test_logfile_with_null_bytes(self):
         receive = ReceiveTestRun(self.project)
@@ -535,6 +536,7 @@ class ReceiveTestRunTest(TestCase):
         testrun = TestRun.objects.last()
 
         self.assertEqual(LOG_FILE_PROPER_CONTENT, testrun.log_file)
+        self.assertEqual(LOG_FILE_PROPER_CONTENT, testrun.log_file_storage.read().decode())
 
     def test_build_datetime(self):
         receive = ReceiveTestRun(self.project)


### PR DESCRIPTION
Inspired from https://github.com/Linaro/squad/pull/850

This PR makes use of storage fields without removing legacy ones. The intention is to start saving data to both DB and S3 so that when migrate legacy data to S3 we'll be sure that no data will be lost.

Next step will be replacing db data by S3 data.