### PR TITLE
Fetch job as they are watched

### DIFF
--- a/squad/api/ci.py
+++ b/squad/api/ci.py
@@ -5,7 +5,7 @@ from django.views.decorators.http import require_http_methods
 
 from squad.http import auth_privileged, read_file_upload, auth_user_from_request
 from squad.ci.exceptions import SubmissionIssue
-from squad.ci.tasks import submit
+from squad.ci.tasks import submit, fetch
 from squad.ci.models import Backend, TestJob
 from squad.core.utils import log_addition
 
@@ -99,6 +99,9 @@ def watch_job(request, group_slug, project_slug, version, environment_slug):
         job_id=testjob_id
     )
     log_addition(request, test_job, "Watch Job submission")
+
+    # schedule a fetch task on this job right away
+    fetch.delay(test_job.id)
 
     # return ID of test job
     return HttpResponse(test_job.id, status=201)

--- a/test/api/test_ci.py
+++ b/test/api/test_ci.py
@@ -207,7 +207,7 @@ class CiApiTest(TestCase):
         r = self.client.post('/api/watchjob/mygroup/myproject/1/myenv', args)
         self.assertEqual(403, r.status_code)
 
-    @patch("squad.ci.tasks.fetch.apply_async")
+    @patch("squad.ci.tasks.fetch.delay")
     def test_watch_testjob(self, fetch):
         testjob_id = 1234
         args = {
@@ -228,6 +228,7 @@ class CiApiTest(TestCase):
             1,
             testjob_queryset.count()
         )
+        fetch.assert_called_with(testjob_queryset.first().id)
         logentry_queryset = LogEntry.objects.filter(
             user_id=self.project_privileged_user.pk,
             object_id=testjob_queryset.last().pk


### PR DESCRIPTION
This patch adds a fetch task immediately as a job is triggered for watching, thus causing watched jobs to be fetched right away.