### PR TITLE
plugins: linux-log-parser: split boot log

### DIFF
--- a/test/plugins/linux_log_parser/oops.log
+++ b/test/plugins/linux_log_parser/oops.log
@@ -1610,3 +1610,6 @@ auto-login-action exception
 [   39.283317] [<ffffff8008130bec>] cpu_startup_entry+0x364/0x448
 [   39.289392] [<ffffff80080914f4>] secondary_start_kernel+0x15c/0x1b0
 [   39.295907] [<0000000000cd103c>] 0xcd103c
+ login: root
+[   14.461360] Internal error: Oops - BUG: 0 [#1] PREEMPT SMP
+[   15.447835] BUG: spinlock lockup suspected on CPU#3, gdbus/2329

--- a/test/plugins/linux_log_parser/rcu_warning.log
+++ b/test/plugins/linux_log_parser/rcu_warning.log
@@ -811,7 +811,6 @@ Welcome to [1mLinux-Kernel-Functional-Testing 2.5+linaro[0m!
 
 Linux-Kernel-Functional-Testing 2.5+linaro juno ttyAMA0
 
-juno login: root
 root
 [   26.738428] audit: type=1006 audit(1574425251.148:2): pid=2596 uid=0 old-auid=4294967295 auid=0 tty=(none) old-ses=4294967295 ses=1 res=1
 7[r[999;999H[6n[   27.774954] sky2 0000:08:00.0 enp8s0: Link is up at 1000 Mbps, full duplex, flow control rx

--- a/test/plugins/test_linux_log_parser.py
+++ b/test/plugins/test_linux_log_parser.py
@@ -29,7 +29,7 @@ class TestLinuxLogParser(TestCase):
         testrun = self.new_testrun('oops.log')
         self.plugin.postprocess_testrun(testrun)
 
-        test = testrun.tests.get(suite__slug='linux-log-parser', metadata__name='check-kernel-oops-999')
+        test = testrun.tests.get(suite__slug='log-parser-test', metadata__name='check-kernel-oops-999')
         self.assertFalse(test.result)
         self.assertIsNotNone(test.log)
         self.assertNotIn('Linux version 4.4.89-01529-gb29bace', test.log)
@@ -40,7 +40,7 @@ class TestLinuxLogParser(TestCase):
         testrun = self.new_testrun('kernelpanic.log')
         self.plugin.postprocess_testrun(testrun)
 
-        test = testrun.tests.get(suite__slug='linux-log-parser', metadata__name='check-kernel-panic-999')
+        test = testrun.tests.get(suite__slug='log-parser-test', metadata__name='check-kernel-panic-999')
         self.assertFalse(test.result)
         self.assertIsNotNone(test.log)
         self.assertNotIn('Booting Linux', test.log)
@@ -52,7 +52,7 @@ class TestLinuxLogParser(TestCase):
         testrun = self.new_testrun('oops.log')
         self.plugin.postprocess_testrun(testrun)
 
-        test = testrun.tests.get(suite__slug='linux-log-parser', metadata__name='check-kernel-bug-999')
+        test = testrun.tests.get(suite__slug='log-parser-test', metadata__name='check-kernel-bug-999')
         self.assertFalse(test.result)
         self.assertIsNotNone(test.log)
         self.assertNotIn('Booting Linux', test.log)
@@ -62,7 +62,7 @@ class TestLinuxLogParser(TestCase):
         testrun = self.new_testrun('kernel_bug_and_invalid_opcode.log', job_id='1000')
         self.plugin.postprocess_testrun(testrun)
 
-        test = testrun.tests.get(suite__slug='linux-log-parser', metadata__name='check-kernel-bug-1000')
+        test = testrun.tests.get(suite__slug='log-parser-test', metadata__name='check-kernel-bug-1000')
         self.assertFalse(test.result)
         self.assertIsNotNone(test.log)
         self.assertNotIn('Booting Linux', test.log)
@@ -74,7 +74,7 @@ class TestLinuxLogParser(TestCase):
         testrun = self.new_testrun('kernel_bug_and_invalid_opcode.log')
         self.plugin.postprocess_testrun(testrun)
 
-        test = testrun.tests.get(suite__slug='linux-log-parser', metadata__name='check-kernel-invalid-opcode-999')
+        test = testrun.tests.get(suite__slug='log-parser-test', metadata__name='check-kernel-invalid-opcode-999')
         self.assertFalse(test.result)
         self.assertIsNotNone(test.log)
         self.assertNotIn('Booting Linux', test.log)
@@ -87,12 +87,12 @@ class TestLinuxLogParser(TestCase):
         self.plugin.postprocess_testrun(testrun)
 
         tests = testrun.tests
-        test_trace = tests.get(suite__slug='linux-log-parser', metadata__name='check-kernel-trace-999')
-        test_panic = tests.get(suite__slug='linux-log-parser', metadata__name='check-kernel-panic-999')
-        test_exception = tests.get(suite__slug='linux-log-parser', metadata__name='check-kernel-exception-999')
-        test_warning = tests.get(suite__slug='linux-log-parser', metadata__name='check-kernel-warning-999')
-        test_oops = tests.get(suite__slug='linux-log-parser', metadata__name='check-kernel-oops-999')
-        test_fault = tests.get(suite__slug='linux-log-parser', metadata__name='check-kernel-fault-999')
+        test_trace = tests.get(suite__slug='log-parser-test', metadata__name='check-kernel-trace-999')
+        test_panic = tests.get(suite__slug='log-parser-test', metadata__name='check-kernel-panic-999')
+        test_exception = tests.get(suite__slug='log-parser-test', metadata__name='check-kernel-exception-999')
+        test_warning = tests.get(suite__slug='log-parser-test', metadata__name='check-kernel-warning-999')
+        test_oops = tests.get(suite__slug='log-parser-test', metadata__name='check-kernel-oops-999')
+        test_fault = tests.get(suite__slug='log-parser-test', metadata__name='check-kernel-fault-999')
 
         self.assertTrue(test_trace.result)
         self.assertEqual('', test_trace.log)
@@ -134,12 +134,12 @@ class TestLinuxLogParser(TestCase):
         self.plugin.postprocess_testrun(testrun)
 
         tests = testrun.tests
-        test_trace = tests.get(suite__slug='linux-log-parser', metadata__name='check-kernel-trace-999')
-        test_panic = tests.get(suite__slug='linux-log-parser', metadata__name='check-kernel-panic-999')
-        test_exception = tests.get(suite__slug='linux-log-parser', metadata__name='check-kernel-exception-999')
-        test_warning = tests.get(suite__slug='linux-log-parser', metadata__name='check-kernel-warning-999')
-        test_oops = tests.get(suite__slug='linux-log-parser', metadata__name='check-kernel-oops-999')
-        test_fault = tests.get(suite__slug='linux-log-parser', metadata__name='check-kernel-fault-999')
+        test_trace = tests.get(suite__slug='log-parser-test', metadata__name='check-kernel-trace-999')
+        test_panic = tests.get(suite__slug='log-parser-test', metadata__name='check-kernel-panic-999')
+        test_exception = tests.get(suite__slug='log-parser-test', metadata__name='check-kernel-exception-999')
+        test_warning = tests.get(suite__slug='log-parser-test', metadata__name='check-kernel-warning-999')
+        test_oops = tests.get(suite__slug='log-parser-test', metadata__name='check-kernel-oops-999')
+        test_fault = tests.get(suite__slug='log-parser-test', metadata__name='check-kernel-fault-999')
 
         self.assertTrue(test_trace.result)
         self.assertTrue(test_panic.result)
@@ -162,12 +162,12 @@ class TestLinuxLogParser(TestCase):
         self.plugin.postprocess_testrun(testrun)
 
         tests = testrun.tests
-        test_trace = tests.get(suite__slug='linux-log-parser', metadata__name='check-kernel-trace-999')
-        test_panic = tests.get(suite__slug='linux-log-parser', metadata__name='check-kernel-panic-999')
-        test_exception = tests.get(suite__slug='linux-log-parser', metadata__name='check-kernel-exception-999')
-        test_warning = tests.get(suite__slug='linux-log-parser', metadata__name='check-kernel-warning-999')
-        test_oops = tests.get(suite__slug='linux-log-parser', metadata__name='check-kernel-oops-999')
-        test_fault = tests.get(suite__slug='linux-log-parser', metadata__name='check-kernel-fault-999')
+        test_trace = tests.get(suite__slug='log-parser-test', metadata__name='check-kernel-trace-999')
+        test_panic = tests.get(suite__slug='log-parser-test', metadata__name='check-kernel-panic-999')
+        test_exception = tests.get(suite__slug='log-parser-test', metadata__name='check-kernel-exception-999')
+        test_warning = tests.get(suite__slug='log-parser-test', metadata__name='check-kernel-warning-999')
+        test_oops = tests.get(suite__slug='log-parser-test', metadata__name='check-kernel-oops-999')
+        test_fault = tests.get(suite__slug='log-parser-test', metadata__name='check-kernel-fault-999')
 
         self.assertTrue(test_trace.result)
         self.assertTrue(test_panic.result)
@@ -191,5 +191,16 @@ class TestLinuxLogParser(TestCase):
         testrun.save_log_file(log)
         self.plugin.postprocess_testrun(testrun)
 
-        test = testrun.tests.get(suite__slug='linux-log-parser', metadata__name='check-kernel-panic-999')
+        test = testrun.tests.get(suite__slug='log-parser-test', metadata__name='check-kernel-panic-999')
         self.assertIsNotNone(test.metadata)
+
+    def test_boot_log(self):
+        testrun = self.new_testrun('oops.log')
+        self.plugin.postprocess_testrun(testrun)
+
+        test = testrun.tests.get(suite__slug='log-parser-boot', metadata__name='check-kernel-oops-999')
+        self.assertFalse(test.result)
+        self.assertIsNotNone(test.log)
+        self.assertNotIn('Linux version 4.4.89-01529-gb29bace', test.log)
+        self.assertIn('Internal error: Oops - BUG: 0 [#1] PREEMPT SMP', test.log)
+        self.assertNotIn('Kernel panic', test.log)


### PR DESCRIPTION
This will split linux log parser tests into 2 different suites: `linux-boot-log-parser` and `linux-test-log-parser`. The first suite will contain matches of kernel failures during boot whereas the second one will contain matches after boot.

* linux-boot-log-parser:
![Screenshot from 2022-05-18 14-32-17](https://user-images.githubusercontent.com/2254825/169106026-6fe46a2b-0cc6-44e5-85b4-a88949dc444e.png)


* linux-test-log-parser:
![Screenshot from 2022-05-18 14-31-07](https://user-images.githubusercontent.com/2254825/169106065-f387aad5-291e-4548-959b-3046824d0e8c.png)
