### PR TITLE
api: rest: order tests by id instead of build_id

### DIFF
--- a/squad/api/rest.py
+++ b/squad/api/rest.py
@@ -1152,7 +1152,7 @@ class TestViewSet(NestedViewSetMixin, ModelViewSet):
     filterset_class = TestFilter
     filter_class = filterset_class  # TODO: remove when django-filters 1.x is not supported anymore
     pagination_class = CursorPaginationWithPageSize
-    ordering = ('build_id',)
+    ordering = ('-id',)
 
 
 class MetricSerializer(DynamicFieldsModelSerializer, serializers.HyperlinkedModelSerializer):


### PR DESCRIPTION
Turns out that using build_id to order Test using CursorPagination is not a good idea, since there could be a situation where the "next" page is exact the same as the current one, thus giving an endless list of tests for clients like squad-client.