### PR TITLE
core: notification: mark as notified even if no recipients available

### DIFF
--- a/squad/core/notification.py
+++ b/squad/core/notification.py
@@ -174,6 +174,8 @@ class Notification(object):
     def send(self):
         recipients = self.recipients
         if not recipients:
+            # No email is sent, but don't try to send it again
+            self.mark_as_notified()
             return
 
         sender = "%s <%s>" % (settings.SITE_NAME, settings.EMAIL_FROM)

--- a/test/core/test_notification.py
+++ b/test/core/test_notification.py
@@ -205,6 +205,15 @@ class TestSendNotification(TestCase):
         self.assertEqual(0, len(mail.outbox))
 
     @patch("squad.core.comparison.TestComparison.diff", new_callable=PropertyMock)
+    def test_no_recipients_no_email_mark_as_notified(self, diff):
+        diff.return_value = fake_diff()
+        status = ProjectStatus.create_or_update(self.build2)
+        send_status_notification(status)
+        self.assertEqual(0, len(mail.outbox))
+        status.refresh_from_db()
+        self.assertTrue(status.notified)
+
+    @patch("squad.core.comparison.TestComparison.diff", new_callable=PropertyMock)
     def test_send_notification_to_user(self, diff):
         self.project.subscriptions.create(user=self.user)
         diff.return_value = fake_diff()


### PR DESCRIPTION
This prevents gerrit notifications from being sent on every new coming testjob