### PR TITLE
Give up fetching when TuxSuite boot fails

### DIFF
--- a/squad/ci/backend/tuxsuite.py
+++ b/squad/ci/backend/tuxsuite.py
@@ -152,8 +152,8 @@ class Backend(BaseBackend):
             if results['result'] == 'fail':
                 test_job.failure = str(results['results'])
 
-            # If any result is unkown, a retry is needed
-            if 'unknown' in results['results'].values():
+            # If boot result is unkown, a retry is needed, otherwise, it either passed or failed
+            if 'unknown' == results['results']['boot']:
                 return None
 
             # Retrieve TuxRun log

--- a/test/ci/backend/test_tuxsuite.py
+++ b/test/ci/backend/test_tuxsuite.py
@@ -326,7 +326,7 @@ class TuxSuiteTest(TestCase):
             'user_agent': 'tuxsuite/0.43.6',
             'state': 'finished',
             'result': 'fail',
-            'results': {'boot': 'fail', 'ltp-smoke': 'fail'},
+            'results': {'boot': 'fail', 'ltp-smoke': 'unknown'},
             'plan': None,
             'waiting_for': None,
             'boot_args': None,
@@ -380,7 +380,7 @@ class TuxSuiteTest(TestCase):
             self.assertEqual(test_logs, logs)
 
         self.assertEqual('ltp-smoke', testjob.name)
-        self.assertEqual("{'boot': 'fail', 'ltp-smoke': 'fail'}", testjob.failure)
+        self.assertEqual("{'boot': 'fail', 'ltp-smoke': 'unknown'}", testjob.failure)
 
     def test_fetch_test_results_for_test_with_failed_build(self):
         job_id = 'TEST:tuxgroup@tuxproject#124'


### PR DESCRIPTION
The behavior for retrying was relying on any result being "unknown", but that does not make sense when the boot already failed.

This patch makes sure to retry fetching a TuxSuite job only in case of an unknown boot result.