### PR TITLE
Handle multiple test results.

### DIFF
--- a/squad/frontend/templates/squad/_results_table.jinja2
+++ b/squad/frontend/templates/squad/_results_table.jinja2
@@ -47,11 +47,19 @@
             {% with result=results.get((build, environment)) %}
               {% if result %}
                 {% if comparison_type == 'test' %}
-                  <td class='{{result|slugify}}'>
-                    <a href="{{url('legacy_test_history', args=[build.project.group.slug, build.project.slug, test])}}">
-                      <strong>{{result}}</strong>
-                    </a>
-                  </td>
+                  {% if result is not string %}
+                    <td class='{{result.0|slugify}}'>
+                      <a href="{{url('legacy_test_history', args=[build.project.group.slug, build.project.slug, test])}}">
+                        <strong>{{result.0}}{% if result.1 %} ({{ result.1 }}%){% endif %}</strong>
+                      </a>
+                     </td>
+                  {% else %}
+                    <td class='{{result|slugify}}'>
+                      <a href="{{url('legacy_test_history', args=[build.project.group.slug, build.project.slug, test])}}">
+                        <strong>{{result}}</strong>
+                      </a>
+                    </td>
+                  {% endif %}
                 {% else %}
                   {% set mean = result.0|float %}
                   {% set stddev = result.1|float %}

--- a/squad/frontend/templates/squad/compare.jinja2
+++ b/squad/frontend/templates/squad/compare.jinja2
@@ -65,7 +65,7 @@
               <td><a href="{% raw %}{{build.build_url_path}}{% endraw %}" target="_self"><span ng-bind='build.build.version'></span></a></td>
               <td><span ng-bind='build.build.created_at'></span></td>
               <td class="{% raw %}{{ testResult.test.status }}{% endraw %}" ng-repeat='testResult in build.environments'>
-                  <a ng-show="{% raw %}{{ testResult.test.status != undefined }}{% endraw %}" href="{% raw %}{{testResult.test_url_path}}{% endraw %}" target="_self"><span ng-bind='testResult.test.status'></span></a>
+                  <a ng-show="{% raw %}{{ testResult.test.status != undefined }}{% endraw %}" href="{% raw %}{{testResult.test_url_path}}{% endraw %}" target="_self"><span ng-bind='testResult.test.status'></span><span ng-show="{% raw %}{{ testResult.test.confidence != undefined }}{% endraw %}"> (</span><span ng-bind='testResult.test.confidence'></span><span ng-show="{% raw %}{{ testResult.test.confidence != undefined }}{% endraw %}">%)</span></a>
                   <span ng-show="{% raw %}{{ testResult.test.status == undefined }}{% endraw %}">{{ _('n/a') }}</span>
               </td>
           </tr>

--- a/squad/frontend/templates/squad/test_history.jinja2
+++ b/squad/frontend/templates/squad/test_history.jinja2
@@ -43,7 +43,7 @@
           {% if result %}
             {% with known_issues=result.known_issues %}
               <td class='{{result.status|slugify}}'>
-                <a href="{{testrun_suite_test_details_url(project.group, project, build, result.test_run_status, result.test)}}">{{result.status}}</a>
+                <a href="{{testrun_suite_test_details_url(project.group, project, build, result.test_run_status, result.test)}}">{{result.status}}{% if result.confidence_score %} ({{result.confidence_score}}%){% endif %}</a>
                 {% if result.info['test_description'] or result.info['suite_instructions'] or result.info['test_instructions'] or result.info['test_log'] %}
                   <a href='#' data-toggle="modal" data-target="#info_modal" data-info="{{ to_json(result.info) }}"><span data-toggle="tooltip" data-placement="right" title="{{ _('Show info') }}" class='fa fa-info-circle'></span></a>
                 {% endif %}

--- a/squad/frontend/templates/squad/test_run_suite_test_details.jinja2
+++ b/squad/frontend/templates/squad/test_run_suite_test_details.jinja2
@@ -38,7 +38,7 @@
                       <br>
                       <i class='fa fa-flag-o'></i>
                       <span class='p-3 mb-2 {{"alert-danger" if test.status == "fail" else "alert-success" if test.status == "pass" else "alert-warning" if test.status == "skip" else "alert-info"}}'>
-                          {{ (_('Result: <strong>%s</strong>') % test.status) | safe }}
+                          {{ (_('Result: <strong>%s</strong>') % test.status) | safe }}{% if test.confidence_score %} ({{ test.confidence_score}} %){% endif %}
                       </span>
                   {% endif %}
                   {% if test.metadata.description or test.known_issues|length > 0 or suite.metadata.description %}

--- a/squad/frontend/templates/squad/tests.jinja2
+++ b/squad/frontend/templates/squad/tests.jinja2
@@ -33,8 +33,8 @@
             <tr id='test-{{test.name|slugify}}' ng-show="match('test-{{test.name|slugify}}')">
                 <td><a href="{{ test_history_url }}">{{test.name}}</a></td>
                 {% for status in test %}
-                <td class="{{status[0]}}"><a href="{{ test_history_url }}">{{status[0]}}</a>
-                  {% if status[1] %}
+                <td class="{{status[0]}}"><a href="{{ test_history_url }}">{{status[0]}}{% if status[1] %} ({{status[1]}} %){% endif %}</a>
+                  {% if status[2] %}
                   <a href='#' data-toggle="modal" data-target="#info_modal" data-status="{{ status[1] }}"><span data-toggle="tooltip" data-placement="right" title="{{ _('Show info') }}" class='fa fa-info-circle'></span></a>
                   {% endif %}
                 </td>

--- a/squad/frontend/tests.py
+++ b/squad/frontend/tests.py
@@ -7,6 +7,7 @@ from django.http import Http404
 from squad.http import auth
 from squad.core.models import Test, Suite, TestRun
 from squad.core.history import TestHistory
+from squad.core.queries import test_confidence
 from squad.core.utils import split_list
 from squad.frontend.views import get_build
 
@@ -125,7 +126,11 @@ class TestResultTable(list):
         memo = {}
         for test in tests:
             memo.setdefault(test.full_name, {})
-            memo[test.full_name][test.test_run.environment_id] = [test.status]
+            if test.test_run.environment_id in memo[test.full_name]:
+                # Found duplicates.
+                memo[test.full_name][test.test_run.environment_id] = list(test_confidence(test))
+            else:
+                memo[test.full_name][test.test_run.environment_id] = [test.status]
             if 'test_metadata' not in memo[test.full_name].keys():
                 memo[test.full_name]['test_metadata'] = (test.test_run, test.suite, test.name)
 

--- a/test/core/test_test_comparison.py
+++ b/test/core/test_test_comparison.py
@@ -23,6 +23,7 @@ class TestComparisonTest(TestCase):
         self.group = models.Group.objects.create(slug='mygruop')
         self.project1 = self.group.projects.create(slug='project1')
         self.project2 = self.group.projects.create(slug='project2')
+        self.project3 = self.group.projects.create(slug='project3')
 
         self.receive_test_run(self.project1, '0', 'myenv', {
             'z': 'pass',
@@ -61,10 +62,23 @@ class TestComparisonTest(TestCase):
             'c': 'pass',
             'd/e': 'pass',
         })
+        self.receive_test_run(self.project3, '2', 'myenv', {
+            'a': 'pass',
+            'b': 'pass',
+        })
+        self.receive_test_run(self.project3, '2', 'myenv', {
+            'a': 'fail',
+            'b': 'fail',
+        })
+        self.receive_test_run(self.project3, '2', 'myenv', {
+            'a': 'pass',
+            'b': 'fail',
+        })
 
         self.build0 = self.project1.builds.first()
         self.build1 = self.project1.builds.last()
         self.build2 = self.project2.builds.last()
+        self.build3 = self.project3.builds.last()
 
     def test_builds(self):
         comp = compare(self.build1, self.build2)
@@ -158,6 +172,14 @@ class TestComparisonTest(TestCase):
         comparison = TestComparison.compare_builds(self.build1, self.build1)
         self.assertEqual({}, comparison.regressions)
 
+    def test_regressions_with_duplicates(self):
+        comparison = TestComparison.compare_builds(self.build1, self.build3)
+        self.assertEqual({'myenv': ['b']}, comparison.regressions)
+
+    def test_fixes_with_duplicates(self):
+        comparison = TestComparison.compare_builds(self.build2, self.build3)
+        self.assertEqual({'myenv': ['a']}, comparison.fixes)
+
     def test_fixes_no_fixes(self):
         # same build! so no fixes, by definition
         comparison = TestComparison.compare_builds(self.build1, self.build1)
@@ -205,7 +227,7 @@ class TestComparisonTest(TestCase):
         | testC | pass | pass | pass  | pass | pass | pass  |
         +-------+------+------+-------+------+------+-------+
         """
-        project = self.group.projects.create(slug='project3')
+        project = self.group.projects.create(slug='project4')
         self.receive_test_run(project, 'buildA', 'envA', {'testA': 'pass', 'testB': 'pass', 'testC': 'pass'})
         self.receive_test_run(project, 'buildA', 'envB', {'testA': 'fail', 'testB': 'skip', 'testC': 'pass'})
         self.receive_test_run(project, 'buildA', 'envC', {'testA': 'xfail', 'testB': 'xfail', 'testC': 'pass'})
@@ -225,7 +247,6 @@ class TestComparisonTest(TestCase):
 
         transitions = [('pass', 'fail'), ('skip', 'n/a')]
         comparison.apply_transitions(transitions)
-
         """
         Test results after transitions are applied
                 +-------------+-------------+


### PR DESCRIPTION
Multiple test results can occur during job resubmission.
Handle them correctly in various pages accross the system.
API and notifications update will be part of the later patch.