### PR TITLE
core: queries: remove extra order_by

### DIFF
--- a/squad/core/queries.py
+++ b/squad/core/queries.py
@@ -128,8 +128,6 @@ def get_summary_series(project, environments, date_start, date_end):
             build__created_at__range=(date_start, date_end)
         ).filter(
             metrics_summary__gt=0
-        ).order_by(
-            'datetime'
         ).values(
             'metrics_summary',
             'build_id',

--- a/test/frontend/test_basics.py
+++ b/test/frontend/test_basics.py
@@ -98,6 +98,9 @@ class FrontendTest(TestCase):
     def test_project_metrics(self):
         self.hit('/mygroup/myproject/metrics/')
 
+    def test_project_metrics_metric_summary(self):
+        self.hit('/mygroup/myproject/metrics/?environment=myenv&metric=:summary:')
+
     def test_project_test_history_404(self):
         self.hit('/mygroup/myproject/tests/foo', 404)
 


### PR DESCRIPTION
The extra order_by was left there probably due to a mistake. And that was causing an error since datetime is not a field of BuildSummary.