### PR TITLE
core, commands: 4th attempt to make faster fix

### DIFF
--- a/squad/core/management/commands/fix_squadplugin_data.py
+++ b/squad/core/management/commands/fix_squadplugin_data.py
@@ -1,52 +1,130 @@
 import logging
+import math
+import threading
 
-from django.db.models import Q
 from django.core.management.base import BaseCommand
-
-from squad.core.models import Test, SuiteMetadata
+from django.db.models import OuterRef, Subquery, F, Q
+from django.db import IntegrityError
+from squad.core.models import SuiteMetadata, Test
 from squad.core.utils import split_list
 
 
+correct_metadata = SuiteMetadata.objects.filter(kind='test', suite=OuterRef('suite__slug'), name=OuterRef('metadata__name'))
+
+first_test = Test.objects.order_by().filter(metadata=OuterRef('pk')).annotate(correct_metadata=Subquery(correct_metadata.values('id')[:1]))
+
+correct_slug = Test.objects.order_by().filter(metadata=OuterRef('pk')).annotate(suite_slug=F('suite__slug'))
+
+annotations = {
+    'correct_metadata_id': Subquery(first_test.values('correct_metadata')[:1]),
+    'correct_suite_slug': Subquery(correct_slug.values('suite_slug')[:1])
+}
+
+buggy_ones = Q(suite__startswith='armeabi') | Q(suite__startswith='arm64')
+
+
 logger = logging.getLogger()
+STEP = 1000
+
+
+class SuiteMetadataFixThread(threading.Thread):
+    def __init__(self, thread_id, suitemetadata_ids, show_progress=False):
+        threading.Thread.__init__(self)
+        self.thread_id = thread_id
+        self.suitemetadata_ids = suitemetadata_ids
+        self.show_progress = show_progress
+
+    def run(self):
+        count = len(self.suitemetadata_ids)
+        logger.info('[thread-%s] processing %d suitemetadata' % (self.thread_id, count))
+        count_updates = 0
+        orphan_metadata = []
+        for offset in range(0, count, STEP):
+            ids = self.suitemetadata_ids[offset:offset + STEP]
+            for metadata in SuiteMetadata.objects.filter(id__in=ids).annotate(**annotations).all():
+                # It means there's no SuiteMetadata with fixed suite, so it's safe to change it in place
+                if metadata.correct_metadata_id is None:
+                    if metadata.correct_suite_slug is None:
+                        orphan_metadata.append(metadata.id)
+                    else:
+                        try:
+                            metadata.suite = metadata.correct_suite_slug
+                            metadata.save()
+                        except IntegrityError:
+                            # 
+                            # 
+                            logger.error('There appears to have a fixed suite metadata already')
+                            logger.error('This was not supposed to happen though, check these cases carefuly')
+                            logger.error('SuiteMetadata (id: %d, kind=test, suite="%s", name="%s")' % (metadata.id, metadata.suite, metadata.name))
+                            return
+                # It means there's a correct one, so just update tests
+                else:
+                    Test.objects.order_by().filter(metadata=metadata).update(metadata_id=metadata.correct_metadata_id)
+                    # It's safe to delete buggy metadata now
+                    orphan_metadata.append(metadata.id)
+
+            if self.show_progress:
+                print('.', end='', flush=True)
+        
+        if len(orphan_metadata) > 0:
+            logger.info('Deleting %d orphan metadata objects' % len(orphan_metadata))
+            chunks = split_list(orphan_metadata, chunk_size=10000)
+            for chunk in chunks:
+                SuiteMetadata.objects.filter(id__in=chunk).delete()
+
+        logger.info('[thread-%s] done updating' % self.thread_id)
 
 
 class Command(BaseCommand):
 
-    help = """fix suite in SuiteMetadata for cts/vts tests"""
+    help = """helper that fixes buggy SuiteMetadata objects"""
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--show-progress',
+            action='store_true',
+            help='Prints out one dot every 1000 (one thousand) metadata processed'
+        )
+        parser.add_argument(
+            '--num-threads',
+            type=int,
+            default=2,
+            help='Number of simultaneous parallel threads to work'
+        )
 
     def handle(self, *args, **options):
-        android_suites = ['cts', 'vts']
-        condition = Q(suite__icontains=android_suites[0])
-        condition |= Q(suite__icontains=android_suites[1])
-        cts_and_vts_metadata = SuiteMetadata.objects.filter(condition, kind='test').order_by('-id')
-        buggy_metadata = []
-        for s in cts_and_vts_metadata:
-            print("Processing SuiteMetedata with suite %s and test %s" % (s.suite, s.name), flush=True)
-            first_test = Test.objects.filter(metadata=s).first()
-            if first_test is None:
-                buggy_metadata.append(s.id)
-                print("# of orphan bad metadata found: %s" % len(buggy_metadata), flush=True)
-                continue
-            print("Found Test for above Suitemetadata. Test.suite is %s " % first_test.suite, flush=True)
-            correct_suite = first_test.suite.slug
-            if correct_suite != s.suite:
-                correct_metadata = SuiteMetadata.objects.filter(kind='test', suite=correct_suite, name=s.name).first()
-                if correct_metadata:
-                    print("Found existing SuiteMetadata with correct suite: %s. Will use it to update all affected tests" % correct_metadata, flush=True)
-                    print("correct_metadata: %s" % correct_metadata.id, flush=True)
-                    print("Updating tests", flush=True)
-                    all_affected_tests = Test.objects.filter(metadata=s)
-                    print("# of affected tests: %s" % all_affected_tests.update(metadata=correct_metadata))
-                else:
-                    print('No existing correct metadata. Updating the corrupt SuiteMetadata and saving it in place ', flush=True)
-                    s.suite = first_test.suite.slug
-                    s.save()
-            print('Done', flush=True)
+        show_progress = options['show_progress']
+        num_threads = options['num_threads']
 
-        print("Completed Fixing all SuiteMetadata")
-        print("Total number of orphan bad metadata found is: %s" % len(buggy_metadata))
-        print("Starting to delete it in chunks")
-        for chunk in split_list(buggy_metadata, 1000):
-            SuiteMetadata.objects.filter(id__in=chunk).delete()
-            print("Deleted 1000 bad metadata. Remaining: %s" % len(buggy_metadata))
-        print("Cleaning All bad metadata concluded")
+        logger.info('Discovering number of metadata that need work...')
+        count = int(SuiteMetadata.objects.filter(buggy_ones).count())
+
+        if count == 0:
+            logger.info('Nothing to do!')
+            return
+
+        logger.info('Working on %d metadatas' % count)
+        metadata_ids = SuiteMetadata.objects.filter(buggy_ones).order_by('-id').values_list('id', flat=True)
+
+        chunk_size = math.floor(len(metadata_ids) / num_threads) + 1
+        chunks = split_list(metadata_ids, chunk_size=chunk_size)
+
+        threads = []
+        for chunk in chunks:
+            thread_id = len(threads)
+            thread = SuiteMetadataFixThread(thread_id, chunk, show_progress=show_progress)
+            thread.start()
+            threads.append(thread)
+
+        for thread in threads:
+            thread.join()
+
+        logger.info('Done updating')
+
+        # Check that everything worked as expected
+        count = int(SuiteMetadata.objects.filter(buggy_ones).count())
+        if count > 0:
+            logger.error('Something went wrong! %d metadata are still buggy' % count)
+            return
+
+        logger.info('Done!')


### PR DESCRIPTION
A pattern has been identified for all buggy suitemetadata introduced
by the tradefed bug. The suite start with either 'armeabi*' or 'arm64*'.
Using this the command has been rewritten to execute faster. This should
be the best we have in hand right now.