### PR TITLE
plugins: Fix URL composing in github plugin

### DIFF
--- a/squad/plugins/github.py
+++ b/squad/plugins/github.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from squad.core.models import ProjectStatus
 from squad.core.plugins import Plugin as BasePlugin
 from squad.frontend.templatetags.squad import project_url
+from urllib.parse import urljoin
 
 
 def build_url(build):
@@ -11,7 +12,6 @@ def build_url(build):
 
 
 class Plugin(BasePlugin):
-
     @staticmethod
     def __github_post__(build, endpoint, payload):
         api_url = build.patch_source.url
@@ -22,10 +22,11 @@ class Plugin(BasePlugin):
             "Authorization": "token %s" % api_token,
         }
 
-        url = api_url + endpoint.format(
-            owner=owner,
-            repository=repository,
-            commit=commit
+        url = urljoin(
+            api_url, endpoint.format(
+                owner=owner,
+                repository=repository,
+                commit=commit)
         )
         return requests.post(url, headers=headers, json=payload)
 

--- a/test/plugins/test_github.py
+++ b/test/plugins/test_github.py
@@ -18,10 +18,27 @@ class GithubPluginTest(TestCase):
             token='123456789',
         )
         self.build = self.project.builds.create(version='1', patch_source=self.patch_source, patch_id='foo/bar/deadbeef')
+        self.patch_source_wrong = PatchSource.objects.create(
+            name='github_wrong',
+            url='https://api.github.com/',
+            username='example',
+            token='123456789',
+        )
+        self.build_wrong = self.project.builds.create(version='2', patch_source=self.patch_source_wrong, patch_id='foo/bar/deadbeef')
+
         self.github = Plugin()
 
     @patch('squad.plugins.github.requests')
     def test_github_post(self, requests):
+        Plugin.__github_post__(self.build_wrong, '/test/{owner}/{repository}/{commit}', {"a": "b"})
+        requests.post.assert_called_with(
+            'https://api.github.com/test/foo/bar/deadbeef',
+            headers={'Authorization': 'token 123456789'},
+            json={"a": "b"},
+        )
+
+    @patch('squad.plugins.github.requests')
+    def test_github_post_wrong_url(self, requests):
         Plugin.__github_post__(self.build, '/test/{owner}/{repository}/{commit}', {"a": "b"})
         requests.post.assert_called_with(
             'https://api.github.com/test/foo/bar/deadbeef',


### PR DESCRIPTION
Github will reject URLs with double / in the middle, like: https://api.github.com//some/api/path
Removing the redundant / fixes the problem. This patch makes sure there is no additional / even if the URL in the database ends with /.