### PR TITLE
frontend: build: add redirect URL to get API URL

### DIFF
--- a/squad/frontend/urls.py
+++ b/squad/frontend/urls.py
@@ -41,6 +41,7 @@ urlpatterns = [
     url(r'^(%s)/(%s)/knownissues/$' % group_and_project, views.known_issues, name='knownissues'),
     url(r'^(%s)/(%s)/builds/$' % group_and_project, views.builds, name='builds'),
     url(r'^(%s)/(%s)/build/([^/]+)/$' % group_and_project, views.build, name='build'),
+    url(r'^(%s)/(%s)/build/([^/]+)/api/$' % group_and_project, views.build_api, name='build_api'),
     url(r'^(%s)/(%s)/build/([^/]+)/badge$' % group_and_project, views.build_badge, name='build_badge'),
     url(r'^(%s)/(%s)/build/([^/]+)/tests/$' % group_and_project, tests.tests, name='tests'),
     url(r'^(%s)/(%s)/build/([^/]+)/failures/$' % group_and_project, failures.failures, name='failures'),

--- a/squad/frontend/views.py
+++ b/squad/frontend/views.py
@@ -6,7 +6,7 @@ from django.db.models import Case, When, Prefetch, Max
 from django.core.paginator import Paginator, EmptyPage
 from django.contrib.auth.decorators import login_required
 from django.http import HttpResponse, Http404
-from django.shortcuts import render, get_object_or_404, redirect
+from django.shortcuts import render, get_object_or_404, redirect, reverse
 
 from squad.ci.models import TestJob
 from squad.core.models import Group, Metric, ProjectStatus, Status, MetricThreshold, KnownIssue, Test
@@ -467,6 +467,13 @@ def build(request, group_slug, project_slug, version):
         'testjobs_progress': testjobs_progress,
     }
     return render(request, 'squad/build.jinja2', context)
+
+
+@auth
+def build_api(request, group_slug, project_slug, version):
+    project = request.project
+    build = get_build(project, version)
+    return redirect(reverse('build-detail', args=[build.id]))
 
 
 @auth

--- a/test/frontend/test_basics.py
+++ b/test/frontend/test_basics.py
@@ -190,6 +190,10 @@ class FrontendTest(TestCase):
     def test_build_metrics(self):
         self.hit('/mygroup/myproject/build/1.0/testrun/%s/suite/%s/metrics/' % (self.test_run.id, self.suite.slug))
 
+    def test_build_api_link(self):
+        response = self.hit('/mygroup/myproject/build/1.0/api/', 302)
+        self.assertRedirects(response, '/api/builds/%d/' % self.build.id, status_code=302)
+
     def test_test_run_build_404(self):
         self.hit('/mygroup/myproject/build/2.0.missing/testrun/999/', 404)
 


### PR DESCRIPTION
When data is submitted via the API, there is currently no structured way
to obtain the internal build ID so that it can be used for API requests.
Add an URL at /<project>/<build>/build/<version>/api/ that will redirect
to the correct API endpoint for the given build, i.e. /api/builds/<id>/.