### PR TITLE
api: add version endpoint

### DIFF
--- a/squad/api/urls.py
+++ b/squad/api/urls.py
@@ -23,4 +23,5 @@ urlpatterns = [
     url(r'^data/(%s)/(%s)' % (group_slug_pattern, slug_pattern), data.get),
     url(r'^resubmit/([0-9]+)', ci.resubmit_job),
     url(r'^forceresubmit/([0-9]+)', ci.force_resubmit_job),
+    url(r'^version/', views.version),
 ]

--- a/squad/api/views.py
+++ b/squad/api/views.py
@@ -22,6 +22,9 @@ from squad.core.utils import log_addition
 from squad.core.utils import log_change
 
 
+from squad.version import __version__
+
+
 logger = logging.getLogger()
 
 
@@ -109,3 +112,8 @@ def add_test_run(request, group_slug, project_slug, version, environment_slug):
         return HttpResponse(str(e), status=400)
 
     return HttpResponse('', status=201)
+
+
+@csrf_exempt
+def version(request):
+    return HttpResponse(__version__)


### PR DESCRIPTION
This will be useful for clients that need to check which version of SQUAD they're running against to.

To be addressed in https://github.com/Linaro/squad-client/pull/103