### PR TITLE
Add build tests api

### DIFF
--- a/squad/api/rest.py
+++ b/squad/api/rest.py
@@ -195,6 +195,11 @@ class TestFilter(filters.FilterSet):
     test_run = filters.RelatedFilter(TestRunFilter, field_name="test_run", queryset=TestRun.objects.all(), widget=forms.TextInput)
     suite = filters.RelatedFilter(SuiteFilter, field_name="suite", queryset=Suite.objects.all(), widget=forms.TextInput)
     known_issues = filters.RelatedFilter(KnownIssueFilter, field_name='known_issues', queryset=KnownIssue.objects.all(), widget=forms.TextInput)
+    build = filters.RelatedFilter(BuildFilter, field_name="build", queryset=Build.objects.all())
+    environment = filters.RelatedFilter(EnvironmentFilter, field_name='environment', queryset=Environment.objects.all())
+    metadata = filters.RelatedFilter(SuiteMetadataFilter, field_name='metadata', queryset=SuiteMetadata.objects.all())
+
+    # Support for legacy clients, name should be queried using metadata
     name = filters.CharFilter(lookup_expr='icontains', field_name='metadata__name')
 
     class Meta:

--- a/test/api/test_rest.py
+++ b/test/api/test_rest.py
@@ -630,6 +630,36 @@ class RestApiTest(APITestCase):
         data = self.hit('/api/builds/%d/testjobs/' % self.build.id)
         self.assertEqual(1, len(data['results']))
 
+    def test_build_tests(self):
+        data = self.hit('/api/builds/%d/tests/' % self.build.id)
+        self.assertEqual(36, len(data['results']))
+
+    def test_build_tests_per_environment(self):
+        data = self.hit('/api/builds/%d/tests/?environment__slug=myenv' % self.build.id)
+        self.assertEqual(18, len(data['results']))
+
+    def test_build_tests_per_environment_not_found(self):
+        data = self.hit('/api/builds/%d/tests/?environment__slug=mycrazynonexistenenv' % self.build.id)
+        self.assertEqual(0, len(data['results']))
+
+    def test_build_tests_per_suite(self):
+        data = self.hit('/api/builds/%d/tests/?suite__slug=foo' % self.build.id)
+        self.assertEqual(18, len(data['results']))
+
+    def test_build_tests_per_suite_not_found(self):
+        data = self.hit('/api/builds/%d/tests/?suite__slug=fooooooodoesreallyexist' % self.build.id)
+        self.assertEqual(0, len(data['results']))
+
+    def test_build_tests_per_suite_and_environment(self):
+        data = self.hit('/api/builds/%d/tests/?environment__slug=myenv&suite__slug=foo' % self.build.id)
+        self.assertEqual(9, len(data['results']))
+
+        data = self.hit('/api/builds/%d/tests/?environment__slug=mycraaaaazyenv&suite__slug=foo' % self.build.id)
+        self.assertEqual(0, len(data['results']))
+
+        data = self.hit('/api/builds/%d/tests/?environment__slug=myenv&suite__slug=foooooooosuitedoestexist' % self.build.id)
+        self.assertEqual(0, len(data['results']))
+
     def test_build_filter(self):
         created_at = str(self.build3.created_at.isoformat()).replace('+00:00', 'Z')
         data = self.hit('/api/builds/?created_at=%s' % created_at)

--- a/test/api/test_rest.py
+++ b/test/api/test_rest.py
@@ -658,6 +658,36 @@ class RestApiTest(APITestCase):
         self.assertEqual(list, type(data['results']))
         self.assertEqual(0, len(data['results']))
 
+    def test_tests_filter_by_metadata_name(self):
+        data = self.hit('/api/tests/?metadata__name=test1')
+        self.assertEqual(list, type(data['results']))
+        self.assertEqual(12, len(data['results']))
+
+    def test_tests_filter_by_metadata_name_not_found(self):
+        data = self.hit('/api/tests/?metadata__name=test-that-does-not-exist')
+        self.assertEqual(list, type(data['results']))
+        self.assertEqual(0, len(data['results']))
+
+    def test_tests_filter_by_environment(self):
+        data = self.hit('/api/tests/?environment__slug=myenv')
+        self.assertEqual(list, type(data['results']))
+        self.assertEqual(50, len(data['results']))
+
+    def test_tests_filter_by_environment_not_found(self):
+        data = self.hit('/api/tests/?environment__slug=mycrazyenvslug')
+        self.assertEqual(list, type(data['results']))
+        self.assertEqual(0, len(data['results']))
+
+    def test_tests_filter_by_build(self):
+        data = self.hit('/api/tests/?build__version=1')
+        self.assertEqual(list, type(data['results']))
+        self.assertEqual(36, len(data['results']))
+
+    def test_tests_filter_by_build_not_found(self):
+        data = self.hit('/api/tests/?build__version=this-build-should-not-exist-really')
+        self.assertEqual(list, type(data['results']))
+        self.assertEqual(0, len(data['results']))
+
     def test_tests_with_page_size(self):
         data = self.hit('/api/tests/?limit=2')
         self.assertEqual(list, type(data['results']))


### PR DESCRIPTION
Really fix https://github.com/Linaro/squad/issues/634

This is the first of a series of PRs I'm working on that makes use of https://github.com/Linaro/squad/pull/922

This adds a nested `tests` to the builds endpoint. So making queries like `/api/builds/1/tests` will return all tests from that build. 

