### PR TITLE
urls: return 401 page on forbidden page access

### DIFF
--- a/squad/frontend/urls.py
+++ b/squad/frontend/urls.py
@@ -19,6 +19,7 @@ from squad.core.models import slug_pattern, group_slug_pattern
 
 group_and_project = (group_slug_pattern, slug_pattern)
 
+handler403 = "squad.urls.permission_denied"
 
 urlpatterns = [
     url(r'^favicon.ico$', lambda _: redirect(settings.MEDIA_URL + '/static/favicon.ico')),


### PR DESCRIPTION
Return HTTP 401 and its custom page when accessing forbidden/not visible content (similar to a 403).