### PR TITLE
ci: lava: fix resubmit on testjobs with empty job_id

### DIFF
--- a/squad/ci/backend/lava.py
+++ b/squad/ci/backend/lava.py
@@ -277,7 +277,8 @@ class Backend(BaseBackend):
 
     def resubmit(self, test_job):
         if test_job.job_id is None:
-            return None
+            # job_id == None means the job never got actually submitted to LAVA, so just submit it
+            return self.submit(test_job)
 
         with self.handle_job_submission():
             new_job_id_list = self.__resubmit__(test_job.job_id)

--- a/test/ci/backend/test_lava.py
+++ b/test/ci/backend/test_lava.py
@@ -1184,3 +1184,24 @@ class LavaTest(TestCase):
         )
         with self.assertRaises(SubmissionIssue):
             lava.resubmit(testjob)
+
+    @patch("squad.ci.backend.lava.Backend.__submit__", return_value="1235")
+    def test_resubmit_canceled_job(self, __resubmit__):
+        """
+            There might be a scenario where a test job got submitted and then canceled
+            and never make it to LAVA to get a job_id from it.
+
+            Because testjob had no job_id, __resubmit__ returns None, which
+            breaks upper functions.
+        """
+        lava = LAVABackend(None)
+        test_definition = "foo: 1\njob_name: bar"
+        testjob = TestJob(
+            definition=test_definition,
+            backend=self.backend,
+            target=self.project,
+            submitted=True,
+            job_status='Canceled',
+        )
+        job_id = lava.resubmit(testjob)
+        self.assertEqual(job_id, ['1235'])


### PR DESCRIPTION
There's a scenario where a TestJob might not have the job_id when resubmit is requested, causing a crash.

This patch checks for that and submits the TestJob instead of trying to resubmit.