### PR TITLE
settings: increase max upload size to 10MB

### DIFF
--- a/squad/settings.py
+++ b/squad/settings.py
@@ -397,6 +397,9 @@ if SENTRY_DSN:
     except ImportError:
         pass
 
+# Django's default is 2.5MB, which is a bit low
+DATA_UPLOAD_MAX_MEMORY_SIZE = 10485760  # 10MB
+
 try:
     from squad.local_settings import *  # noqa: F401,F403
 except ImportError:


### PR DESCRIPTION
From Sentry we've got `Request body exceeded settings.DATA_UPLOAD_MAX_MEMORY_SIZE`. It defaults to 2.5MB according [docs](https://docs.djangoproject.com/en/3.1/ref/settings/#data-upload-max-memory-size). This PR just increases it to 10MB, which I think it's a fine number.

BTW this error was generated when a user tried to submit 5MB of data.