### PR TITLE
[Don't merge it yet] core: notification: use fast TestComparison

### DIFF
--- a/squad/core/notification.py
+++ b/squad/core/notification.py
@@ -34,9 +34,10 @@ class Notification(object):
     @property
     def comparison(self):
         if self.__comparison__ is None:
-            self.__comparison__ = TestComparison.compare_builds(
+            self.__comparison__ = TestComparison(
                 self.previous_build,
                 self.build,
+                regressions_and_fixes_only=True,
             )
         return self.__comparison__
 


### PR DESCRIPTION
Passing `regressions_and_fixes_only=True` to TestComparison will force it to use a fast way to compute regressions and fixes
thus improving performance of overall Notifications

I'll run a bigger round of tests before we can merge this.