### PR TITLE
api: rest: hide storage fields

### DIFF
--- a/squad/api/rest.py
+++ b/squad/api/rest.py
@@ -1053,7 +1053,7 @@ class TestRunSerializer(serializers.HyperlinkedModelSerializer):
 
     class Meta:
         model = TestRun
-        fields = '__all__'
+        exclude = ['tests_file_storage', 'metrics_file_storage', 'log_file_storage']
 
 
 class SuiteSerializer(serializers.HyperlinkedModelSerializer):


### PR DESCRIPTION
These aren't useful for the enduser and they'll be abstracted by their non-storage siblings.