### PR TITLE
Fix doc quotes

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -193,4 +193,4 @@ epub_copyright = copyright
 # A list of files that should not be packed into the epub file.
 epub_exclude_files = ['search.html']
 
-
+smartquotes = False

--- a/doc/plugins.rst
+++ b/doc/plugins.rst
@@ -176,7 +176,9 @@ By default, the plugin will only apply "Code-Review -1" for builds that errored.
 Custom labels are supported if specified in project settings. Here is a example on how
 to specify custom labels for gerrit:
 
-    ...
+
+.. code-block:: yaml
+
     plugins:
       gerrit:
         build_finished:
@@ -186,7 +188,6 @@ to specify custom labels for gerrit:
           error:
             Code-Review: "-1"
             My-Custom-Bot-Review: "-1"
-    ...
 
 
 If everything was successfully submitted, you should see a notification in the Gerrit


### PR DESCRIPTION
Quotes in gerrit plugin doc caused a misconfiguration to happen, this PR makes sure that quotes look just like the way they were supposed to look and also make gerrit yaml configuration look like yaml syntax.