### PR TITLE
Use lighter version of TestComparison

### DIFF
--- a/squad/api/rest.py
+++ b/squad/api/rest.py
@@ -639,7 +639,7 @@ class ProjectViewSet(viewsets.ModelViewSet):
             raise serializers.ValidationError("Invalid args provided. 'baseline' and 'to_compare' build ids must NOT be empty")
 
         if baseline and to_compare:
-            comparison = TestComparison(baseline, to_compare)
+            comparison = TestComparison(baseline, to_compare, regressions_and_fixes_only=True)
             serializer = BuildsComparisonSerializer(comparison)
             return Response(serializer.data)
 

--- a/test/api/test_rest.py
+++ b/test/api/test_rest.py
@@ -948,8 +948,8 @@ class RestApiTest(APITestCase):
     def test_project_compare_builds_with_finished_status_and_regressions(self):
         foo_suite, _ = self.project.suites.get_or_create(slug='foo')
         foo_metadata, _ = models.SuiteMetadata.objects.get_or_create(suite=foo_suite.slug, name='dummy', kind='test')
-        self.testrun4.tests.get_or_create(suite=foo_suite, metadata=foo_metadata, result=True)
-        self.testrun6.tests.get_or_create(suite=foo_suite, metadata=foo_metadata, result=False)
+        self.testrun4.tests.get_or_create(suite=foo_suite, metadata=foo_metadata, result=True, build=self.testrun4.build, environment=self.testrun4.environment)
+        self.testrun6.tests.get_or_create(suite=foo_suite, metadata=foo_metadata, result=False, build=self.testrun6.build, environment=self.testrun6.environment)
         UpdateProjectStatus()(self.testrun4)
         UpdateProjectStatus()(self.testrun6)
         data = self.hit('/api/projects/%d/compare_builds/?baseline=%d&to_compare=%d' % (self.project.id, self.build4.id, self.build6.id))


### PR DESCRIPTION
Use `regressions_and_fixes_only=True` for comparing bulds from the same projects using the API.