### PR TITLE
ci: listen: increase backend check poll to 1 min

### DIFF
--- a/squad/ci/management/commands/listen.py
+++ b/squad/ci/management/commands/listen.py
@@ -103,7 +103,7 @@ class ListenerManager(object):
                 # for a change to happen in the database, but we didn't find a
                 # simple/portable way of doing that yet. Let's just sleep for a
                 # few seconds instead, for now.
-                time.sleep(5)
+                time.sleep(60)
         except KeyboardInterrupt:
             pass  # cleanup() will terminate sub-processes
 


### PR DESCRIPTION
Fixes https://github.com/Linaro/squad/issues/931

We check for changes in Backend models every 5s, and it probably take half of that just to run the query. This patch increases that poll interval to 1min as it's not something that changes that often