### PR TITLE
Dockerfile: update debian from buster to bullseye

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -6,6 +6,8 @@ RUN apt-get update -q=2 && \
     apt-get install -q=2 --no-install-recommends iproute2 auto-apt-proxy && \
     apt-get install -q=2 --no-install-recommends \
         python3 \
+        python3-asgiref \
+        python3-boto3 \
         python3-celery \
         python3-coreapi  \
         python3-cryptography \
@@ -24,6 +26,7 @@ RUN apt-get update -q=2 && \
         python3-djangorestframework-extensions \
         python3-future \
         python3-gunicorn \
+        python3-importlib-metadata \
         python3-jinja2 \
         python3-markdown \
         python3-msgpack \
@@ -37,6 +40,7 @@ RUN apt-get update -q=2 && \
         python3-whitenoise \
         python3-yaml \
         python3-zmq \
+        python3-zipp \
         fail2ban \
         gettext \
         git \
@@ -60,18 +64,13 @@ RUN cd /squad-build && ./scripts/git-build && \
         ./dist/squad*.whl \
         squad-linaro-plugins \
         sentry-sdk==0.14.3 \
-        zipp \
-        importlib-metadata==3.1.1 \
-        asgiref \
         django-bootstrap3 \
         django-storages==1.9 && \
-    pip3 install boto3==1.15 && \
     cd / && rm -rf /squad-build && \
     mkdir -p /app/static && \
     useradd -d /app squad && \
     python3 -m squad.frontend && \
     squad-admin collectstatic --noinput --verbosity 0 && \
-    squad-admin compilemessages && \
     chown -R squad:squad /app
 
 # TODO: use --ignore for `squad-admin compilemessages` to save time compiling

--- a/dev-docker
+++ b/dev-docker
@@ -11,10 +11,10 @@ mkdir -p "$datadir"
 dockerfile="$datadir"/../Dockerfile.dev
 (
   sed -e '1,/# Prepare the environment/!d' "$basedir"/Dockerfile
-  echo 'RUN apt-get update -q2 && apt-get install -q2 snakefood flake8 python3-django-extensions python3-django-debug-toolbar python3-pytest ipython3 rabbitmq-server chromium nodejs ruby-foreman procps && \'
+  echo 'RUN apt-get update -q2 && apt-get install -q2 flake8 python3-django-extensions python3-pytest ipython3 ruby-foreman procps && \'
   echo "    groupadd -g $(id -g) $(id -gn) && \\"
   echo "    useradd -m -u $(id -u) -g $(id -g) -s /bin/bash ${USER}"
-  echo "RUN pip3 install --no-dependencies zipp importlib-metadata==3.1.1 asgiref django-bootstrap3"
+  echo "RUN pip3 install django-bootstrap3 django-debug-toolbar"
   echo "WORKDIR /app"
   echo "USER ${USER}"
   echo 'CMD ["bash"]'


### PR DESCRIPTION
This update will upgrade the following important packages:
- Django will go from 1.11 to 2.0
- Python will go from 3.6 to 3.9
- Allauth will stay at 0.42 (which doesn't have a bug with Github login)

A few packages that were being installed via pip are now available in
Debian packaging system.

Some packages were dropped therefore removed from dev-docker.

NOTE: because now chromium is no longer in Debian Bullseye, we won't
be doing JS tests in dev-docker. They will still be run in travis though.