### PR TITLE
View testjobs progress

### DIFF
--- a/squad/api/rest.py
+++ b/squad/api/rest.py
@@ -849,6 +849,12 @@ class BuildViewSet(NestedViewSetMixin, ModelViewSet):
 
         List of test jobs in the build (if any)
 
+     * `api/builds/<id>/testjobs_summary` GET
+
+        List of test jobs in the build summarized by job_status.
+        If `per_environment` is specified in the query string, the summary
+        will be split by environments.
+
      * `api/builds/<id>/cancel` POST
 
         Cancel all test jobs of the build (if any)
@@ -965,6 +971,12 @@ class BuildViewSet(NestedViewSetMixin, ModelViewSet):
         page = self.paginate_queryset(testjobs)
         serializer = TestJobSerializer(page, many=True, context={'request': request})
         return self.get_paginated_response(serializer.data)
+
+    @action(detail=True, methods=['get'], suffix='test jobs summary')
+    def testjobs_summary(self, request, pk=None):
+        per_environment = request.query_params.get("per_environment", None)
+        summary = self.get_object().test_jobs_summary(per_environment is not None)
+        return Response({'results': summary})
 
     @action(detail=True, methods=['post'], suffix='cancel')
     def cancel(self, request, pk=None):

--- a/squad/core/models.py
+++ b/squad/core/models.py
@@ -636,6 +636,8 @@ class Build(models.Model):
         summary = {}
         if per_environment:
             for env, jobs in groupby(testjobs, lambda tj: tj.environment):
+                if env is None:
+                    continue
                 summary[env] = Counter([tj.job_status for tj in jobs])
         else:
             summary = Counter([tj.job_status for tj in testjobs])

--- a/squad/core/models.py
+++ b/squad/core/models.py
@@ -1,8 +1,9 @@
 import json
 import yaml
 import logging
-from collections import OrderedDict
+from collections import OrderedDict, Counter
 from hashlib import sha1
+from itertools import groupby
 import re
 
 
@@ -629,6 +630,17 @@ class Build(models.Model):
                 key=lambda suite_dict: suite_dict[0].slug)
 
         return result
+
+    def test_jobs_summary(self, per_environment=False):
+        testjobs = self.test_jobs.only('environment', 'job_status', 'target_build').order_by('environment')
+        summary = {}
+        if per_environment:
+            for env, jobs in groupby(testjobs, lambda tj: tj.environment):
+                summary[env] = Counter([tj.job_status for tj in jobs])
+        else:
+            summary = Counter([tj.job_status for tj in testjobs])
+
+        return summary
 
 
 class BuildPlaceholder(models.Model):

--- a/squad/frontend/ci.py
+++ b/squad/frontend/ci.py
@@ -13,7 +13,7 @@ from squad.core.models import TestRun
 class TestjobFilter(django_filters.FilterSet):
     has_errors = django_filters.BooleanFilter(field_name='failure', lookup_expr='isnull', label=N_('Success'))
     name = django_filters.CharFilter(field_name='name', lookup_expr='icontains', label=N_('Name'))
-    job_status = django_filters.CharFilter(field_name='job_status', lookup_expr='icontains', label=N_('Job Status'))
+    job_status = django_filters.CharFilter(field_name='job_status', lookup_expr='iexact', label=N_('Job Status'))
     submitted = django_filters.BooleanFilter(field_name='submitted', lookup_expr='exact', label=N_('Is submitted'))
     fetched = django_filters.BooleanFilter(field_name='fetched', lookup_expr='exact', label=N_('Is Fetched'))
     job_id = django_filters.CharFilter(field_name='job_id', lookup_expr='icontains', label=N_('Job ID'))

--- a/squad/frontend/static/main.css
+++ b/squad/frontend/static/main.css
@@ -413,7 +413,7 @@ div#environment-separator {
 }
 
 .progress-container .progress {
-  height: 3rem;
+  height: 2rem;
   display: inline-block;
   padding: 0;
   transition: width 2s ease;
@@ -422,7 +422,7 @@ div#environment-separator {
 }
 
 .progress-container .complete {
-  background: #3c763d;
+  background: #5aaf5b;
 }
 
 .progress-container .failed {

--- a/squad/frontend/static/main.css
+++ b/squad/frontend/static/main.css
@@ -406,8 +406,10 @@ div#environment-separator {
 /* test jobs progress bar */
 .progress-container {
   display: flex;
-  padding: 0;
   height: 3rem;
+  padding: 0;
+  margin-bottom: 15px;
+  margin-top: -5px;
 }
 
 .progress-container .progress {
@@ -419,18 +421,18 @@ div#environment-separator {
   cursor: pointer;
 }
 
-.progress-container #progress-complete {
+.progress-container .complete {
   background: #3c763d;
 }
 
-.progress-container #progress-failed {
+.progress-container .failed {
   background: #a94442;
 }
 
-.progress-container #progress-running {
+.progress-container .running {
   background: #f8efc0;
 }
 
-.progress-container #progress-none {
+.progress-container .none {
   background: gray;
 }

--- a/squad/frontend/static/main.css
+++ b/squad/frontend/static/main.css
@@ -402,3 +402,35 @@ div#environment-separator {
 .panel-heading a.collapsed:after {
     content: "\f054";
 }
+
+/* test jobs progress bar */
+.progress-container {
+  display: flex;
+  padding: 0;
+  height: 3rem;
+}
+
+.progress-container .progress {
+  height: 3rem;
+  display: inline-block;
+  padding: 0;
+  transition: width 2s ease;
+  border-radius: 0px;
+  cursor: pointer;
+}
+
+.progress-container #progress-complete {
+  background: #3c763d;
+}
+
+.progress-container #progress-failed {
+  background: #a94442;
+}
+
+.progress-container #progress-running {
+  background: #f8efc0;
+}
+
+.progress-container #progress-none {
+  background: gray;
+}

--- a/squad/frontend/static/squad/build.js
+++ b/squad/frontend/static/squad/build.js
@@ -3,6 +3,7 @@ import {BuildCompareController} from './controllers/build_compare.js'
 import {FilterController} from './controllers/filter.js'
 import {ResubmitController} from './controllers/resubmit.js'
 import {CancelController} from './controllers/cancel.js'
+import {TestJobsProgressController} from './controllers/testjobs_progress.js'
 import {Config as appConfig} from './config.js'
 import {attach_select2} from './attach_select2.js'
 
@@ -61,5 +62,14 @@ app.controller(
         '$scope',
         'attach_select2',
         BuildCompareController
+    ]
+);
+
+app.controller(
+    'TestJobsProgressController',
+    [
+        '$scope',
+        '$http',
+        TestJobsProgressController
     ]
 );

--- a/squad/frontend/static/squad/controllers/testjobs_progress.js
+++ b/squad/frontend/static/squad/controllers/testjobs_progress.js
@@ -1,0 +1,60 @@
+export function TestJobsProgressController($scope, $http) {
+    $scope.build_id = undefined;
+    $scope.init = function(build_id, is_build_finished) {
+        if (is_build_finished) {
+            return;
+        }
+
+        // IE doesn't support Math.trunc :/: https://stackoverflow.com/questions/60402658/ie-browser-not-supporting-math-trunc
+        if (!Math.trunc) {
+            Math.trunc = function (v) {
+                return v < 0 ? Math.ceil(v) : Math.floor(v);
+            };
+        }
+
+        $scope.build_id = build_id;
+        var oneMinute = 60000;
+
+        setTimeout(function updateProgress() {
+            $http.get('/api/builds/'+ $scope.build_id +'/testjobs_summary/').then(function(response) {
+                var summary = response.data.results;
+                console.log(summary);
+                var progress_complete = summary.Complete || 0;
+                var progress_failed = (summary.Incomplete || 0) + (summary.Canceled || 0);
+                var progress_running = summary.Running || 0;
+                var progress_none = (summary.null || 0) + (summary.Submitted || 0);
+                var total = progress_complete + progress_failed + progress_running + progress_none;
+
+                if (total == 0) {
+                    console.log('Detected zero test jobs. Aborting...');
+                    return;
+                }
+
+                var div_complete = $('#progress-complete');
+                var div_failed   = $('#progress-failed');
+                var div_running  = $('#progress-running');
+                var div_none     = $('#progress-none');
+                var div_percentage= $('#progress-percentage');
+
+                div_complete.css('width', Math.trunc((progress_complete / total) * 100) + '%');
+                div_failed.css('width', Math.trunc((progress_failed / total) * 100) + '%');
+                div_running.css('width', Math.trunc((progress_running / total) * 100) + '%');
+                div_none.css('width', Math.trunc((progress_none / total) * 100) + '%');
+
+                div_complete.attr('data-original-title', progress_complete);
+                div_failed.attr('data-original-title', progress_failed);
+                div_running.attr('data-original-title', progress_running);
+                div_none.attr('data-original-title', progress_none);
+
+                div_percentage.text(Math.trunc(((progress_complete + progress_failed) / total) * 100) + '%');
+
+                var finished = (progress_complete + progress_failed) == total;
+                if (!finished) {
+                    setTimeout(updateProgress, oneMinute);
+                    return;
+                }
+                console.log('testjobs completed');
+            }).catch(function (data) {});
+        }, oneMinute);
+    }
+}

--- a/squad/frontend/static/squad/controllers/testjobs_progress.js
+++ b/squad/frontend/static/squad/controllers/testjobs_progress.js
@@ -1,6 +1,7 @@
 export function TestJobsProgressController($scope, $http) {
     $scope.build_id = undefined;
-    $scope.init = function(build_id, is_build_finished) {
+    $scope.per_environment = false;
+    $scope.init = function(build_id, is_build_finished, per_environment) {
         if (is_build_finished) {
             return;
         }
@@ -13,42 +14,92 @@ export function TestJobsProgressController($scope, $http) {
         }
 
         $scope.build_id = build_id;
+        $scope.per_environment = per_environment;
         var oneMinute = 60000;
+        var summary_url = '/api/builds/'+ $scope.build_id +'/testjobs_summary/';
+        if (per_environment) {
+            summary_url += '?per_environment=true';
+        }
 
         setTimeout(function updateProgress() {
-            $http.get('/api/builds/'+ $scope.build_id +'/testjobs_summary/').then(function(response) {
+            $http.get(summary_url).then(function(response) {
                 var summary = response.data.results;
-                console.log(summary);
-                var progress_complete = summary.Complete || 0;
-                var progress_failed = (summary.Incomplete || 0) + (summary.Canceled || 0);
-                var progress_running = summary.Running || 0;
-                var progress_none = (summary.null || 0) + (summary.Submitted || 0);
-                var total = progress_complete + progress_failed + progress_running + progress_none;
+                var finished = false;
+                var div_percentage= $('#progress-percentage');
+                var total_finished = 0;
+                var total = 0;
+
+                if (!$scope.per_environment) {
+                    var progress_complete = summary.Complete || 0;
+                    var progress_failed = (summary.Incomplete || 0) + (summary.Canceled || 0);
+                    var progress_running = summary.Running || 0;
+                    var progress_none = (summary.null || 0) + (summary.Submitted || 0);
+                    total = progress_complete + progress_failed + progress_running + progress_none;
+                    total_finished = progress_complete + progress_failed;
+
+                    if (total == 0) {
+                        console.log('Detected zero test jobs. Aborting...');
+                        return;
+                    }
+
+                    var div_complete = $('#progress-complete');
+                    var div_failed   = $('#progress-failed');
+                    var div_running  = $('#progress-running');
+                    var div_none     = $('#progress-none');
+
+                    div_complete.css('width', Math.trunc((progress_complete / total) * 100) + '%');
+                    div_failed.css('width', Math.trunc((progress_failed / total) * 100) + '%');
+                    div_running.css('width', Math.trunc((progress_running / total) * 100) + '%');
+                    div_none.css('width', Math.trunc((progress_none / total) * 100) + '%');
+
+                    div_complete.attr('data-original-title', progress_complete);
+                    div_failed.attr('data-original-title', progress_failed);
+                    div_running.attr('data-original-title', progress_running);
+                    div_none.attr('data-original-title', progress_none);
+                } else {
+                    var environments = Object.keys(summary);
+                    environments.forEach(function(env) {
+                        var env_summary = summary[env];
+                        var progress_complete = env_summary.Complete || 0;
+                        var progress_failed = (env_summary.Incomplete || 0) + (env_summary.Canceled || 0);
+                        var progress_running = env_summary.Running || 0;
+                        var progress_none = (env_summary.null || 0) + (env_summary.Submitted || 0);
+                        var env_total = progress_complete + progress_failed + progress_running + progress_none;
+                        total += env_total;
+                        total_finished += progress_complete + progress_failed;
+
+                        // No jobs for this environment, weird but could happen
+                        if (env_total == 0) {
+                            return;
+                        }
+
+                        var env_key = env.replaceAll('-', '_').replaceAll(' ', '_');
+                        var div_complete = $('#progress-complete-' + env_key);
+                        var div_failed   = $('#progress-failed-' + env_key);
+                        var div_running  = $('#progress-running-' + env_key);
+                        var div_none     = $('#progress-none-' + env_key);
+
+                        div_complete.css('width', Math.trunc((progress_complete / env_total) * 100) + '%');
+                        div_failed.css('width', Math.trunc((progress_failed / env_total) * 100) + '%');
+                        div_running.css('width', Math.trunc((progress_running / env_total) * 100) + '%');
+                        div_none.css('width', Math.trunc((progress_none / env_total) * 100) + '%');
+
+                        div_complete.attr('data-original-title', progress_complete);
+                        div_failed.attr('data-original-title', progress_failed);
+                        div_running.attr('data-original-title', progress_running);
+                        div_none.attr('data-original-title', progress_none);
+                    });
+                }
 
                 if (total == 0) {
                     console.log('Detected zero test jobs. Aborting...');
                     return;
                 }
 
-                var div_complete = $('#progress-complete');
-                var div_failed   = $('#progress-failed');
-                var div_running  = $('#progress-running');
-                var div_none     = $('#progress-none');
-                var div_percentage= $('#progress-percentage');
+                div_percentage.text(Math.trunc((total_finished / total) * 100) + '%');
 
-                div_complete.css('width', Math.trunc((progress_complete / total) * 100) + '%');
-                div_failed.css('width', Math.trunc((progress_failed / total) * 100) + '%');
-                div_running.css('width', Math.trunc((progress_running / total) * 100) + '%');
-                div_none.css('width', Math.trunc((progress_none / total) * 100) + '%');
+                finished = (total_finished == total);
 
-                div_complete.attr('data-original-title', progress_complete);
-                div_failed.attr('data-original-title', progress_failed);
-                div_running.attr('data-original-title', progress_running);
-                div_none.attr('data-original-title', progress_none);
-
-                div_percentage.text(Math.trunc(((progress_complete + progress_failed) / total) * 100) + '%');
-
-                var finished = (progress_complete + progress_failed) == total;
                 if (!finished) {
                     setTimeout(updateProgress, oneMinute);
                     return;

--- a/squad/frontend/templates/squad/build.jinja2
+++ b/squad/frontend/templates/squad/build.jinja2
@@ -8,6 +8,10 @@
 <h2>{{ _('Metadata') }}</h2>
 {% include "squad/_metadata.jinja2" %}
 
+{% if build.test_jobs.count() > 0 %}
+    {% include "squad/testjobs_progress.jinja2" %}
+{% endif %}
+
 <div class="form-group row">
     <div class="col-md-12 col-sm-12" ng-controller='BuildCompareController' ng-init="init({{ build.project_id }})">
         <h2>{{ _('Compare builds') }}</h2>

--- a/squad/frontend/templates/squad/testjobs_progress.jinja2
+++ b/squad/frontend/templates/squad/testjobs_progress.jinja2
@@ -1,20 +1,43 @@
 {% set testjobs_url = [project.group.slug, project.slug, 'build', build.version, 'testjobs'] | join('/') -%}
+{% set per_environment = request.GET.get('testjobs_progress_per_environments', None) -%}
+{% set attrs = 'data-toggle="tooltip" data-placement="bottom"' -%}
 {% set summary = build.test_jobs_summary() -%}
 {% set progress_complete = summary.get('Complete', 0) -%}
 {% set progress_failed = summary.get('Incomplete', 0) + summary.get('Canceled', 0) -%}
 {% set progress_running = summary.get('Running', 0) -%}
 {% set progress_none = summary.get(None, 0) + summary.get('Submitted', 0) -%}
 {% set total = progress_complete + progress_failed + progress_running + progress_none -%}
-{% set attrs = 'data-toggle="tooltip" data-placement="bottom" class="progress"' -%}
 
-<div class="form-group row">
+<div class="form-group row" ng-controller="TestJobsProgressController" ng-init="init({{ build.id }}, {{ build.status.finished | lower }}, {{ 'true' if per_environment else 'false' }})">
   <div class="col-md-12 col-sm-12">
-    <h2>{{ _('Test jobs progress') }} <span id="progress-percentage">{{ (((progress_complete + progress_failed) / total) * 100)|round|int }}%</span></h2>
-    <div class="progress-container col-md-12 col-sm-12" ng-controller="TestJobsProgressController" ng-init="init({{ build.id }}, {{ build.status.finished | lower }})">
-      <div {{ attrs|safe }} title="{{ progress_complete }}" style="width: {{ ((progress_complete / total) * 100)|round|int }}%;" id="progress-complete" onclick="location.href='/{{ testjobs_url }}/?job_status=Complete'"></div>
-      <div {{ attrs|safe }} title="{{ progress_failed }}" style="width: {{ ((progress_failed / total) * 100)|round|int }}%;" id="progress-failed" onclick="location.href='/{{ testjobs_url }}/?job_status=Incomplete'"></div>
-      <div {{ attrs|safe }} title="{{ progress_running }}" style="width: {{ ((progress_running / total) * 100)|round|int }}%;" id="progress-running" onclick="location.href='/{{ testjobs_url }}/?job_status=Running'"></div>
-      <div {{ attrs|safe }} title="{{ progress_none }}" style="width: {{ ((progress_none / total) * 100)|round|int }}%;" id="progress-none" onclick="location.href='/{{ testjobs_url }}/?submitted=true&fetched=false'"></div>
-    </div>
+    <h2 id="testjobs-progress">{{ _('Test jobs progress') }} <span id="progress-percentage">{{ (((progress_complete + progress_failed) / total) * 100)|round|int }}%</span></h2>
+    {% if per_environment == None %}
+      <div class="progress-container col-md-12 col-sm-12">
+        <div {{ attrs|safe }} title="{{ progress_complete }}" style="width: {{ ((progress_complete / total) * 100)|round|int }}%;" class="progress complete" id="progress-complete" onclick="location.href='/{{ testjobs_url }}/?job_status=Complete'"></div>
+        <div {{ attrs|safe }} title="{{ progress_failed }}" style="width: {{ ((progress_failed / total) * 100)|round|int }}%;" class="progress failed" id="progress-failed" onclick="location.href='/{{ testjobs_url }}/?job_status=Incomplete'"></div>
+        <div {{ attrs|safe }} title="{{ progress_running }}" style="width: {{ ((progress_running / total) * 100)|round|int }}%;" class="progress running" id="progress-running" onclick="location.href='/{{ testjobs_url }}/?job_status=Running'"></div>
+        <div {{ attrs|safe }} title="{{ progress_none }}" style="width: {{ ((progress_none / total) * 100)|round|int }}%;" class="progress none" id="progress-none" onclick="location.href='/{{ testjobs_url }}/?submitted=true&fetched=false'"></div>
+      </div>
+      <a style="cursor: pointer" onclick="window.location = '{{ update_get_parameters({'testjobs_progress_per_environments': 'true'}) }}#testjobs-progress'">{{ _('see progress for each environment') }}</a>
+    {% else %}
+      {% set env_summary = build.test_jobs_summary(per_environment=True) -%}
+      {% for env, summary in env_summary.items() %}
+        {% set env_key = env.replace('-', '_').replace(' ', '_') %}
+        {% set progress_complete = summary.get('Complete', 0) -%}
+        {% set progress_failed = summary.get('Incomplete', 0) + summary.get('Canceled', 0) -%}
+        {% set progress_running = summary.get('Running', 0) -%}
+        {% set progress_none = summary.get(None, 0) + summary.get('Submitted', 0) -%}
+        {% set total = progress_complete + progress_failed + progress_running + progress_none -%}
+	<h4>{{ env }} <span id="progress-percentage-{{ env_key }}">{{ (((progress_complete + progress_failed) / total) * 100)|round|int }}%</span></h4>
+        <div class="progress-container col-md-12 col-sm-12">
+          <div {{ attrs|safe }} title="{{ progress_complete }}" style="width: {{ ((progress_complete / total) * 100)|round|int }}%;" class="progress complete" id="progress-complete-{{ env_key }}" onclick="location.href='/{{ testjobs_url }}/?job_status=Complete&environment={{ env }}'"></div>
+          <div {{ attrs|safe }} title="{{ progress_failed }}" style="width: {{ ((progress_failed / total) * 100)|round|int }}%;" class="progress failed" id="progress-failed-{{ env_key }}" onclick="location.href='/{{ testjobs_url }}/?job_status=Incomplete&environment={{ env }}'"></div>
+          <div {{ attrs|safe }} title="{{ progress_running }}" style="width: {{ ((progress_running / total) * 100)|round|int }}%;" class="progress running" id="progress-running-{{ env_key }}" onclick="location.href='/{{ testjobs_url }}/?job_status=Running&environment={{ env }}'"></div>
+          <div {{ attrs|safe }} title="{{ progress_none }}" style="width: {{ ((progress_none / total) * 100)|round|int }}%;" class="none" id="progress progress-none-{{ env_key }}" onclick="location.href='/{{ testjobs_url }}/?submitted=true&fetched=false&environment={{ env }}'"></div>
+        </div>
+      {% endfor %}
+      <a style="cursor: pointer" onclick="window.location = '{{ update_get_parameters({'testjobs_progress_per_environments': None}) }}#testjobs-progress'">{{ _('see progress across all environments') }}</a>
+    {% endif %}
+
   </div>
 </div>

--- a/squad/frontend/templates/squad/testjobs_progress.jinja2
+++ b/squad/frontend/templates/squad/testjobs_progress.jinja2
@@ -1,42 +1,63 @@
 {% set testjobs_url = [project.group.slug, project.slug, 'build', build.version, 'testjobs'] | join('/') -%}
 {% set per_environment = request.GET.get('testjobs_progress_per_environments', None) -%}
-{% set attrs = 'data-toggle="tooltip" data-placement="bottom"' -%}
-{% set summary = build.test_jobs_summary() -%}
-{% set progress_complete = summary.get('Complete', 0) -%}
-{% set progress_failed = summary.get('Incomplete', 0) + summary.get('Canceled', 0) -%}
-{% set progress_running = summary.get('Running', 0) -%}
-{% set progress_none = summary.get(None, 0) + summary.get('Submitted', 0) -%}
-{% set total = progress_complete + progress_failed + progress_running + progress_none -%}
+{% set div_attrs = 'data-toggle="tooltip" data-placement="bottom"' -%}
 
-<div class="form-group row" ng-controller="TestJobsProgressController" ng-init="init({{ build.id }}, {{ build.status.finished | lower }}, {{ 'true' if per_environment else 'false' }})">
+<div
+  class="form-group row"
+  ng-controller="TestJobsProgressController"
+  ng-init="init({{ build.id }}, {{ build.status.finished | lower }}, {{ 'true' if per_environment else 'false' }})">
   <div class="col-md-12 col-sm-12">
-    <h2 id="testjobs-progress">{{ _('Test jobs progress') }} <span id="progress-percentage">{{ (((progress_complete + progress_failed) / total) * 100)|round|int }}%</span></h2>
+    <h2 id="testjobs-progress">
+      {{ _('Test jobs progress') }}
+      <span id="progress-finished">{{ testjobs_progress['finished'] }}</span>
+      /
+      <span id="progress-total">{{ testjobs_progress['total'] }}</span>
+      <span id="progress-percentage">({{ testjobs_progress['percentage'] }}%)</span>
+    </h2>
     {% if per_environment == None %}
       <div class="progress-container col-md-12 col-sm-12">
-        <div {{ attrs|safe }} title="{{ progress_complete }}" style="width: {{ ((progress_complete / total) * 100)|round|int }}%;" class="progress complete" id="progress-complete" onclick="location.href='/{{ testjobs_url }}/?job_status=Complete'"></div>
-        <div {{ attrs|safe }} title="{{ progress_failed }}" style="width: {{ ((progress_failed / total) * 100)|round|int }}%;" class="progress failed" id="progress-failed" onclick="location.href='/{{ testjobs_url }}/?job_status=Incomplete'"></div>
-        <div {{ attrs|safe }} title="{{ progress_running }}" style="width: {{ ((progress_running / total) * 100)|round|int }}%;" class="progress running" id="progress-running" onclick="location.href='/{{ testjobs_url }}/?job_status=Running'"></div>
-        <div {{ attrs|safe }} title="{{ progress_none }}" style="width: {{ ((progress_none / total) * 100)|round|int }}%;" class="progress none" id="progress-none" onclick="location.href='/{{ testjobs_url }}/?submitted=true&fetched=false'"></div>
+        {% for progress, attrs in testjobs_progress['progress'].items() %}
+        <div {{ div_attrs|safe }}
+	  id="progress-{{ progress }}"
+	  title="{{ attrs['total'] }}"
+	  style="width: {{ attrs['width'] }}%;"
+	  class="progress {{ progress }}"
+	  onclick="location.href='/{{ testjobs_url }}/?{{ attrs['query_string'] }}'">
+	</div>
+	{% endfor %}
       </div>
-      <a style="cursor: pointer" onclick="window.location = '{{ update_get_parameters({'testjobs_progress_per_environments': 'true'}) }}#testjobs-progress'">{{ _('see progress for each environment') }}</a>
+      <a
+        style="cursor: pointer"
+	onclick="window.location = '{{ update_get_parameters({'testjobs_progress_per_environments': 'true'}) }}#testjobs-progress'">
+	{{ _('see progress for each environment') }}
+      </a>
     {% else %}
-      {% set env_summary = build.test_jobs_summary(per_environment=True) -%}
-      {% for env, summary in env_summary.items() %}
-        {% set env_key = env.replace('-', '_').replace(' ', '_') %}
-        {% set progress_complete = summary.get('Complete', 0) -%}
-        {% set progress_failed = summary.get('Incomplete', 0) + summary.get('Canceled', 0) -%}
-        {% set progress_running = summary.get('Running', 0) -%}
-        {% set progress_none = summary.get(None, 0) + summary.get('Submitted', 0) -%}
-        {% set total = progress_complete + progress_failed + progress_running + progress_none -%}
-	<h4>{{ env }} <span id="progress-percentage-{{ env_key }}">{{ (((progress_complete + progress_failed) / total) * 100)|round|int }}%</span></h4>
+      {% for env, summary in testjobs_progress['envs'].items() %}
+	{% set env_key = env.replace('-', '_').replace(' ', '_') -%}
+	<h4>
+	  {{ env }}:
+	  <span id="progress-finished-{{ env_key }}">{{ summary['finished'] }}</span>
+	  /
+	  <span id="progress-total-{{ env_key }}">{{ summary['total'] }}</span>
+	  <span id="progress-percentage-{{ env_key }}">({{ summary['percentage'] }}%)</span>
+	</h4>
         <div class="progress-container col-md-12 col-sm-12">
-          <div {{ attrs|safe }} title="{{ progress_complete }}" style="width: {{ ((progress_complete / total) * 100)|round|int }}%;" class="progress complete" id="progress-complete-{{ env_key }}" onclick="location.href='/{{ testjobs_url }}/?job_status=Complete&environment={{ env }}'"></div>
-          <div {{ attrs|safe }} title="{{ progress_failed }}" style="width: {{ ((progress_failed / total) * 100)|round|int }}%;" class="progress failed" id="progress-failed-{{ env_key }}" onclick="location.href='/{{ testjobs_url }}/?job_status=Incomplete&environment={{ env }}'"></div>
-          <div {{ attrs|safe }} title="{{ progress_running }}" style="width: {{ ((progress_running / total) * 100)|round|int }}%;" class="progress running" id="progress-running-{{ env_key }}" onclick="location.href='/{{ testjobs_url }}/?job_status=Running&environment={{ env }}'"></div>
-          <div {{ attrs|safe }} title="{{ progress_none }}" style="width: {{ ((progress_none / total) * 100)|round|int }}%;" class="none" id="progress progress-none-{{ env_key }}" onclick="location.href='/{{ testjobs_url }}/?submitted=true&fetched=false&environment={{ env }}'"></div>
+	  {% for progress, attrs in summary['progress'].items() %}
+          <div {{ div_attrs|safe }}
+	    id="progress-{{ progress }}-{{ env_key }}"
+	    title="{{ attrs['total'] }}"
+	    style="width: {{ attrs['width'] }}%;"
+	    class="progress {{ progress }}"
+	    onclick="location.href='/{{ testjobs_url }}/?{{ attrs['query_string']|safe }}'">
+	  </div>
+	  {% endfor %}
         </div>
       {% endfor %}
-      <a style="cursor: pointer" onclick="window.location = '{{ update_get_parameters({'testjobs_progress_per_environments': None}) }}#testjobs-progress'">{{ _('see progress across all environments') }}</a>
+      <a
+        style="cursor: pointer"
+	onclick="window.location = '{{ update_get_parameters({'testjobs_progress_per_environments': None}) }}#testjobs-progress'">
+	{{ _('see progress across all environments') }}
+      </a>
     {% endif %}
 
   </div>

--- a/squad/frontend/templates/squad/testjobs_progress.jinja2
+++ b/squad/frontend/templates/squad/testjobs_progress.jinja2
@@ -1,0 +1,20 @@
+{% set testjobs_url = [project.group.slug, project.slug, 'build', build.version, 'testjobs'] | join('/') -%}
+{% set summary = build.test_jobs_summary() -%}
+{% set progress_complete = summary.get('Complete', 0) -%}
+{% set progress_failed = summary.get('Incomplete', 0) + summary.get('Canceled', 0) -%}
+{% set progress_running = summary.get('Running', 0) -%}
+{% set progress_none = summary.get(None, 0) + summary.get('Submitted', 0) -%}
+{% set total = progress_complete + progress_failed + progress_running + progress_none -%}
+{% set attrs = 'data-toggle="tooltip" data-placement="bottom" class="progress"' -%}
+
+<div class="form-group row">
+  <div class="col-md-12 col-sm-12">
+    <h2>{{ _('Test jobs progress') }} <span id="progress-percentage">{{ (((progress_complete + progress_failed) / total) * 100)|round|int }}%</span></h2>
+    <div class="progress-container col-md-12 col-sm-12" ng-controller="TestJobsProgressController" ng-init="init({{ build.id }}, {{ build.status.finished | lower }})">
+      <div {{ attrs|safe }} title="{{ progress_complete }}" style="width: {{ ((progress_complete / total) * 100)|round|int }}%;" id="progress-complete" onclick="location.href='/{{ testjobs_url }}/?job_status=Complete'"></div>
+      <div {{ attrs|safe }} title="{{ progress_failed }}" style="width: {{ ((progress_failed / total) * 100)|round|int }}%;" id="progress-failed" onclick="location.href='/{{ testjobs_url }}/?job_status=Incomplete'"></div>
+      <div {{ attrs|safe }} title="{{ progress_running }}" style="width: {{ ((progress_running / total) * 100)|round|int }}%;" id="progress-running" onclick="location.href='/{{ testjobs_url }}/?job_status=Running'"></div>
+      <div {{ attrs|safe }} title="{{ progress_none }}" style="width: {{ ((progress_none / total) * 100)|round|int }}%;" id="progress-none" onclick="location.href='/{{ testjobs_url }}/?submitted=true&fetched=false'"></div>
+    </div>
+  </div>
+</div>

--- a/test/api/test_rest.py
+++ b/test/api/test_rest.py
@@ -676,6 +676,16 @@ class RestApiTest(APITestCase):
         data = self.hit('/api/builds/%d/testjobs/' % self.build.id)
         self.assertEqual(1, len(data['results']))
 
+    def test_build_testjobs_summary(self):
+        data = self.hit('/api/builds/%d/testjobs_summary/' % self.build.id)
+        self.assertEqual(1, len(data['results']))
+        self.assertEqual({'null': 1}, data['results'])
+
+    def test_build_testjobs_summary_per_environment(self):
+        data = self.hit('/api/builds/%d/testjobs_summary/?per_environment=1' % self.build.id)
+        self.assertEqual(1, len(data['results']))
+        self.assertEqual({'myenv': {'null': 1}}, data['results'])
+
     def test_build_tests(self):
         data = self.hit('/api/builds/%d/tests/' % self.build.id)
         self.assertEqual(36, len(data['results']))

--- a/test/frontend/test_basics.py
+++ b/test/frontend/test_basics.py
@@ -117,6 +117,9 @@ class FrontendTest(TestCase):
     def test_build(self):
         self.hit('/mygroup/myproject/build/1.0/')
 
+    def test_build_testjobs_progress_per_environment(self):
+        self.hit('/mygroup/myproject/build/1.0/?testjobs_progress_per_environments=true')
+
     def test_build_badge(self):
         self.hit('/mygroup/myproject/build/1.0/badge')
 


### PR DESCRIPTION
This patch allows SQUAD users to follow up which testjobs for a given build are completed, failed, running or still queued.

Below is a snapshot of how it looks like:

![Screenshot from 2021-11-25 16-13-34](https://user-images.githubusercontent.com/2254825/143491993-29053519-9d3e-4668-b2da-3196ed357358.png)

And below is another snapshot of the same view, this time for each environment:
![Screenshot from 2021-11-25 16-13-55](https://user-images.githubusercontent.com/2254825/143491998-eb9a66f9-0d44-4705-81d2-5ec65d234acb.png)

I have also added an interval function in the browser that keeps updating the progress bar every MINUTE until the progress is 100%.
