### PR TITLE
Allow resetting build events

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -136,6 +136,11 @@ By default, the original test job object's results are kept in, but there's
 a project setting named `CI_DELETE_RESULTS_RESUBMITTED_JOBS` that tells SQUAD
 to remove all results from the resubmitted job. 
 
+Resubmitted jobs on finished builds do not cause events (email/patchsource/callback notifications)
+to be triggered when the job is fetched. But there's an option named `CI_RESET_BUILD_EVENTS_ON_JOB_RESUBMISSION`
+that tells SQUAD to reset all build events on job resubmission so that they
+can be triggered once more next time the build reaches its "finished" state.
+
 forceresubmit
 ~~~~~~~~~~~~~
 

--- a/doc/ci.rst
+++ b/doc/ci.rst
@@ -74,6 +74,11 @@ Example (with test job definition as file upload)::
         --form definition=@/path/to/definition.txt \
         https://squad.example.com/api/submitjob/my-group/my-project/x.y.z/my-ci-env
 
+Submitted jobs on finished builds do not cause events (email/patchsource/callback notifications)
+to be triggered when the job is fetched. But there's an option named `CI_RESET_BUILD_EVENTS_ON_JOB_RESUBMISSION`
+that tells SQUAD to reset all build events on job submission so that they
+can be triggered once more next time the build reaches its "finished" state.
+
 .. _ci_watch_ref_label:
 
 Submitting test job watch requests

--- a/squad/core/models.py
+++ b/squad/core/models.py
@@ -473,6 +473,26 @@ class Build(models.Model):
     def prefetch(self, *related):
         prefetch_related_objects([self], *related)
 
+    def reset_events(self):
+        """
+        It might be useful for some projects to "reset" build events like
+        sending out reports or triggering callbacks.
+        """
+
+        # Reset notifications
+        self.status.finished = False
+        self.status.notified = False
+        self.status.notified_on_timeout = None
+        self.status.approved = False
+        self.status.save()
+
+        # Reset patch notifications
+        self.patch_notified = False
+        self.save()
+
+        # Reset callbacks
+        self.callbacks.filter(event=callback_events.ON_BUILD_FINISHED, is_sent=True).update(is_sent=False)
+
     @property
     def test_summary(self):
         return TestSummary(self)


### PR DESCRIPTION
Currently, job submissions/resubmissions on finished builds DO NOT retrigger email/patchsource/callback events.
This patch adds the new project setting `CI_RESET_BUILD_EVENTS_ON_JOB_RESUBMISSION` that when enabled, tells SQUAD to reset the events flags so that the next time a build finishes, events DO get triggered.
