### PR TITLE
frontend: metrics: prefetch metric's metadata

### DIFF
--- a/squad/core/models.py
+++ b/squad/core/models.py
@@ -1109,7 +1109,7 @@ class Metric(models.Model):
 
     @property
     def full_name(self):
-        return join_name(self.suite.slug, self.name)
+        return join_name(self.metadata.suite, self.name)
 
     @property
     def name(self):

--- a/squad/frontend/metrics.py
+++ b/squad/frontend/metrics.py
@@ -10,7 +10,7 @@ def build_metrics(request, group_slug, project_slug, build_version):
     project = request.project
     build = get_build(project, build_version)
     environments = Environment.objects.filter(project=project).order_by("name")
-    metrics = Metric.objects.filter(build=build)
+    metrics = Metric.objects.filter(build=build).prefetch_related("metadata", "environment")
 
     search = request.GET.get('search', '')
 

--- a/test/core/test_metric.py
+++ b/test/core/test_metric.py
@@ -2,7 +2,7 @@ from django.test import TestCase
 from unittest.mock import patch
 
 
-from squad.core.models import Metric, Suite
+from squad.core.models import Metric, SuiteMetadata
 
 
 class MetricTest(TestCase):
@@ -21,6 +21,6 @@ class MetricTest(TestCase):
 
     @patch("squad.core.models.join_name", lambda x, y: 'woooops')
     def test_full_name(self):
-        s = Suite()
-        m = Metric(suite=s)
+        sm = SuiteMetadata()
+        m = Metric(metadata=sm)
         self.assertEqual('woooops', m.full_name)


### PR DESCRIPTION
The "All Metrics" page was way too slow, it was due to a missing prefetch on SuiteMetadata to retrieve the metric's name.