### PR TITLE
Disable resubmit button

### DIFF
--- a/squad/frontend/templates/squad/testjobs.jinja2
+++ b/squad/frontend/templates/squad/testjobs.jinja2
@@ -111,16 +111,18 @@
                         </a>
                     </div>
                     {% endif %}
+                    {% set num_resubmitted_jobs = testjob.resubmitted_jobs.count() %}
                     <div class='pull-right' ng-controller='ResubmitController'>
                         <a
                             class="btn"
                             ng-click="resubmit({{testjob.id}}, true)"
                             ng-class="{'btn-info': !done, 'btn-success': done, 'btn-danger': error}"
-                            ng-disabled="done"
+                            ng-disabled="{{ num_resubmitted_jobs }} > 0"
                             title="{{ _('Resubmit job no matter the status') }}">
                             <span
                                 ng-class="{'fa':true, 'fa-recycle':!done, 'fa-check': done && !error, 'fa-spin': loading, 'fa-close': error}"
-                                ng-disabled="done"title="{{ _('Resubmit job no matter the status') }}">
+                                ng-disabled="done"
+                                title="{{ _('Resubmit job no matter the status') }}">
                             </span>
                             {{ _('%s - force resubmit') % testjob.job_id }}
                         </a>
@@ -129,7 +131,7 @@
                             class="btn"
                             ng-click="resubmit({{testjob.id}}, false)"
                             ng-class="{'btn-info': !done, 'btn-success': done, 'btn-danger': error}"
-                            ng-disabled="done"
+                            ng-disabled="{{ num_resubmitted_jobs }} > 0"
                             title="{{ _('Resubmit job') }}">
                             <span
                                 ng-class="{'fa':true, 'fa-recycle':!done, 'fa-check': done && !error, 'fa-spin': loading, 'fa-close': error}"

--- a/squad/frontend/templates/squad/testjobs.jinja2
+++ b/squad/frontend/templates/squad/testjobs.jinja2
@@ -99,8 +99,6 @@
                 <div class='pull-right' ng-controller='CancelController' title="{{ _('Cancel job') }}">
                     <a class="btn" ng-click="cancel({{testjob.id}})" ng-class="{'btn-info': !done, 'btn-success': done, 'btn-danger': error}" ng-disabled="done" ><span ng-class="{'fa':true, 'fa-recycle':!done, 'fa-check': done && !error, 'fa-spin': loading, 'fa-close': error}" ng-disabled="done"></span> {{ _('%s - cancel')  % testjob.job_id }}</a>
                 </div>
-                {% if testjob.submitted %}
-                {% endif %}
                 <div class='pull-right' ng-controller='ResubmitController'>
                     <a class="btn" ng-click="resubmit({{testjob.id}}, true)" ng-class="{'btn-info': !done, 'btn-success': done, 'btn-danger': error}" ng-disabled="done" title="{{ _('Resubmit job no matter the status') }}"><span ng-class="{'fa':true, 'fa-recycle':!done, 'fa-check': done && !error, 'fa-spin': loading, 'fa-close': error}" ng-disabled="done" title="{{ _('Resubmit job no matter the status') }}"></span> {{ _('%s - force resubmit') % testjob.job_id }}</a>
                 {% if testjob.can_resubmit %}

--- a/squad/frontend/templates/squad/testjobs.jinja2
+++ b/squad/frontend/templates/squad/testjobs.jinja2
@@ -96,17 +96,49 @@
                 <button class="btn btn-default btn-sm" type="button" data-toggle="collapse" data-target="#collapse-definition-{{testjob.pk}}" aria-expanded="false" aria-controls="collapse-definition-{{testjob.pk}}" title="{{ _('Job definition') }}"><span class="glyphicon glyphicon-list-alt" aria-hidden="true" title="{{ _('Job definition') }}"></span></button>
                 {% endif %}
                 {% if project.can_submit_testjobs(user) %}
-                <div class='pull-right' ng-controller='CancelController' title="{{ _('Cancel job') }}">
-                    <a class="btn" ng-click="cancel({{testjob.id}})" ng-class="{'btn-info': !done, 'btn-success': done, 'btn-danger': error}" ng-disabled="done" ><span ng-class="{'fa':true, 'fa-recycle':!done, 'fa-check': done && !error, 'fa-spin': loading, 'fa-close': error}" ng-disabled="done"></span> {{ _('%s - cancel')  % testjob.job_id }}</a>
-                </div>
-                <div class='pull-right' ng-controller='ResubmitController'>
-                    <a class="btn" ng-click="resubmit({{testjob.id}}, true)" ng-class="{'btn-info': !done, 'btn-success': done, 'btn-danger': error}" ng-disabled="done" title="{{ _('Resubmit job no matter the status') }}"><span ng-class="{'fa':true, 'fa-recycle':!done, 'fa-check': done && !error, 'fa-spin': loading, 'fa-close': error}" ng-disabled="done" title="{{ _('Resubmit job no matter the status') }}"></span> {{ _('%s - force resubmit') % testjob.job_id }}</a>
-                {% if testjob.can_resubmit %}
-                    <a class="btn" ng-click="resubmit({{testjob.id}}, false)" ng-class="{'btn-info': !done, 'btn-success': done, 'btn-danger': error}" ng-disabled="done" title="{{ _('Resubmit job') }}"><span ng-class="{'fa':true, 'fa-recycle':!done, 'fa-check': done && !error, 'fa-spin': loading, 'fa-close': error}" ng-disabled="done" title="{{ _('Resubmit job') }}"></span> {{ _('%s - resubmit')  % testjob.job_id }}</a>
+                    <div class='pull-right' ng-controller='CancelController' title="{{ _('Cancel job') }}">
+                        <a
+                            class="btn"
+                            ng-click="cancel({{testjob.id}})"
+                            ng-class="{'btn-info': !done, 'btn-success': done, 'btn-danger': error}"
+                            ng-disabled="done">
+                            <span
+                                ng-class="{'fa':true, 'fa-recycle':!done, 'fa-check': done && !error, 'fa-spin': loading, 'fa-close': error}"
+                                ng-disabled="done">
+                            </span>
+                            {{ _('%s - cancel')  % testjob.job_id }}
+                        </a>
+                    </div>
+                    <div class='pull-right' ng-controller='ResubmitController'>
+                        <a
+                            class="btn"
+                            ng-click="resubmit({{testjob.id}}, true)"
+                            ng-class="{'btn-info': !done, 'btn-success': done, 'btn-danger': error}"
+                            ng-disabled="done"
+                            title="{{ _('Resubmit job no matter the status') }}">
+                            <span
+                                ng-class="{'fa':true, 'fa-recycle':!done, 'fa-check': done && !error, 'fa-spin': loading, 'fa-close': error}"
+                                ng-disabled="done"title="{{ _('Resubmit job no matter the status') }}">
+                            </span>
+                            {{ _('%s - force resubmit') % testjob.job_id }}
+                        </a>
+                        {% if testjob.can_resubmit %}
+                        <a
+                            class="btn"
+                            ng-click="resubmit({{testjob.id}}, false)"
+                            ng-class="{'btn-info': !done, 'btn-success': done, 'btn-danger': error}"
+                            ng-disabled="done"
+                            title="{{ _('Resubmit job') }}">
+                            <span
+                                ng-class="{'fa':true, 'fa-recycle':!done, 'fa-check': done && !error, 'fa-spin': loading, 'fa-close': error}"
+                                ng-disabled="done"
+                                title="{{ _('Resubmit job') }}">
+                            </span>
+                            {{ _('%s - resubmit') % testjob.job_id }}
+                        </a>
+                        {% endif %}
+                    </div>
                 {% endif %}
-                </div>
-                {% endif %}
-
             </div>
             {% if testjob.failure %}
             <div class="collapse" id="collapse-failure-{{testjob.pk}}">

--- a/squad/frontend/templates/squad/testjobs.jinja2
+++ b/squad/frontend/templates/squad/testjobs.jinja2
@@ -96,6 +96,7 @@
                 <button class="btn btn-default btn-sm" type="button" data-toggle="collapse" data-target="#collapse-definition-{{testjob.pk}}" aria-expanded="false" aria-controls="collapse-definition-{{testjob.pk}}" title="{{ _('Job definition') }}"><span class="glyphicon glyphicon-list-alt" aria-hidden="true" title="{{ _('Job definition') }}"></span></button>
                 {% endif %}
                 {% if project.can_submit_testjobs(user) %}
+                    {% if not testjob.fetched %}
                     <div class='pull-right' ng-controller='CancelController' title="{{ _('Cancel job') }}">
                         <a
                             class="btn"
@@ -109,6 +110,7 @@
                             {{ _('%s - cancel')  % testjob.job_id }}
                         </a>
                     </div>
+                    {% endif %}
                     <div class='pull-right' ng-controller='ResubmitController'>
                         <a
                             class="btn"


### PR DESCRIPTION
Fix https://github.com/Linaro/squad/issues/997

This patch will disable the "resubmit" option of jobs that already got resubmitted. Things will look like this:

![Screenshot from 2021-07-12 09-08-54](https://user-images.githubusercontent.com/2254825/125285435-055e6480-e2f1-11eb-8658-41c76b94c3ae.png)

The patch also hides the "cancel" button on Jobs that are fetched already (it only makes sense to cancel jobs that aren't yet finished)
