### PR TITLE
Add pagination to failures view

### DIFF
--- a/squad/core/failures.py
+++ b/squad/core/failures.py
@@ -1,0 +1,69 @@
+from django.core.paginator import Paginator
+from squad.core.models import Test
+
+
+class FailuresWithConfidence(object):
+    def __init__(self, project, build, per_page=25, page=1, search=''):
+        self.project = project
+        self.build = build
+        self.per_page = per_page
+        self.page = page
+        self.search = search
+
+    __paginator__ = None
+
+    @property
+    def paginator(self):
+        if self.__paginator__ is not None:
+            return self.__paginator__
+
+        names = self.build.tests.filter(
+            result=False,
+        ).exclude(
+            has_known_issues=True,
+        ).only(
+            'suite__slug', 'metadata__name', 'metadata__id',
+        ).order_by(
+            'suite__slug', 'metadata__name',
+        ).distinct().values_list(
+            'suite__slug', 'metadata__name', 'metadata__id', named=True,
+        )
+
+        if self.search:
+            names = names.filter(metadata__name__icontains=self.search)
+
+        self.__paginator__ = Paginator(names, self.per_page)
+        return self.__paginator__
+
+    @property
+    def number(self):
+        return self.page
+
+    def failures(self):
+        page = self.paginator.page(self.page)
+
+        failures = self.build.tests.filter(
+            result=False,
+            metadata_id__in=[o.metadata__id for o in page.object_list],
+        ).prefetch_related(
+            'metadata', 'environment',
+        ).order_by(
+            'suite__slug', 'metadata__name'
+        )
+
+        limit = self.project.build_confidence_count
+        builds = self.project.builds.filter(
+            id__lt=self.build.id,
+        ).order_by("-id").only("id")[:limit]
+
+        previous = Test.objects.filter(
+            metadata__in=[f.metadata for f in failures],
+            environment__in=[f.environment for f in failures],
+            build_id__in=list(builds.values_list("id", flat=True)),
+        ).order_by("-build_id").prefetch_related("metadata", "environment").defer("log")
+
+        for f in failures:
+            f_p = [t for t in previous if t.metadata == f.metadata and t.environment == f.environment]
+            f.set_confidence(self.project.build_confidence_threshold, f_p)
+
+        return failures

--- a/squad/core/models.py
+++ b/squad/core/models.py
@@ -563,10 +563,10 @@ class Build(models.Model):
             return False
         return True
 
-    __failures__ = None
+    __failures_with_confidence__ = None
 
-    def failures(self):
-        if self.__failures__ is None:
+    def failures_with_confidence(self):
+        if self.__failures_with_confidence__ is None:
             failures = self.tests.filter(result=False).exclude(has_known_issues=True).prefetch_related("metadata", "environment")
 
             limit = self.project.build_confidence_count
@@ -584,9 +584,9 @@ class Build(models.Model):
                 f_history = [t for t in history if t.metadata == f.metadata and t.environment == f.environment]
                 f.set_confidence(self.project.build_confidence_threshold, f_history)
 
-            self.__failures__ = failures
+            self.__failures_with_confidence__ = failures
 
-        return self.__failures__
+        return self.__failures_with_confidence__
 
     @property
     def finished(self):

--- a/squad/core/models.py
+++ b/squad/core/models.py
@@ -565,7 +565,6 @@ class Build(models.Model):
 
     __failures__ = None
 
-    @property
     def failures(self):
         if self.__failures__ is None:
             failures = self.tests.filter(result=False).exclude(has_known_issues=True).prefetch_related("metadata", "environment")

--- a/squad/frontend/failures.py
+++ b/squad/frontend/failures.py
@@ -1,5 +1,6 @@
 from django.shortcuts import render
 
+from squad.core.failures import FailuresWithConfidence
 from squad.http import auth
 from squad.frontend.views import get_build
 
@@ -8,18 +9,16 @@ from squad.frontend.views import get_build
 def failures(request, group_slug, project_slug, build_version):
     project = request.project
     build = get_build(project, build_version)
-    failures = build.failures_with_confidence()
     environments = project.environments.order_by("slug")
+    fc = FailuresWithConfidence(project, build)
 
+    page = request.GET.get('page', 1)
     search = request.GET.get('search', '')
 
-    if search:
-        failures = failures.filter(metadata__name__icontains=search)
-
-    unique_failures = sorted(set([t.full_name for t in failures]))
+    fc = FailuresWithConfidence(project, build, page=int(page), search=search)
 
     rows = {}
-    for t in build.failures_with_confidence():
+    for t in fc.failures():
         if t.environment.slug not in rows:
             rows[t.environment.slug] = {}
 
@@ -29,7 +28,8 @@ def failures(request, group_slug, project_slug, build_version):
         "project": project,
         "build": build,
         "environments": environments,
-        "ufailures": unique_failures,
+        "page": page,
+        "fc": fc,
         "rows": rows,
         "search": search,
     }

--- a/squad/frontend/failures.py
+++ b/squad/frontend/failures.py
@@ -8,7 +8,7 @@ from squad.frontend.views import get_build
 def failures(request, group_slug, project_slug, build_version):
     project = request.project
     build = get_build(project, build_version)
-    failures = build.failures()
+    failures = build.failures_with_confidence()
     environments = project.environments.order_by("slug")
 
     search = request.GET.get('search', '')
@@ -19,7 +19,7 @@ def failures(request, group_slug, project_slug, build_version):
     unique_failures = sorted(set([t.full_name for t in failures]))
 
     rows = {}
-    for t in build.failures():
+    for t in build.failures_with_confidence():
         if t.environment.slug not in rows:
             rows[t.environment.slug] = {}
 

--- a/squad/frontend/failures.py
+++ b/squad/frontend/failures.py
@@ -8,7 +8,7 @@ from squad.frontend.views import get_build
 def failures(request, group_slug, project_slug, build_version):
     project = request.project
     build = get_build(project, build_version)
-    failures = build.failures
+    failures = build.failures()
     environments = project.environments.order_by("slug")
 
     search = request.GET.get('search', '')
@@ -19,7 +19,7 @@ def failures(request, group_slug, project_slug, build_version):
     unique_failures = sorted(set([t.full_name for t in failures]))
 
     rows = {}
-    for t in build.failures:
+    for t in build.failures():
         if t.environment.slug not in rows:
             rows[t.environment.slug] = {}
 

--- a/squad/frontend/templates/squad/failures.jinja2
+++ b/squad/frontend/templates/squad/failures.jinja2
@@ -41,7 +41,7 @@
                 {% for e in environments %}
                 {% if e.slug in rows and fn in rows[e.slug]: %}
                   <td class="{{ rows[e.slug][fn].status }}">
-                    {{ rows[e.slug][fn].confidence.score }}
+                    {{ rows[e.slug][fn].confidence.score }}&nbsp;
                     <span data-toggle="tooltip" title="{{ _('Click to display confidence info') }}">
                       <button class="fa fa-info-circle popover-regressions-fixes"></button>
                       <span title="{{ _('Confidence') }}" class="hidden">

--- a/squad/frontend/templates/squad/failures.jinja2
+++ b/squad/frontend/templates/squad/failures.jinja2
@@ -8,6 +8,10 @@
 
 <h2>{{ _('All test failures') }}</h2>
 
+{% with items=fc %}
+{% include "squad/_pagination.jinja2" %}
+{% endwith %}
+
 <div>
     <div class='row row-bordered'>
         <div class='col-md-12 col-sm-12 filter'>
@@ -23,26 +27,27 @@
             <th>{{ e.slug }}</th>
             {% endfor %}
         </thead>
-        {% if not ufailures %}
+        {% if rows|length == 0 %}
         <tr>
             <td colspan="{{environments|length|add(1)}}" class="alert alert-warning">
                 <em>{{ _('This build has no failures yet.') }}</em>
             </td>
         </tr>
         {% else %}
-            {% for u in ufailures %}
+            {% for i in fc.paginator.page(page) %}
+                {% set fn = i.suite__slug + "/" + i.metadata__name %}
               <tr>
-                <td>{{ u }}</td>
+                <td>{{ fn }}</td>
                 {% for e in environments %}
-                {% if e.slug in rows and u in rows[e.slug]: %}
-                  <td class="{{ rows[e.slug][u].status }}">
-                    {{ rows[e.slug][u].confidence.score }}
+                {% if e.slug in rows and fn in rows[e.slug]: %}
+                  <td class="{{ rows[e.slug][fn].status }}">
+                    {{ rows[e.slug][fn].confidence.score }}
                     <span data-toggle="tooltip" title="{{ _('Click to display confidence info') }}">
                       <button class="fa fa-info-circle popover-regressions-fixes"></button>
                       <span title="{{ _('Confidence') }}" class="hidden">
-                        Pass: {{ rows[e.slug][u].confidence.passes }}
-                        Count: {{ rows[e.slug][u].confidence.count }}
-                        Threshold: {{ rows[e.slug][u].confidence.threshold }}
+                        Pass: {{ rows[e.slug][fn].confidence.passes }}
+                        Count: {{ rows[e.slug][fn].confidence.count }}
+                        Threshold: {{ rows[e.slug][fn].confidence.threshold }}
                       </span>
                     </span>
                   </td>
@@ -56,6 +61,10 @@
     </table>
 
 </div>
+
+{% with items=fc %}
+{% include "squad/_pagination.jinja2" %}
+{% endwith %}
 
 {% endblock %}
 

--- a/test/core/test_build.py
+++ b/test/core/test_build.py
@@ -211,7 +211,7 @@ class BuildTest(TestCase):
         self.project.builds.get_or_create(version='1.0-rc1')
         self.project.builds.get_or_create(version='1.0-rc1')
 
-    def test_failures(self):
+    def test_failures_with_confidence(self):
         env = self.project.environments.create(slug="env")
         suite = self.project.suites.create(slug="suite")
         metadata, _ = SuiteMetadata.objects.get_or_create(suite=suite.slug, name="test", kind="test")
@@ -228,11 +228,11 @@ class BuildTest(TestCase):
         tr3 = b3.test_runs.create(environment=env)
         tr3.tests.create(build=tr3.build, environment=tr3.environment, suite=suite, metadata=metadata, result=False)
 
-        self.assertFalse(b1.failures().exists())
-        self.assertFalse(b2.failures().exists())
-        self.assertEqual(b3.failures().count(), 1)
+        self.assertFalse(b1.failures_with_confidence().exists())
+        self.assertFalse(b2.failures_with_confidence().exists())
+        self.assertEqual(b3.failures_with_confidence().count(), 1)
 
-        test = b3.failures().first()
+        test = b3.failures_with_confidence().first()
         self.assertIsNotNone(test)
         self.assertIsNotNone(test.confidence)
         self.assertEqual(test.confidence.passes, 2)
@@ -240,7 +240,7 @@ class BuildTest(TestCase):
         self.assertEqual(test.confidence.score, 100)
         self.assertEqual(test.confidence.threshold, self.project.build_confidence_threshold)
 
-    def test_failures_no_history(self):
+    def test_failures_with_confidence_with_no_history(self):
         env = self.project.environments.create(slug="env")
         suite = self.project.suites.create(slug="suite")
         metadata, _ = SuiteMetadata.objects.get_or_create(suite=suite.slug, name="test", kind="test")
@@ -249,10 +249,10 @@ class BuildTest(TestCase):
         tr1 = b1.test_runs.create(environment=env)
         tr1.tests.create(build=tr1.build, environment=tr1.environment, suite=suite, metadata=metadata, result=False)
 
-        self.assertTrue(b1.failures().exists())
-        self.assertEqual(b1.failures().count(), 1)
+        self.assertTrue(b1.failures_with_confidence().exists())
+        self.assertEqual(b1.failures_with_confidence().count(), 1)
 
-        test = b1.failures().first()
+        test = b1.failures_with_confidence().first()
         self.assertIsNotNone(test)
         self.assertIsNotNone(test.confidence)
         self.assertEqual(test.confidence.passes, 0)

--- a/test/core/test_build.py
+++ b/test/core/test_build.py
@@ -228,11 +228,11 @@ class BuildTest(TestCase):
         tr3 = b3.test_runs.create(environment=env)
         tr3.tests.create(build=tr3.build, environment=tr3.environment, suite=suite, metadata=metadata, result=False)
 
-        self.assertFalse(b1.failures.exists())
-        self.assertFalse(b2.failures.exists())
-        self.assertEqual(b3.failures.count(), 1)
+        self.assertFalse(b1.failures().exists())
+        self.assertFalse(b2.failures().exists())
+        self.assertEqual(b3.failures().count(), 1)
 
-        test = b3.failures.first()
+        test = b3.failures().first()
         self.assertIsNotNone(test)
         self.assertIsNotNone(test.confidence)
         self.assertEqual(test.confidence.passes, 2)
@@ -249,10 +249,10 @@ class BuildTest(TestCase):
         tr1 = b1.test_runs.create(environment=env)
         tr1.tests.create(build=tr1.build, environment=tr1.environment, suite=suite, metadata=metadata, result=False)
 
-        self.assertTrue(b1.failures.exists())
-        self.assertEqual(b1.failures.count(), 1)
+        self.assertTrue(b1.failures().exists())
+        self.assertEqual(b1.failures().count(), 1)
 
-        test = b1.failures.first()
+        test = b1.failures().first()
         self.assertIsNotNone(test)
         self.assertIsNotNone(test.confidence)
         self.assertEqual(test.confidence.passes, 0)

--- a/test/core/test_failures.py
+++ b/test/core/test_failures.py
@@ -1,0 +1,104 @@
+from django.test import TestCase
+from squad.core.failures import FailuresWithConfidence
+from squad.core.models import Build, Group, SuiteMetadata
+
+
+class FailuresWithConfidenceTest(TestCase):
+
+    def setUp(self):
+        self.group = Group.objects.create(slug='mygroup')
+        self.project = self.group.projects.create(slug='myproject')
+
+    def test_failures_with_confidence(self):
+        env = self.project.environments.create(slug="env")
+        suite = self.project.suites.create(slug="suite")
+        metadata, _ = SuiteMetadata.objects.get_or_create(suite=suite.slug, name="test", kind="test")
+
+        b1 = Build.objects.create(project=self.project, version='1.1')
+        tr1 = b1.test_runs.create(environment=env)
+        tr1.tests.create(build=tr1.build, environment=tr1.environment, suite=suite, metadata=metadata, result=True)
+
+        b2 = Build.objects.create(project=self.project, version='1.2')
+        tr2 = b2.test_runs.create(environment=env)
+        tr2.tests.create(build=tr2.build, environment=tr2.environment, suite=suite, metadata=metadata, result=True)
+
+        b3 = Build.objects.create(project=self.project, version='1.3')
+        tr3 = b3.test_runs.create(environment=env)
+        tr3.tests.create(build=tr3.build, environment=tr3.environment, suite=suite, metadata=metadata, result=False)
+
+        f1 = FailuresWithConfidence(self.project, b1)
+        self.assertEqual(len(f1.failures()), 0)
+
+        f2 = FailuresWithConfidence(self.project, b2)
+        self.assertEqual(len(f2.failures()), 0)
+
+        f3 = FailuresWithConfidence(self.project, b3)
+        self.assertEqual(len(f3.failures()), 1)
+
+        test = f3.failures().first()
+        self.assertIsNotNone(test)
+        self.assertIsNotNone(test.confidence)
+        self.assertEqual(test.confidence.passes, 2)
+        self.assertEqual(test.confidence.count, 2)
+        self.assertEqual(test.confidence.score, 100)
+        self.assertEqual(test.confidence.threshold, self.project.build_confidence_threshold)
+
+    def test_failures_with_confidence_with_no_history(self):
+        env = self.project.environments.create(slug="env")
+        suite = self.project.suites.create(slug="suite")
+        metadata, _ = SuiteMetadata.objects.get_or_create(suite=suite.slug, name="test", kind="test")
+
+        b1 = Build.objects.create(project=self.project, version='1.1')
+        tr1 = b1.test_runs.create(environment=env)
+        tr1.tests.create(build=tr1.build, environment=tr1.environment, suite=suite, metadata=metadata, result=False)
+
+        f1 = FailuresWithConfidence(self.project, b1)
+        self.assertEqual(len(f1.failures()), 1)
+
+        test = f1.failures().first()
+        self.assertIsNotNone(test)
+        self.assertIsNotNone(test.confidence)
+        self.assertEqual(test.confidence.passes, 0)
+        self.assertEqual(test.confidence.count, 0)
+        self.assertEqual(test.confidence.score, 0)
+        self.assertEqual(test.confidence.threshold, self.project.build_confidence_threshold)
+
+    def test_failures_with_confidence_pagination(self):
+        env = self.project.environments.create(slug="env")
+        suite = self.project.suites.create(slug="suite")
+        metadata1, _ = SuiteMetadata.objects.get_or_create(suite=suite.slug, name="test1", kind="test")
+        metadata2, _ = SuiteMetadata.objects.get_or_create(suite=suite.slug, name="test2", kind="test")
+
+        b1 = Build.objects.create(project=self.project, version='1.1')
+        tr1 = b1.test_runs.create(environment=env)
+        tr1.tests.create(build=tr1.build, environment=tr1.environment, suite=suite, metadata=metadata1, result=False)
+        tr1.tests.create(build=tr1.build, environment=tr1.environment, suite=suite, metadata=metadata2, result=False)
+
+        # default failures per page
+        f = FailuresWithConfidence(self.project, b1)
+        self.assertEqual(len(f.failures()), 2)
+
+        # one failure per page
+        fp1 = FailuresWithConfidence(self.project, b1, per_page=1, page=1)
+        self.assertEqual(len(fp1.failures()), 1)
+
+        fp2 = FailuresWithConfidence(self.project, b1, per_page=1, page=2)
+        self.assertEqual(len(fp2.failures()), 1)
+
+    def test_failures_with_confidence_search(self):
+        env = self.project.environments.create(slug="env")
+        suite = self.project.suites.create(slug="suite")
+        metadata1, _ = SuiteMetadata.objects.get_or_create(suite=suite.slug, name="test1", kind="test")
+        metadata2, _ = SuiteMetadata.objects.get_or_create(suite=suite.slug, name="test2", kind="test")
+
+        b1 = Build.objects.create(project=self.project, version='1.1')
+        tr1 = b1.test_runs.create(environment=env)
+        tr1.tests.create(build=tr1.build, environment=tr1.environment, suite=suite, metadata=metadata1, result=False)
+        tr1.tests.create(build=tr1.build, environment=tr1.environment, suite=suite, metadata=metadata2, result=False)
+
+        f = FailuresWithConfidence(self.project, b1, search="test2")
+        self.assertEqual(len(f.failures()), 1)
+
+        test = f.failures().first()
+        self.assertIsNotNone(test)
+        self.assertEqual(test.full_name, "suite/test2")


### PR DESCRIPTION
Use the FailuresWithConfidence class to control database access,
pagination, and searching for the failures view.

This class provides these features to improve performance when gathering
failing tests and their confidence score.