### PR TITLE
ci: tasks: submit: log message as warning instead of error

### DIFF
--- a/squad/ci/tasks.py
+++ b/squad/ci/tasks.py
@@ -38,11 +38,13 @@ def submit(self, job_id):
             test_job.failure = None
             test_job.save()
         except SubmissionIssue as issue:
-            logger.error("submitting job %s to %s: %s" % (test_job.id, test_job.backend.name, str(issue)))
             test_job.failure = str(issue)
             test_job.save()
+
             if issue.retry:
                 raise self.retry(exc=issue, countdown=3600)  # retry in 1 hour
+
+            logger.warning("submitting job %s to %s: %s" % (test_job.id, test_job.backend.name, str(issue)))
 
 
 @celery.task


### PR DESCRIPTION
This will log SubmissionIssue as warning. TemporarySubmissionIssue will be saved (temporarily) to TestJob.failure. The intention is to leave Lava instability errors as warning only. Thoughts? There's a similar PR in squadplugins https://github.com/Linaro/squadplugins/pull/34