### PR TITLE
core: comparison: use raw sql to get regressions and fixes

### DIFF
--- a/squad/core/models.py
+++ b/squad/core/models.py
@@ -1112,7 +1112,7 @@ class ProjectStatus(models.Model, TestSummaryBase):
                 project=build.project,
             ).order_by('datetime').last()
         if previous_build is not None:
-            comparison = TestComparison(previous_build, build)
+            comparison = TestComparison(previous_build, build, regressions_and_fixes_only=True)
             if comparison.regressions:
                 regressions = yaml.dump(comparison.regressions)
             if comparison.fixes:

--- a/test/core/test_history.py
+++ b/test/core/test_history.py
@@ -12,7 +12,7 @@ from squad.core.history import TestHistory
 class TestHistoryTest(TestCase):
 
     def receive_test_run(self, project, version, env, tests):
-        receive = ReceiveTestRun(project)
+        receive = ReceiveTestRun(project, update_project_status=False)
         receive(version, env, tests_file=json.dumps(tests))
 
     def setUp(self):

--- a/test/core/test_metric_comparison.py
+++ b/test/core/test_metric_comparison.py
@@ -19,7 +19,7 @@ def compare(b1, b2):
 class MetricComparisonTest(TestCase):
 
     def receive_test_run(self, project, version, env, metrics):
-        receive = ReceiveTestRun(project)
+        receive = ReceiveTestRun(project, update_project_status=False)
         receive(version, env, metrics_file=json.dumps(metrics))
 
     def setUp(self):

--- a/test/frontend/test_comparison.py
+++ b/test/frontend/test_comparison.py
@@ -9,7 +9,7 @@ from squad.core.tasks import ReceiveTestRun
 
 class ProjectComparisonTest(TestCase):
     def receive_test_run(self, project, version, env, tests):
-        receive = ReceiveTestRun(project)
+        receive = ReceiveTestRun(project, update_project_status=False)
         receive(version, env, tests_file=json.dumps(tests))
 
     def setUp(self):


### PR DESCRIPTION
This PR improves TestComparison when it's used for regressions and fixes only. If it's used for applying transitions, the code will still use legacy load-all-in-memory.

It fixes half of https://github.com/Linaro/squad/issues/906. I say half because I couldn't find a way to apply all transitions in one trip to DB, especially `n/a - any other` and `any other - n/a`.

Also, this accidentally fixes https://github.com/Linaro/squad/issues/609. It turns out that current comparison will do something funny when the same test is run for the same build/environment. I can't say for sure why it does that, maybe a failed test gets overwritten by a passing one.