### PR TITLE
ci: models: delete results from resubmitted jobs

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -132,6 +132,10 @@ resubmit
 This API is only available to superusers at the moment. It allows to resubmit
 CI test jobs using Backend's implementation.
 
+By default, the original test job object's results are kept in, but there's
+a project setting named `CI_DELETE_RESULTS_RESUBMITTED_JOBS` that tells SQUAD
+to remove all results from the resubmitted job. 
+
 forceresubmit
 ~~~~~~~~~~~~~
 

--- a/squad/ci/models.py
+++ b/squad/ci/models.py
@@ -252,7 +252,18 @@ class TestJob(models.Model):
         # resubmit test job not respecting any restrictions
         self.backend.get_implementation().resubmit(self)
         self.resubmitted_count += 1
-        self.save()
+
+        # Delete testrun, if any
+        if self.target.get_setting('CI_DELETE_RESULTS_RESUBMITTED_JOBS', False) and self.testrun:
+            testrun = self.testrun
+
+            self.testrun = None
+            self.save()
+
+            testrun.delete()
+        else:
+            self.save()
+
         return True
 
     def cancel(self):


### PR DESCRIPTION
Fix https://github.com/Linaro/squad/issues/996

This patch checks whether the setting `CI_DELETE_RESULTS_RESUBMITTED_JOBS` is enabled, if so, delete the test run associated with the TestJob.

This will be useful for projects that need to resubmit jobs from whatever reason.