### PR TITLE
Enhance test field selection

### DIFF
--- a/squad/core/models.py
+++ b/squad/core/models.py
@@ -856,7 +856,12 @@ class Test(models.Model):
 
     @property
     def full_name(self):
-        return join_name(self.suite.slug, self.name)
+        suite = ''
+        if self.metadata is None:
+            suite = self.suite.slug
+        else:
+            suite = self.metadata.suite
+        return join_name(suite, self.name)
 
     class History(object):
         def __init__(self, since, count, last_different):

--- a/test/api/test_rest.py
+++ b/test/api/test_rest.py
@@ -723,6 +723,43 @@ class RestApiTest(APITestCase):
         self.assertEqual(list, type(data['results']))
         self.assertEqual(2, len(data['results']))
 
+    def test_tests_minimal_fields(self):
+        data = self.hit('/api/tests/?fields=name,status')
+        self.assertEqual(list, type(data['results']))
+        self.assertEqual(50, len(data['results']))
+
+        should_not_exist = {'url', 'build', 'environment', 'test_run', 'short_name', 'result', 'log', 'has_known_issues', 'suite', 'known_issues'}
+        for test in data['results']:
+            fields = set(test.keys())
+            self.assertEqual(set(), should_not_exist & fields)
+            self.assertTrue('name' in fields)
+            self.assertTrue('status' in fields)
+            self.assertEqual(2, len(fields))
+
+    def test_tests_with_known_issues_fields(self):
+        data = self.hit('/api/tests/?fields=known_issues')
+        self.assertEqual(list, type(data['results']))
+        self.assertEqual(50, len(data['results']))
+
+        should_not_exist = {'url', 'build', 'environment', 'test_run', 'short_name', 'result', 'log', 'has_known_issues', 'suite', 'name', 'status'}
+        for test in data['results']:
+            fields = set(test.keys())
+            self.assertEqual(set(), should_not_exist & fields)
+            self.assertTrue('known_issues' in fields)
+            self.assertEqual(1, len(fields))
+
+    def test_tests_no_status_fields(self):
+        data = self.hit('/api/tests/?fields=name')
+        self.assertEqual(list, type(data['results']))
+        self.assertEqual(50, len(data['results']))
+
+        should_not_exist = {'url', 'build', 'environment', 'test_run', 'short_name', 'result', 'log', 'has_known_issues', 'suite', 'status', 'known_issues'}
+        for test in data['results']:
+            fields = set(test.keys())
+            self.assertEqual(set(), should_not_exist & fields)
+            self.assertTrue('name' in fields)
+            self.assertEqual(1, len(fields))
+
     def test_metrics(self):
         data = self.hit('/api/metrics/')
         self.assertEqual(list, type(data['results']))


### PR DESCRIPTION
Since @amrohassaan enabled field selection, the tests endpoint gained  a great speed improvement.

Getting 1000 tests used to take ~1s, then if only name/status selected, it takes ~500ms.

The solution was almost good enough, it still made queries to DB to fetch all the fields and just after it get removed before rendered to json.

This PR squeezes out a few extra ms by checking which fields are being requested to reduce DB prefetched and data loading.

Getting 1000 tests with only name/status takes now ~100ms.

I don't think doing the same for all endpoints is necessary, given that tests might be the endpoint with most access.