### PR TITLE
Remove duplicates in queries when computing regressions and fixes comparison

### DIFF
--- a/squad/core/comparison.py
+++ b/squad/core/comparison.py
@@ -152,7 +152,7 @@ class BaseComparison(object):
         where = ' AND '.join(sql['where'])
         values = sql['values']
 
-        sql = 'SELECT %s FROM %s WHERE %s' % (select, _from, where)
+        sql = 'SELECT DISTINCT %s FROM %s WHERE %s' % (select, _from, where)
         sql = sql.format(**values)
 
         return sql


### PR DESCRIPTION
Without the `DISTINCT` keyword, the query might return duplicate rows due to same test/metric be present in more than one testrun.

By adding a distinct, the duplicates go away, thus reducing the amount of memory to populate python objects.