### PR TITLE
core: comparison: fix regression detection

### DIFF
--- a/squad/core/comparison.py
+++ b/squad/core/comparison.py
@@ -466,6 +466,7 @@ class TestComparison(BaseComparison):
             query['where'].append('target_environment.slug = baseline_environment.slug')
 
         query['where'].append('target.result IS NOT NULL')
+        query['where'].append('target.has_known_issues <> true')
         query['where'].append('baseline.result IS NOT NULL')
         query['where'].append('target.result != baseline.result')
 

--- a/test/core/test_test_comparison.py
+++ b/test/core/test_test_comparison.py
@@ -174,6 +174,17 @@ class TestComparisonTest(TestCase):
         fixes = comparison.fixes
         self.assertEqual(['c'], fixes['myenv'])
 
+    def test_pass_to_xfail_not_a_regressions(self):
+        """
+        This test is using builds from different projects because the relevant
+        test data is already prepared in setUp(), but usually fixes is
+        only used when comparing subsequent builds from the same project.
+        """
+        models.Test.objects.filter(test_run__build=self.build2, metadata__name='a').update(has_known_issues=True)
+        comparison = TestComparison(self.build1, self.build2, regressions_and_fixes_only=True)
+        regressions = comparison.regressions
+        self.assertEqual(0, len(regressions))
+
     def test_intermittent_xfail_is_not_a_fix(self):
         """
         This test is using builds from different projects because the relevant


### PR DESCRIPTION
After https://github.com/Linaro/squad/pull/929 got merged, I tried it in staging with the following parameters:

Target: https://qa-reports.linaro.org/lkft/linux-stable-rc-linux-5.8.y/build/v5.8.18/
Baseline: https://qa-reports.linaro.org/lkft/linux-stable-rc-linux-5.8.y/build/v5.8.17-71-g46e8244bb94f/

And got the following results
Regressions:
- x15:
  - ltp-tracing-tests/ftrace-stress-test - OK
- qemu_arm:
  - ltp-tracing-tests/ftrace-stress-test - OK
  + **ltp-controllers-tests/memcg_subgroup_charge - NOT PRESENT IN qa-reports (fixed in this PR)**
- qemu_arm64:
  - ltp-fs-tests/read_all_proc - OK
  + **ltp-controllers-tests/memcg_subgroup_charge - NOT PRESENT IN qa-reports (fixed in this PR)**
- x86:
  - kselftest-vsyscall-mode-native/x86.fsgsbase_64 - OK
- hi6220-hikey:
  - kselftest/cgroup.test_freezer - OK
  - kselftest/cgroup.test_freezer.test_cgfreezer_ptrace - OK
  - kselftest/rtc.rtctest - OK

Fixes:
- x15:
  - ltp-cve-tests/cve-2019-8912 - OK
  - ltp-syscalls-tests/msgrcv01 - OK
- qemu_arm64:
  - ltp-tracing-tests/dynamic_debug01 - OK
- x86: 
  - kselftest-vsyscall-mode-none/net.fib-onlink-tests.sh - OK 
  - kselftest-vsyscall-mode-none/rtc.rtctest - OK
  - kselftest-vsyscall-mode-none/x86.fsgsbase_64 - OK
- hi6220-hikey:
  - kselftest/net.tls - OK
- i386:
  - kselftest/net.fib-onlink-tests.sh - OK
 
Bottom line, all regressions and fixes are OK (except for those fixed in this PR) if compared to current results in qa-reports.