### PR TITLE
api: rest: add cancel endpoint to builds

### DIFF
--- a/squad/ci/models.py
+++ b/squad/ci/models.py
@@ -256,15 +256,18 @@ class TestJob(models.Model):
         return True
 
     def cancel(self):
+        if self.job_status == "Canceled":
+            return False
+
         if self.job_id is not None:
             return self.backend.get_implementation().cancel(self)
-        else:
-            self.fetched = True
-            self.submitted = True
-            self.job_status = "Canceled"
-            self.failure = "Cancelled before submission"
-            self.save()
-        return self.fetched
+
+        self.fetched = True
+        self.submitted = True
+        self.job_status = "Canceled"
+        self.failure = "Canceled before submission"
+        self.save()
+        return True
 
     def __str__(self):
         return "%s/%s" % (self.backend.name, self.job_id)

--- a/squad/ci/tasks.py
+++ b/squad/ci/tasks.py
@@ -29,6 +29,13 @@ def fetch(job_id):
     backend.fetch(job_id)
 
 
+@celery.task
+def cancel(job_id):
+    logger.info("canceling %s" % job_id)
+    testjob = TestJob.objects.get(pk=job_id)
+    testjob.cancel()
+
+
 @celery.task(bind=True)
 def submit(self, job_id):
     test_job = TestJob.objects.get(pk=job_id)

--- a/squad/frontend/static/squad/controllers/cancel.js
+++ b/squad/frontend/static/squad/controllers/cancel.js
@@ -25,4 +25,28 @@ export function CancelController($scope, $http, $location, $timeout) {
             }
         )
     }
+
+    $scope.cancel_all = function(build_id) {
+        if ($scope.done) return
+        $scope.loading = true
+
+        $http.post("/api/builds/" + build_id + "/cancel/").then(
+            function(response) {
+                $timeout(function() {
+                    $scope.loading = false
+                    $scope.done = true
+                }, 1000)
+                alert(response.data['status'])
+            },
+            function(response) {
+                var msg = "There was an error while cancelling.\n" +
+                    "Status = " + response.status + " " + response.statusText +
+                    "(" + response.xhrStatus + ")"
+                alert(msg)
+                $scope.loading = false
+                $scope.error = true
+                $scope.done = true
+            }
+        )
+    }
 }

--- a/squad/frontend/templates/squad/testjobs.jinja2
+++ b/squad/frontend/templates/squad/testjobs.jinja2
@@ -50,6 +50,16 @@
     </div>
 
     <div>
+    {% if project.can_submit_testjobs(user) and testjobs|length %}
+    <div class='pull-right clearfix' ng-controller='CancelController' title="{{ _('Cancel all jobs') }}">
+        <a class="btn" ng-click="cancel_all({{ build.id }})" ng-class="{'btn-info': !done, 'btn-success': done, 'btn-danger': error}" ng-disabled="done" >
+	    <span ng-class="{'fa':true, 'fa-recycle':!done, 'fa-check': done && !error, 'fa-spin': loading, 'fa-close': error}" ng-disabled="done"></span>
+	    {{ _('Cancell all jobs') }}
+	</a>
+    </div>
+    <br />
+    <br />
+    {% endif %}
 
     {% with items=testjobs %}
       {% include "squad/_pagination.jinja2" %}

--- a/test/api/test_rest.py
+++ b/test/api/test_rest.py
@@ -721,6 +721,16 @@ class RestApiTest(APITestCase):
         self.assertTrue('version' in fields)
         self.assertEqual(1, len(fields))
 
+    def test_build_cancel(self):
+        testjob = self.build.test_jobs.first()
+        testjob.submitted = True
+        testjob.save()
+        self.assertEqual(self.build.test_jobs.filter(job_status='Canceled').count(), 0)
+        data = self.post('/api/builds/%d/cancel/' % self.build.id, {})
+        self.assertEqual(data.status_code, 200)
+        self.assertEqual(data.json()['count'], 1)
+        self.assertEqual(self.build.test_jobs.filter(job_status='Canceled').count(), 1)
+
     def test_testjob(self):
         data = self.hit('/api/testjobs/%d/' % self.testjob.id)
         self.assertEqual('myenv', data['environment'])


### PR DESCRIPTION
Fix https://github.com/Linaro/squad/issues/1001

This patch adds "cancel" endpoint to builds that, when invoked cancel all test jobs in that build.

![Screenshot from 2021-10-18 13-36-26](https://user-images.githubusercontent.com/2254825/137772706-a59d61bb-a7a0-47dc-975e-20e94618599f.png)

**cc** @roxell
Signed-off-by: Charles Oliveira <charles.oliveira@linaro.org>