### PR TITLE
ci: models: clear TestJob.falure on successful

### DIFF
--- a/squad/ci/models.py
+++ b/squad/ci/models.py
@@ -93,6 +93,7 @@ class Backend(models.Model):
 
             test_job.fetched = True
             test_job.fetched_at = timezone.now()
+            test_job.failure = None
             test_job.save()
 
         status, completed, metadata, tests, metrics, logs = results


### PR DESCRIPTION
TestJobs that received TemporaryFetchIssue and are successfuly fetched afterwards still keep the failure in them. This patch makes sure to clear any failure on successful fetches.