### PR TITLE
Rollback debian bullseye

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim
+FROM debian:buster-slim
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -6,8 +6,6 @@ RUN apt-get update -q=2 && \
     apt-get install -q=2 --no-install-recommends iproute2 auto-apt-proxy && \
     apt-get install -q=2 --no-install-recommends \
         python3 \
-        python3-asgiref \
-        python3-boto3 \
         python3-celery \
         python3-coreapi  \
         python3-cryptography \
@@ -26,7 +24,6 @@ RUN apt-get update -q=2 && \
         python3-djangorestframework-extensions \
         python3-future \
         python3-gunicorn \
-        python3-importlib-metadata \
         python3-jinja2 \
         python3-markdown \
         python3-msgpack \
@@ -40,7 +37,6 @@ RUN apt-get update -q=2 && \
         python3-whitenoise \
         python3-yaml \
         python3-zmq \
-        python3-zipp \
         fail2ban \
         gettext \
         git \
@@ -64,13 +60,18 @@ RUN cd /squad-build && ./scripts/git-build && \
         ./dist/squad*.whl \
         squad-linaro-plugins \
         sentry-sdk==0.14.3 \
+        zipp \
+        importlib-metadata==3.1.1 \
+        asgiref \
         django-bootstrap3 \
         django-storages==1.9 && \
+    pip3 install boto3==1.15 && \
     cd / && rm -rf /squad-build && \
     mkdir -p /app/static && \
     useradd -d /app squad && \
     python3 -m squad.frontend && \
     squad-admin collectstatic --noinput --verbosity 0 && \
+    squad-admin compilemessages && \
     chown -R squad:squad /app
 
 # TODO: use --ignore for `squad-admin compilemessages` to save time compiling

--- a/dev-docker
+++ b/dev-docker
@@ -11,10 +11,10 @@ mkdir -p "$datadir"
 dockerfile="$datadir"/../Dockerfile.dev
 (
   sed -e '1,/# Prepare the environment/!d' "$basedir"/Dockerfile
-  echo 'RUN apt-get update -q2 && apt-get install -q2 flake8 python3-django-extensions python3-pytest ipython3 ruby-foreman procps && \'
+  echo 'RUN apt-get update -q2 && apt-get install -q2 snakefood flake8 python3-django-extensions python3-django-debug-toolbar python3-pytest ipython3 rabbitmq-server chromium nodejs ruby-foreman procps && \'
   echo "    groupadd -g $(id -g) $(id -gn) && \\"
   echo "    useradd -m -u $(id -u) -g $(id -g) -s /bin/bash ${USER}"
-  echo "RUN pip3 install django-bootstrap3 django-debug-toolbar"
+  echo "RUN pip3 install --no-dependencies zipp importlib-metadata==3.1.1 asgiref django-bootstrap3"
   echo "WORKDIR /app"
   echo "USER ${USER}"
   echo 'CMD ["bash"]'

--- a/dev-docker
+++ b/dev-docker
@@ -11,7 +11,7 @@ mkdir -p "$datadir"
 dockerfile="$datadir"/../Dockerfile.dev
 (
   sed -e '1,/# Prepare the environment/!d' "$basedir"/Dockerfile
-  echo 'RUN apt-get update -q2 && apt-get install -q2 snakefood flake8 python3-django-extensions python3-django-debug-toolbar python3-pytest ipython3 rabbitmq-server chromium nodejs ruby-foreman procps && \'
+  echo 'RUN apt-get update -q2 && apt-get install -q2 tmux snakefood flake8 python3-django-extensions python3-django-debug-toolbar python3-pytest ipython3 rabbitmq-server chromium nodejs ruby-foreman procps && \'
   echo "    groupadd -g $(id -g) $(id -gn) && \\"
   echo "    useradd -m -u $(id -u) -g $(id -g) -s /bin/bash ${USER}"
   echo "RUN pip3 install --no-dependencies zipp importlib-metadata==3.1.1 asgiref django-bootstrap3"


### PR DESCRIPTION
I upgraded our debian base docker image to bullseye in order to get newer packages, but mainly to satisfy django-allauth's requirement of having Django 2.2. Doing so proved to cause some compatibility issues mainly with boto and ldap connections.

I reverted that commit and started using -backports instead.