### PR TITLE
ci: tuxsuite: retry fetching buggy Tuxsuite tests

### DIFF
--- a/test/ci/backend/test_tuxsuite.py
+++ b/test/ci/backend/test_tuxsuite.py
@@ -449,3 +449,44 @@ class TuxSuiteTest(TestCase):
 
         self.assertEqual('ltp-smoke', testjob.name)
         self.assertEqual('build failed', testjob.failure)
+
+    def test_fetch_test_results_unknown(self):
+        job_id = 'TEST:tuxgroup@tuxproject#125'
+        testjob = self.build.test_jobs.create(target=self.project, backend=self.backend, job_id=job_id)
+        test_url = urljoin(TUXSUITE_URL, '/groups/tuxgroup/projects/tuxproject/tests/125')
+
+        test_results = {
+            'project': 'tuxgroup/tuxproject',
+            'device': 'qemu-armv7',
+            'uid': '124',
+            'kernel': 'https://storage.tuxboot.com/armv7/zImage',
+            'ap_romfw': None,
+            'mcp_fw': None,
+            'mcp_romfw': None,
+            'modules': None,
+            'parameters': {},
+            'rootfs': None,
+            'scp_fw': None,
+            'scp_romfw': None,
+            'fip': None,
+            'tests': ['boot', 'ltp-smoke'],
+            'user': 'tuxbuild@linaro.org',
+            'user_agent': 'tuxsuite/0.43.6',
+            'state': 'finished',
+            'result': 'fail',
+            'results': {'boot': 'unknown', 'ltp-mm': 'unknown'},
+            'plan': None,
+            'waiting_for': None,
+            'boot_args': None,
+            'provisioning_time': '2022-03-25T15:49:11.441860',
+            'running_time': '2022-03-25T15:50:11.770607',
+            'finished_time': '2022-03-25T15:52:42.672483',
+            'retries': 0,
+            'retries_messages': [],
+            'duration': 151
+        }
+
+        with requests_mock.Mocker() as fake_request:
+            fake_request.get(test_url, json=test_results)
+
+            self.assertEqual(None, self.tuxsuite.fetch(testjob))


### PR DESCRIPTION
Sometimes, Tuxsuite might run into internal bugs when running tests. Squad should detect such cases and retry fetching results
later on.