### PR TITLE
socialaccount: add Github and Gitlab social account login

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update -q=2 && \
         python3-dateutil \
         python3-dev \
         python3-django \
+        python3-django-allauth \
         python3-django-auth-ldap \
         python3-django-cors-headers \
         python3-django-celery-results \

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ cryptography
 coreapi
 django_crispy_forms
 Django>=2.2,<3.0
+django-allauth
 django-bootstrap3
 django-celery-results
 django-cors-headers

--- a/squad/core/models.py
+++ b/squad/core/models.py
@@ -209,7 +209,7 @@ class UserNamespaceManager(models.Manager):
 
     @transaction.atomic
     def create_for(self, user):
-        slug = '~' + user.username
+        slug = '~' + user.username.replace('@', '')
         ns = self.create(slug=slug)
         ns.add_admin(user)
         return ns

--- a/squad/frontend/templates/squad/login.jinja2
+++ b/squad/frontend/templates/squad/login.jinja2
@@ -23,34 +23,48 @@
       <h3 class="panel-title">{{ _("Log in") }}</h3>
     </div>
     <div class='panel-body'>
-      {% autoescape off %}
-        {{login_message('div', 'alert alert-info')}}
-      {% endautoescape %}
-      <form action="{{ app_path }}" method="post" id="login-form">
-        {{ csrf_input }}
-        <div class="form-group">
-          {{ form.username.errors }}
-          <label for="id_username" class="sr-only">{{ _('Username') }}</label>
-          <input type="text" id="id_username" name="username" class="form-control" placeholder="Username" required autofocus>
-        </div>
-        <div class="form-group">
-          {{ form.password.errors }}
-          <label for="id_password" class="sr-only">{{ _('Password') }}</label>
-          <input type="password" id="id_password" name="password" class="form-control" placeholder="Password" required>
-          <input type="hidden" name="next" value="{{ next }}" />
-        </div>
-        {# We currently do not implement password reset feature. If that's needed, check out link below #}
-        {# https://github.com/django/django/blob/c49ea6f5911296dcb40190c905e38b43cdc7c7a3/docs/ref/contrib/admin/index.txt#L3081 #}
-        {% set password_reset_url = url('admin_password_reset') %}
-        {% if password_reset_url %}
-        <div class="password-reset-link">
-          <a href="{{ password_reset_url }}">{{ _("Forgotten your password or username?") }}</a>
-        </div>
-        {% endif %}
-        <div class="form-group">
-          <input class='btn btn-default' type="submit" value="{{ _("Log in") }}" />
-        </div>
-      </form>
+      <div id='plain-old-login'>
+        {% autoescape off %}
+          {{login_message('div', 'alert alert-info')}}
+        {% endautoescape %}
+        <form action="{{ app_path }}" method="post" id="login-form">
+          {{ csrf_input }}
+          <div class="form-group">
+            {{ form.username.errors }}
+            <label for="id_username" class="sr-only">{{ _('Username') }}</label>
+            <input type="text" id="id_username" name="username" class="form-control" placeholder="Username" required autofocus>
+          </div>
+          <div class="form-group">
+            {{ form.password.errors }}
+            <label for="id_password" class="sr-only">{{ _('Password') }}</label>
+            <input type="password" id="id_password" name="password" class="form-control" placeholder="Password" required>
+            <input type="hidden" name="next" value="{{ next }}" />
+          </div>
+          {# We currently do not implement password reset feature. If that's needed, check out link below #}
+          {# https://github.com/django/django/blob/c49ea6f5911296dcb40190c905e38b43cdc7c7a3/docs/ref/contrib/admin/index.txt#L3081 #}
+          {% set password_reset_url = url('admin_password_reset') %}
+          {% if password_reset_url %}
+          <div class="password-reset-link">
+            <a href="{{ password_reset_url }}">{{ _("Forgotten your password or username?") }}</a>
+          </div>
+          {% endif %}
+          <div class="form-group">
+            <input class='btn btn-default' type="submit" value="{{ _("Log in") }}" />
+          </div>
+        </form>
+      </div>
+      {% set providers = socialaccount_providers() %}
+      {% if providers %}
+          <div id='social-login'>
+          {{ _('Or login with these social accounts') }}:
+            <div style="margin-top: 10px;">
+              {% for provider, login_url in providers.items() %}
+                  <a class='btn btn-default' href='{{ login_url }}'>{{ provider.name }}</a>
+                  &nbsp;
+              {% endfor %}
+            </div>
+          </div>
+      {% endif %}
     </div>
   </div>
 </div>

--- a/squad/frontend/templatetags/squad.py
+++ b/squad/frontend/templatetags/squad.py
@@ -9,6 +9,8 @@ from django.template.defaultfilters import safe
 from hashlib import md5
 from markdown import markdown as to_markdown
 from bootstrap3.templatetags.bootstrap3 import bootstrap_field as b3_field
+from allauth.socialaccount.templatetags import socialaccount
+
 
 from squad import version
 from squad.core.models import Test, Build
@@ -263,3 +265,12 @@ def to_json(d):
     except TypeError:
         json_string = ''
     return json_string
+
+
+@register_global_function(takes_context=True)
+def socialaccount_providers(context):
+    request = context['request']
+    providers = socialaccount.get_providers()
+    if providers:
+        return {p: p.get_login_url(request) for p in providers}
+    return None

--- a/squad/settings.py
+++ b/squad/settings.py
@@ -87,6 +87,7 @@ __apps__ = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.humanize',
+    'django.contrib.sites',
     'corsheaders',
     'whitenoise.runserver_nostatic',
     'django.contrib.staticfiles',
@@ -103,7 +104,31 @@ __apps__ = [
     'squad.frontend',
     'squad.ci',
     'django_celery_results',
+    'allauth',
+    'allauth.account',
+    'allauth.socialaccount',
+    'allauth.socialaccount.providers.github',
+    'allauth.socialaccount.providers.gitlab',
 ]
+
+# SocialLogin setup
+# SQUAD installations should add their own providers and setups if more needed.
+# By default github and gitlab are enabled.
+# ref: https://django-allauth.readthedocs.io/en/latest/installation.html
+ACCOUNT_EMAIL_VERIFICATION = os.getenv('SQUAD_ACCOUNT_EMAIL_VERIFICATION', 'none')
+SOCIALACCOUNT_ADAPTER = 'squad.socialaccount.CustomSocialAccountAdapter'
+SOCIALACCOUNT_QUERY_EMAIL = True
+SOCIALACCOUNT_PROVIDERS = {
+    # https://docs.github.com/en/free-pro-team@latest/developers/apps/scopes-for-oauth-apps
+    'github': {
+        'SCOPE': ['read:user', 'user:email'],
+    },
+    'gitlab': {
+        'SCOPE': ['read_user'],
+    }
+}
+
+SITE_ID = 1
 
 INSTALLED_APPS = [app for app in __apps__ if app]
 
@@ -201,6 +226,12 @@ AUTH_PASSWORD_VALIDATORS = [
     {
         'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
     },
+]
+
+
+AUTHENTICATION_BACKENDS = [
+    'django.contrib.auth.backends.ModelBackend',
+    'allauth.account.auth_backends.AuthenticationBackend',
 ]
 
 

--- a/squad/socialaccount.py
+++ b/squad/socialaccount.py
@@ -1,0 +1,23 @@
+from allauth.socialaccount.adapter import DefaultSocialAccountAdapter
+from allauth.account.utils import perform_login
+
+from squad.core.models import User
+
+
+class CustomSocialAccountAdapter(DefaultSocialAccountAdapter):
+
+    def populate_user(self, request, sociallogin, data):
+        user = super().populate_user(request, sociallogin, data)
+        user.username = user.email
+        return user
+
+    def pre_social_login(self, request, sociallogin):
+        user = sociallogin.user
+        if user.id:
+            return
+        try:
+            existing_user = User.objects.get(email=user.username)
+            sociallogin.state['process'] = 'connect'
+            perform_login(request, existing_user, request.GET.get('next', '/'))
+        except User.DoesNotExist:
+            pass

--- a/squad/urls.py
+++ b/squad/urls.py
@@ -71,5 +71,6 @@ urlpatterns = extra_urls + [
     url(r'^api/', include('squad.api.urls')),
     url(r'^login/', auth.LoginView.as_view(template_name='squad/login.jinja2')),
     url(r'^logout/', auth.LogoutView.as_view(next_page='/')),
+    url(r'^accounts/', include('allauth.urls')),
     url(r'', include('squad.frontend.urls'))
 ]


### PR DESCRIPTION
Fixes https://github.com/Linaro/squad/issues/829

Answering @mwasilew questions:


> should we combine user accounts using different auth methods? For example if I have Linaro account and github account, should they be combined so I could authenticated with either provider?

That could be done, but I'm going with **no**. I don't think a user being logged in via Github/Gitlab should be authenticated as any Linaro user. It feels wrong, dunno why.

> do we even want to allow multiple auth providers at the same time?

That's done! Users can authenticate via Github or Gitlab

> how to manage access to projects for users with different auth providers (this is mainly for qa-reports.l.o)

Users will be granted default `squad` permissions, allowing them to create their own user space and with that they can submit jobs, generate their own auth-token. If further permissions are required, so Group managers should do accordingly.

> what to use as username?

I opted for using email, as this will be used to determine if user already exists or not. If a user uses the same email for both Gitlab and Github accounts, he/she can use both methods to log to the same SQUAD user. When such users create their own user namespace, the symbol `@` will be removed from it, as it's not a match for `group_slug` regex pattern.

That's how the login page will look like:
![Screenshot from 2021-01-12 23-50-45](https://user-images.githubusercontent.com/2254825/104400345-1e987b00-5531-11eb-8fb2-b7964696ad0b.png)
