### PR TITLE
frontend: failures: compute a confidence score

### DIFF
--- a/squad/frontend/failures.py
+++ b/squad/frontend/failures.py
@@ -1,0 +1,37 @@
+from django.shortcuts import render
+
+from squad.http import auth
+from squad.frontend.views import get_build
+
+
+@auth
+def failures(request, group_slug, project_slug, build_version):
+    project = request.project
+    build = get_build(project, build_version)
+    failures = build.failures
+    environments = project.environments.order_by("slug")
+
+    search = request.GET.get('search', '')
+
+    if search:
+        failures = failures.filter(metadata__name__icontains=search)
+
+    unique_failures = sorted(set([t.full_name for t in failures]))
+
+    rows = {}
+    for t in build.failures:
+        if t.environment.slug not in rows:
+            rows[t.environment.slug] = {}
+
+        rows[t.environment.slug][t.full_name] = t
+
+    context = {
+        "project": project,
+        "build": build,
+        "environments": environments,
+        "ufailures": unique_failures,
+        "rows": rows,
+        "search": search,
+    }
+
+    return render(request, 'squad/failures.jinja2', context)

--- a/squad/frontend/templates/squad/build-nav.jinja2
+++ b/squad/frontend/templates/squad/build-nav.jinja2
@@ -56,6 +56,11 @@
             {{ _('All test results') }}
         </a>
     </li>
+    <li role="presentation" {% if url_name == 'failures' %}class="active"{% endif %}>
+        <a href="{{build_section_url(build, 'failures')}}">
+            {{ _('All test failures') }}
+        </a>
+    </li>
     <li role="presentation" {% if url_name == 'build_metrics' %}class="active"{% endif %}>
         <a href="{{build_section_url(build, 'build_metrics')}}">
             {{ _('All Metrics') }}

--- a/squad/frontend/templates/squad/failures.jinja2
+++ b/squad/frontend/templates/squad/failures.jinja2
@@ -1,0 +1,82 @@
+{% extends "squad/base.jinja2" %}
+
+{% block content %}
+
+<div ng-app='Build'>
+{% include "squad/build-nav.jinja2" %}
+</div>
+
+<h2>{{ _('All test failures') }}</h2>
+
+<div>
+    <div class='row row-bordered'>
+        <div class='col-md-12 col-sm-12 filter'>
+          <a id="searchLink"><button type='button' class='btn btn-primary fa fa-search'></button></a>
+          <input name='search' id='search' type='text' placeholder='{{ _('Filter results ...') }}' value='{{search}}' />
+        </div>
+    </div>
+
+    <table class='test-results'>
+        <thead>
+            <th>{{ _('Test') }}</th>
+            {% for e in environments %}
+            <th>{{ e.slug }}</th>
+            {% endfor %}
+        </thead>
+        {% if not ufailures %}
+        <tr>
+            <td colspan="{{environments|length|add(1)}}" class="alert alert-warning">
+                <em>{{ _('This build has no failures yet.') }}</em>
+            </td>
+        </tr>
+        {% else %}
+            {% for u in ufailures %}
+              <tr>
+                <td>{{ u }}</td>
+                {% for e in environments %}
+                {% if e.slug in rows and u in rows[e.slug]: %}
+                  <td class="{{ rows[e.slug][u].status }}">
+                    {{ rows[e.slug][u].confidence.score }}
+                    <span data-toggle="tooltip" title="{{ _('Click to display confidence info') }}">
+                      <button class="fa fa-info-circle popover-regressions-fixes"></button>
+                      <span title="{{ _('Confidence') }}" class="hidden">
+                        Pass: {{ rows[e.slug][u].confidence.passes }}
+                        Count: {{ rows[e.slug][u].confidence.count }}
+                        Threshold: {{ rows[e.slug][u].confidence.threshold }}
+                      </span>
+                    </span>
+                  </td>
+                {% else %}
+                  <td>&nbsp;</td>
+                {% endif %}
+                {% endfor %}
+              <tr>
+            {% endfor %}
+        {% endif %}
+    </table>
+
+</div>
+
+{% endblock %}
+
+{% block javascript %}
+<script type="module" src='{{static("squad/build.js")}}'></script>
+<script type="text/javascript" src='{{static("squad/table.js")}}'></script>
+<script type="text/javascript">
+$('[data-toggle="tooltip"]').tooltip();
+function loadSearchURL(pageParam, search) {
+  searchURL = pageParam + "&search=" + search;
+  window.location = searchURL;
+}
+$("#search").keypress(function(e) {
+  if(e.which == 13) {
+    window.location = "?page=1&search=" + $("#search").val();
+    return false;
+  }
+});
+$("#searchLink").click(function(event) {
+  window.location = "?page=1&search=" + $("#search").val();
+  return false;
+});
+</script>
+{% endblock %}

--- a/squad/frontend/urls.py
+++ b/squad/frontend/urls.py
@@ -5,6 +5,7 @@ from django.shortcuts import redirect
 
 from . import views
 from . import comparison
+from . import failures
 from . import metrics
 from . import tests
 from . import ci
@@ -40,6 +41,7 @@ urlpatterns = [
     url(r'^(%s)/(%s)/build/([^/]+)/$' % group_and_project, views.build, name='build'),
     url(r'^(%s)/(%s)/build/([^/]+)/badge$' % group_and_project, views.build_badge, name='build_badge'),
     url(r'^(%s)/(%s)/build/([^/]+)/tests/$' % group_and_project, tests.tests, name='tests'),
+    url(r'^(%s)/(%s)/build/([^/]+)/failures/$' % group_and_project, failures.failures, name='failures'),
     url(r'^(%s)/(%s)/build/([^/]+)/metrics/$' % group_and_project, metrics.build_metrics, name='build_metrics'),
     url(r'^(%s)/(%s)/build/([^/]+)/testjobs/$' % group_and_project, ci.testjobs, name='testjobs'),
     url(r'^(%s)/(%s)/build/([^/]+)/metadata/$' % group_and_project, views.build_metadata, name='build_metadata'),

--- a/test/core/test_build.py
+++ b/test/core/test_build.py
@@ -211,6 +211,35 @@ class BuildTest(TestCase):
         self.project.builds.get_or_create(version='1.0-rc1')
         self.project.builds.get_or_create(version='1.0-rc1')
 
+    def test_failures(self):
+        env = self.project.environments.create(slug="env")
+        suite = self.project.suites.create(slug="suite")
+        metadata, _ = SuiteMetadata.objects.get_or_create(suite=suite.slug, name="test", kind="test")
+
+        b1 = Build.objects.create(project=self.project, version='1.1')
+        tr1 = b1.test_runs.create(environment=env)
+        tr1.tests.create(build=tr1.build, environment=tr1.environment, suite=suite, metadata=metadata, result=True)
+
+        b2 = Build.objects.create(project=self.project, version='1.2')
+        tr2 = b2.test_runs.create(environment=env)
+        tr2.tests.create(build=tr2.build, environment=tr2.environment, suite=suite, metadata=metadata, result=True)
+
+        b3 = Build.objects.create(project=self.project, version='1.3')
+        tr3 = b3.test_runs.create(environment=env)
+        tr3.tests.create(build=tr3.build, environment=tr3.environment, suite=suite, metadata=metadata, result=False)
+
+        self.assertFalse(b1.failures.exists())
+        self.assertFalse(b2.failures.exists())
+        self.assertEqual(b3.failures.count(), 1)
+
+        test = b3.failures.first()
+        self.assertIsNotNone(test)
+        self.assertIsNotNone(test.confidence)
+        self.assertEqual(test.confidence.passes, 2)
+        self.assertEqual(test.confidence.count, 2)
+        self.assertEqual(test.confidence.score, 100)
+        self.assertEqual(test.confidence.threshold, self.project.build_confidence_threshold)
+
     def test_test_suites_by_environment(self):
         build = Build.objects.create(project=self.project, version='1.1')
         env1 = self.project.environments.create(slug='env1')


### PR DESCRIPTION
It is difficult to tell if a test failure is a true regression or a
flakey test. To try and address this, we create a new view of test
failures for a build that displays a confidence score.

A confidence score is the ratio of the number of times the test has
passed over some number number of times the test has been run.

Signed-off-by: Justin Cook <justin.cook@linaro.org>