### PR TITLE
Raise TemporaryFetchIssue on fetch timeout

### DIFF
--- a/squad/ci/backend/lava.py
+++ b/squad/ci/backend/lava.py
@@ -144,6 +144,12 @@ class Backend(BaseBackend):
                 raise FetchIssue(self.url_remove_token(str(fault)))
         except ssl.SSLError as fault:
             raise FetchIssue(self.url_remove_token(str(fault)))
+        except requests.exceptions.RequestException as fault:
+            if isinstance(fault, requests.exceptions.Timeout):
+                # assume HTTP errors 5xx are temporary issues
+                raise TemporaryFetchIssue(self.url_remove_token(str(fault)))
+            else:
+                raise FetchIssue(self.url_remove_token(str(fault)))
 
     def listen(self):
         listener_url = self.get_listener_url()


### PR DESCRIPTION
Fix https://github.com/Linaro/squad/issues/988

By not handling Timeouts, TestJob.fetch_attempt was never increased so the job would be retried over and over and over.

Now with correct exception handling, Backend.fetch() will correctly increase TestJob.fetch_attempts whenever there's a Lab downtime.