### PR TITLE
core: models: return a zero confidence score if there is no history

### DIFF
--- a/squad/core/models.py
+++ b/squad/core/models.py
@@ -1020,6 +1020,9 @@ class Test(models.Model):
 
         @property
         def score(self):
+            if not self.count:
+                return 0
+
             return 100 * (self.passes / self.count)
 
     __confidence__ = None


### PR DESCRIPTION
If this is the first time a test ran and it failed, there is no test
history to generate a confidence score from.

Return a score of zero for this case.

Signed-off-by: Justin Cook <justin.cook@linaro.org>