### PR TITLE
api: add_test_run: signal invalid request on validation errors

### DIFF
--- a/squad/api/views.py
+++ b/squad/api/views.py
@@ -115,7 +115,7 @@ def add_test_run(request, group_slug, project_slug, version, environment_slug):
         log_addition(request, testrun, "Test Run created")
         if build:
             log_addition(request, build, "Build created")
-    except (exceptions.invalid_input + (exceptions.DuplicatedTestJob,)) as e:
+    except (exceptions.invalid_input + (exceptions.DuplicatedTestJob, ValidationError)) as e:
         logger.warning(request.get_full_path() + ": " + str(e))
         return HttpResponse(str(e), status=400)
 

--- a/test/api/tests.py
+++ b/test/api/tests.py
@@ -376,6 +376,15 @@ class CreateTestRunApiTest(ApiTest):
         )
         self.assertEqual(400, response.status_code)
 
+    def test_metadata_invalid_date_format(self):
+        response = self.client.post(
+            '/api/submit/mygroup/myproject/1.0.0/myenvironment',
+            {
+                'metadata': '{"job_id": "123", "datetime": "1661282149"}',
+            }
+        )
+        self.assertEqual(400, response.status_code)
+
     def test_reject_submission_without_job_id(self):
         response = self.client.post(
             '/api/submit/mygroup/myproject/1.0.18/myenvironment',


### PR DESCRIPTION
Currentlty, an invalid date will cause an unhandled exception.