### PR TITLE
all: add the project settings endpoint

### DIFF
--- a/squad/api/rest.py
+++ b/squad/api/rest.py
@@ -497,6 +497,10 @@ class ProjectViewSet(viewsets.ModelViewSet):
 
         Test results of the last build
 
+     * `api/projects/<id>/justin` GET
+
+        List of settings for this project
+
      * `api/projects/<id>/subscribe` POST
 
         Subscribe to project notifications
@@ -598,6 +602,14 @@ class ProjectViewSet(viewsets.ModelViewSet):
         )
         return Response(serializer.data)
 
+    @action(detail=True, methods=['get'], suffix='justin')
+    def justin(self, request, pk=None):
+        """
+        List of settings for this project
+        """
+        project = self.get_object()
+        return Response({}, status=status.HTTP_200_OK)
+
     @action(detail=True, methods=['post'], suffix='subscribe')
     def subscribe(self, request, pk=None):
         subscriber_email = request.data.get("email", None)
@@ -667,7 +679,6 @@ class ProjectViewSet(viewsets.ModelViewSet):
 
             serializer = BuildsComparisonSerializer(comparison)
             return Response(serializer.data)
-
 
 class ProjectStatusSerializer(DynamicFieldsModelSerializer, serializers.HyperlinkedModelSerializer):
 

--- a/test/api/test_rest.py
+++ b/test/api/test_rest.py
@@ -200,6 +200,10 @@ class RestApiTest(APITestCase):
         data = self.hit('/api/projects/')
         self.assertEqual(2, len(data['results']))
 
+    def test_project_settings(self):
+        data = self.hit('/api/projects/%d/justin/' % self.project.id)
+        self.assertEqual(data, {})
+
     def test_project_builds(self):
         data = self.hit('/api/projects/%d/builds/' % self.project.id)
         self.assertEqual(6, len(data['results']))


### PR DESCRIPTION
This endpoint allows a user to query settings about a project via the
api.

Signed-off-by: Justin Cook <justin.cook@linaro.org>