### PR TITLE
ci: backend: lava: handle HTTP 408 as TemporarySubmissionIssue

### DIFF
--- a/squad/ci/backend/lava.py
+++ b/squad/ci/backend/lava.py
@@ -220,8 +220,9 @@ class Backend(BaseBackend):
         except xmlrpc.client.ProtocolError as error:
             raise TemporarySubmissionIssue(self.url_remove_token(str(error)))
         except xmlrpc.client.Fault as fault:
-            if fault.faultCode // 100 == 5:
+            if fault.faultCode // 100 == 5 or fault.faultCode == 408:
                 # assume HTTP errors 5xx are temporary issues
+                # consider 408 as TemporarySubmissionIssue, as it's considered as timeout
                 raise TemporarySubmissionIssue(self.url_remove_token(str(fault)))
             else:
                 raise SubmissionIssue(self.url_remove_token(str(fault)))


### PR DESCRIPTION
Fix https://github.com/Linaro/squad/issues/919

For some reason, requests library doesn't raise 408 Timeout as exception, which causes submit to return empty list of ids and
causing IndexError.

This patch explicitly checks if requests returns 408 and handle that as TemporarySubmissionIssue