### PR TITLE
Use `expected_testruns == -1` to disable and environment for receiving new submissions

### DIFF
--- a/squad/api/ci.py
+++ b/squad/api/ci.py
@@ -28,6 +28,11 @@ def submit_job(request, group_slug, project_slug, version, environment_slug):
     if project is None:
         return HttpResponseBadRequest("malformed request")
 
+    # `Environment.expected_test_runs == -1` means that environment will stop receiving submissions
+    environment, created = project.environments.get_or_create(slug=environment_slug)
+    if environment.expected_test_runs == -1:
+        return HttpResponseBadRequest("environment '%s' is disabled and squad will not accept new submissions to it" % environment_slug)
+
     # create Build object
     build, _ = project.builds.get_or_create(version=version)
 


### PR DESCRIPTION
This patch let users disable environments in projects, thus avoiding test job submissions to such environments.

It's a WIP because it needs some extra discussion.