### PR TITLE
core: commands: fix command users crash with Django 2

### DIFF
--- a/squad/core/management/commands/users.py
+++ b/squad/core/management/commands/users.py
@@ -39,7 +39,14 @@ class Command(BaseCommand):
             """
 
             def __init__(self, **kwargs):
-                super().__init__(cmd, **kwargs)
+                kwargs.update(
+                    {
+                        "called_from_command_line": getattr(
+                            cmd, "_called_from_command_line", None
+                        )
+                    }
+                )
+                super().__init__(**kwargs)
 
         sub = parser.add_subparsers(
             dest="sub_command", help="Sub commands", parser_class=SubParser


### PR DESCRIPTION
After upgrading Dockerfile to buster-backports in commit f778bc6 (included in version 1.34) and upgrading Django to version 2 all "squad-admin users" commands fail with:
```
  File squad/core/management/commands/users.py", line 42, in __init__
    super().__init__(cmd, **kwargs)
TypeError: __init__() takes 1 positional argument but 2 were given
```
To fix that, check Django version to pass correct number of arguments
to `__init__()` from Django CommandParser.

How to reproduce the crash:
- Run latest (or any 1.34+ version) squad container:
```
$ docker run -it --entrypoint /bin/bash squadproject/squad
squad@d4381404d0e4:/$ squad --bind 0.0.0.0:${SQUAD_PORT} &
...
squad@d4381404d0e4:/$ squad-admin users add admin
Traceback (most recent call last):
  File "/usr/local/bin/squad-admin", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.9/dist-packages/squad/manage.py", line 22, in main
    execute_from_command_line(sys.argv)
  File "/usr/lib/python3/dist-packages/django/core/management/__init__.py", line 419, in execute_from_command_line
    utility.execute()
  File "/usr/lib/python3/dist-packages/django/core/management/__init__.py", line 413, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/usr/lib/python3/dist-packages/django/core/management/base.py", line 346, in run_from_argv
    parser = self.create_parser(argv[0], argv[1])
  File "/usr/lib/python3/dist-packages/django/core/management/base.py", line 320, in create_parser
    self.add_arguments(parser)
  File "/usr/local/lib/python3.9/dist-packages/squad/core/management/commands/users.py", line 50, in add_arguments
    add_parser = sub.add_parser("add", help="Add a user")
  File "/usr/lib/python3.9/argparse.py", line 1183, in add_parser
    parser = self._parser_class(**kwargs)
  File "/usr/local/lib/python3.9/dist-packages/squad/core/management/commands/users.py", line 42, in __init__
    super().__init__(cmd, **kwargs)
TypeError: __init__() takes 1 positional argument but 2 were given
squad@d4381404d0e4:/$ squad-admin help users
Traceback (most recent call last):
  File "/usr/local/bin/squad-admin", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.9/dist-packages/squad/manage.py", line 22, in main
    execute_from_command_line(sys.argv)
  File "/usr/lib/python3/dist-packages/django/core/management/__init__.py", line 419, in execute_from_command_line
    utility.execute()
  File "/usr/lib/python3/dist-packages/django/core/management/__init__.py", line 405, in execute
    self.fetch_command(options.args[0]).print_help(self.prog_name, options.args[0])
  File "/usr/lib/python3/dist-packages/django/core/management/base.py", line 334, in print_help
    parser = self.create_parser(prog_name, subcommand)
  File "/usr/lib/python3/dist-packages/django/core/management/base.py", line 320, in create_parser
    self.add_arguments(parser)
  File "/usr/local/lib/python3.9/dist-packages/squad/core/management/commands/users.py", line 50, in add_arguments
    add_parser = sub.add_parser("add", help="Add a user")
  File "/usr/lib/python3.9/argparse.py", line 1183, in add_parser
    parser = self._parser_class(**kwargs)
  File "/usr/local/lib/python3.9/dist-packages/squad/core/management/commands/users.py", line 42, in __init__
    super().__init__(cmd, **kwargs)
TypeError: __init__() takes 1 positional argument but 2 were given
```