### PR TITLE
ci: lava: clear TestJob.failure in backend implementation

### DIFF
--- a/squad/ci/backend/lava.py
+++ b/squad/ci/backend/lava.py
@@ -123,6 +123,7 @@ class Backend(BaseBackend):
                         end_time = None
                 test_job.started_at = start_time
                 test_job.ended_at = end_time
+                test_job.failure = None
                 test_job.save()
                 data['results'] = self.__get_testjob_results_yaml__(test_job.job_id)
 

--- a/squad/ci/models.py
+++ b/squad/ci/models.py
@@ -93,7 +93,6 @@ class Backend(models.Model):
 
             test_job.fetched = True
             test_job.fetched_at = timezone.now()
-            test_job.failure = None
             test_job.save()
 
         status, completed, metadata, tests, metrics, logs = results

--- a/test/ci/backend/test_lava.py
+++ b/test/ci/backend/test_lava.py
@@ -896,6 +896,7 @@ class LavaTest(TestCase):
             target=self.project)
         status, completed, metadata, results, metrics, logs = lava.fetch(testjob)
         self.assertFalse(completed)
+        self.assertEqual(TEST_RESULTS_INFRA_FAILURE_STR[0]['metadata'], testjob.failure)
 
     @patch("squad.ci.backend.lava.Backend.__download_full_log__", return_value=LOG_DATA)
     @patch("squad.ci.backend.lava.Backend.__get_job_details__", return_value=JOB_DETAILS_CANCELED)

--- a/test/ci/test_tasks.py
+++ b/test/ci/test_tasks.py
@@ -67,6 +67,8 @@ class FetchTest(TestCase):
         tests = {}
         metrics = {}
         logs = ''
+        test_job.failure = None
+        test_job.save()
         return status, completed, metadata, tests, metrics, logs
 
     @patch('squad.ci.models.Backend.fetch')


### PR DESCRIPTION
Cleaning TestJob.failure outside of Backend.get_implementation() can hide backend-specific errors.