### PR TITLE
core: delay notification if there are PluginScratch-es

### DIFF
--- a/squad/core/tasks/notification.py
+++ b/squad/core/tasks/notification.py
@@ -50,8 +50,10 @@ def maybe_notify_project_status(status_id):
             return
 
     if projectstatus.finished and not projectstatus.notified:
-        notify_patch_build_finished.delay(projectstatus.build_id)
-        send_status_notification(projectstatus)
+        # check if there are any outstanding PluginScratch objects
+        if not projectstatus.build.pluginscratch_set.all():
+            notify_patch_build_finished.delay(projectstatus.build_id)
+            send_status_notification(projectstatus)
 
 
 @celery.task


### PR DESCRIPTION
When plugin is still running on the build, but the ProjectStatus for
this build is marked as finished, delay sending notification until
timeout or until the plugin finishes (whichever comes first)

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>