### PR TITLE
ci: models: avoid polling jobs waiting more than a week on the backend

### DIFF
--- a/squad/ci/models.py
+++ b/squad/ci/models.py
@@ -50,10 +50,18 @@ class Backend(models.Model):
     def poll(self):
         if not self.poll_enabled:
             return
+
+        # There are cases that the backend might be running into issues and there is no
+        # way for SQUAD to know it, causing jobs to this backend/environment to clog the
+        # ci_fetch queue with jobs that are never ready to fetch. In order to avoid this
+        # SQUAD will not poll jobs that didn't get processed after a week. It's hardcoded
+        # for now, but it can become a setting in the backend model.
+        week_ago = timezone.now() - relativedelta(days=7)
         test_jobs = self.test_jobs.filter(
             submitted=True,
             fetched=False,
-            fetch_attempts__lt=self.max_fetch_attempts
+            fetch_attempts__lt=self.max_fetch_attempts,
+            submitted_at__gt=week_ago,
         )
         for test_job in test_jobs:
             last = test_job.last_fetch_attempt

--- a/test/ci/test_tasks.py
+++ b/test/ci/test_tasks.py
@@ -6,6 +6,7 @@ import threading
 
 
 from celery.exceptions import Retry
+from django.utils import timezone
 
 
 from squad.ci import models
@@ -41,7 +42,7 @@ class PollTest(TestCase):
         group = core_models.Group.objects.create(slug='testgroup')
         project = group.projects.create(slug='testproject')
         backend = models.Backend.objects.create(name='b1')
-        testjob = backend.test_jobs.create(target=project, submitted=True)
+        testjob = backend.test_jobs.create(target=project, submitted=True, submitted_at=timezone.now())
         poll.apply()
         fetch_method.apply_async.assert_called_with(args=(testjob.id,), task_id=task_id(testjob))
 


### PR DESCRIPTION
SQUAD has no way to tell whether a TestJob has been worked on by its backend. It might be that the device is out or that the backend is undergoing a unusually long maintenance. Overtime, jobs in this scenario will start clogging up the fetch queue, delaying other fetched jobs.

I hardcoded this feature for a week, because that's the usual behavior I noticed, but this can be done via a backend setting as well if requested.