### PR TITLE
frontend: fix reverse url for annotations UI

### DIFF
--- a/squad/core/plugins.py
+++ b/squad/core/plugins.py
@@ -88,7 +88,7 @@ def apply_plugins(plugin_names):
     for p in plugin_names:
         try:
             plugin = get_plugin_instance(p)
-            yield(plugin)
+            yield plugin
         except PluginNotFound:
             pass
 

--- a/squad/frontend/templates/squad/build-nav.jinja2
+++ b/squad/frontend/templates/squad/build-nav.jinja2
@@ -113,7 +113,7 @@
         <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
         <h4 class="modal-title">{{ _('Build annotation') }}</h4>
       </div>
-      <form class="well" id="annotation_form" ng-controller="AnnotationController" ng-submit="updateAnnotation('{{ build.id }}')" ng-init="{% if build.annotation%}annotation_id={{ build.annotation.id }}{% endif %}">
+      <form class="well" id="annotation_form" ng-controller="AnnotationController" ng-submit="updateAnnotation('{{ url("build-detail", args=[build.pk]) }}')" ng-init="{% if build.annotation%}annotation_id={{ build.annotation.id }}{% endif %}">
         <div class="modal-body">
           <div class="row">
             <div class="col-md-2">


### PR DESCRIPTION
When submitting annotation from UI it requires reverse API URL as a
parameter. Previous implementation only send Build object ID. It
resulted in a HTTP 400 response. This patch fixes the issue and provides
full reverse URL for the Build object API.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@foundries.io>