### PR TITLE
add suport to django-health-check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,8 @@ RUN apt-get update -q=2 && \
         django-filter==2.0.0 \
         djangorestframework-filters==1.0.0.dev0 \
         django-storages==1.9 \
-        django-allauth==0.44.0 && \
+        django-allauth==0.44.0 \
+        django-health-check==3.16.4 && \
     pip3 install boto3==1.15
 
 # Prepare the environment

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,4 +12,4 @@ exclude =
     doc,
     dist
 
-ignore = E501
+ignore = E501,C101

--- a/squad/frontend/templates/squad/_user_menu.jinja2
+++ b/squad/frontend/templates/squad/_user_menu.jinja2
@@ -15,6 +15,9 @@
         {% if user.is_staff %}
           <li role="separator" class="divider"></li>
           <li><a href="/admin/">{{ _('Administration') }}</a></li>
+          {% if url('health_check') %}
+              <li><a href="/ht/">{{ _('System status') }}</a></li>
+          {% endif %}
         {% endif %}
         <li role="separator" class="divider"></li>
         <li><a href="{{url('settings-home')}}">{{ _('Settings')}}</a></li>

--- a/squad/urls.py
+++ b/squad/urls.py
@@ -66,6 +66,13 @@ if settings.DEBUG:
         pass
 
 
+if 'health_check' in settings.INSTALLED_APPS:
+    try:
+        import health_check  # noqa
+        extra_urls.append(url(r'^ht/', include('health_check.urls')))
+    except ImportError:
+        pass
+
 urlpatterns = extra_urls + [
     url(r'^admin/', admin.site.urls),
     url(r'^api/', include('squad.api.urls')),


### PR DESCRIPTION
This package allows simple system checks to be made in a running SQUAD instance. The full configuration should take place in an external set up file.

This is how it's going to look:

![Screenshot from 2021-04-23 00-41-21](https://user-images.githubusercontent.com/2254825/115815141-ccd37c80-a3cc-11eb-9a3c-03400a6dd70a.png)


For more information, please read:
https://django-health-check.readthedocs.io/en/stable/readme.html#

