### PR TITLE
core: failures: query past N tests instead of builds

### DIFF
--- a/squad/frontend/templates/squad/failures.jinja2
+++ b/squad/frontend/templates/squad/failures.jinja2
@@ -35,7 +35,7 @@
         </tr>
         {% else %}
             {% for i in page %}
-                {% set fn = i.suite__slug + "/" + i.metadata__name %}
+                {% set fn = i.metadata__suite + "/" + i.metadata__name %}
               <tr>
                 <td>{{ fn }}</td>
                 {% for e in environments %}


### PR DESCRIPTION
SQUAD was comparing the history with the past N builds, and because not necessarily a build has the test in it, this could cause variations on the "count" in the UI.

Now it'll query the past N number of tests x environment that ensure that the count number is always equals to N.