### PR TITLE
api: rest: add allow filtering testjobs by backend

### DIFF
--- a/squad/api/rest.py
+++ b/squad/api/rest.py
@@ -145,10 +145,19 @@ class TestRunFilter(filters.FilterSet):
                   'completed': ['exact']}
 
 
+class BackendFilter(filters.FilterSet):
+    class Meta:
+        model = Backend
+        fields = {'id': ['exact', 'in'],
+                  'name': ['exact', 'in', 'startswith', 'contains', 'icontains'],
+                  'implementation_type': ['exact']}
+
+
 class TestJobFilter(filters.FilterSet):
     testrun = filters.RelatedFilter(TestRunFilter, field_name="testrun", queryset=TestRun.objects.all(), widget=forms.TextInput)
     target_build = filters.RelatedFilter(BuildFilter, field_name="target_build", queryset=Build.objects.all(), widget=forms.TextInput)
     target = filters.RelatedFilter(ProjectFilter, field_name="target", queryset=Project.objects.all(), widget=forms.TextInput)
+    backend = filters.RelatedFilter(BackendFilter, field_name="backend", queryset=Backend.objects.all(), widget=forms.TextInput)
 
     class Meta:
         model = TestJob

--- a/test/api/test_rest.py
+++ b/test/api/test_rest.py
@@ -1057,6 +1057,12 @@ class RestApiTest(APITestCase):
         self.assertEqual(data.json()['status'], 'Queued for fetching')
         fetch_task.assert_called_with(self.testjob5.id)
 
+    def test_testjob_backend_filter(self):
+        data = self.get('/api/testjobs/?backend__implementation_type=fake')
+        self.assertEqual(data.status_code, 200)
+        for testjob in data.json()['results']:
+            self.assertIn(f'/{self.fake_backend.id}/', testjob['backend'])
+
     def test_backends(self):
         data = self.hit('/api/backends/')
         self.assertEqual('foobar', data['results'][0]['name'])


### PR DESCRIPTION
This will allow filtering jobs by backend types, such as lava or tuxsuite