### PR TITLE
ci: lava: add websocket listener

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+aiohttp
 celery<5.0,>=4.4
 cryptography
 coreapi


### PR DESCRIPTION
LAVA has recently enabled websocket in favor of ZMQ. Newer instances running on the cloud no longer have ZMQ working, so now SQUAD should first attempt connecting to websocket and fallback to ZMQ if the first doesn't work.