### PR TITLE
api: ci: reject job submission with malformed definition

### DIFF
--- a/squad/api/ci.py
+++ b/squad/api/ci.py
@@ -46,6 +46,10 @@ def submit_job(request, group_slug, project_slug, version, environment_slug):
     if definition is None:
         return HttpResponseBadRequest("test job definition is required")
 
+    check = backend.check_job_definition(definition)
+    if check is not True:
+        return HttpResponseBadRequest(f"test job definition is not valid: {check}")
+
     # create TestJob object
     test_job = TestJob.objects.create(
         backend=backend,

--- a/squad/ci/backend/fake.py
+++ b/squad/ci/backend/fake.py
@@ -62,3 +62,6 @@ class Backend(object):
 
     def cancel(self, test_job):
         return True
+
+    def check_job_definition(self, definition):
+        return True

--- a/squad/ci/backend/lava.py
+++ b/squad/ci/backend/lava.py
@@ -730,3 +730,10 @@ class Backend(BaseBackend):
         if job.job_status in self.complete_statuses:
             self.log_info("scheduling fetch for job %s" % job.job_id)
             fetch.apply_async(args=[job.id])
+
+    def check_job_definition(self, definition):
+        try:
+            yaml.safe_load(definition)
+            return True
+        except yaml.YAMLError as e:
+            return str(e)

--- a/squad/ci/backend/null.py
+++ b/squad/ci/backend/null.py
@@ -98,6 +98,12 @@ class Backend(object):
         """
         raise NotImplementedError
 
+    def check_job_definition(selt, definition):
+        """
+        Returns True if job definition checks out or an error message
+        """
+        raise NotImplementedError
+
     def format_message(self, msg):
         if self.data and hasattr(self.data, "name"):
             return self.data.name + ': ' + msg

--- a/squad/ci/models.py
+++ b/squad/ci/models.py
@@ -161,6 +161,9 @@ class Backend(models.Model):
     def get_implementation(self):
         return get_backend_implementation(self)
 
+    def check_job_definition(self, definition):
+        return self.get_implementation().check_job_definition(definition)
+
     def __str__(self):
         return '%s (%s)' % (self.name, self.implementation_type)
 

--- a/test/api/test_ci.py
+++ b/test/api/test_ci.py
@@ -146,6 +146,15 @@ class CiApiTest(TestCase):
         r = self.client.post('/api/submitjob/mygroup/myproject/1/myenv', args)
         self.assertEqual(400, r.status_code)
 
+    @patch('squad.ci.backend.fake.Backend.check_job_definition', return_value='bad definition')
+    def test_malformed_definition(self, check_job_definition):
+        args = {
+            'backend': 'lava',
+            'definition': 'unmatched double quotes: "a""'
+        }
+        r = self.client.post('/api/submitjob/mygroup/myproject/1/myenv', args)
+        self.assertEqual(400, r.status_code)
+
     def test_disabled_environment(self):
         args = {
             'backend': 'lava',

--- a/test/ci/backend/test_lava.py
+++ b/test/ci/backend/test_lava.py
@@ -442,6 +442,12 @@ class LavaTest(TestCase):
         self.assertEqual('bar', testjob.name)
         __submit__.assert_called_with(test_definition)
 
+    def test_check_job_definition(self):
+        lava = LAVABackend(None)
+        definition = 'bad: "mismatch quotes""'
+        check = lava.check_job_definition(definition)
+        self.assertIn('found unexpected end of stream', check)
+
     @patch("requests.post", side_effect=requests.exceptions.Timeout)
     def test_submit_timeout(self, post):
         test_definition = "foo: 1\njob_name: bar"


### PR DESCRIPTION
There wasn't any checks against the job definition being submitted.

Signed-off-by: Charles Oliveira <charles.oliveira@linaro.org>