### PR TITLE
plugins: Fix URL returned by github plugin to the UI

### DIFF
--- a/squad/plugins/github.py
+++ b/squad/plugins/github.py
@@ -65,9 +65,10 @@ class Plugin(BasePlugin):
         api_url = build.patch_source.url
         owner, repository, commit = re.split(r'[:/]', build.patch_id)
 
-        return "{api_url}/{owner}/{repository}/commit/{commit}".format(
-            api_url=api_url,
+        endpoint = "/repos/{owner}/{repository}/commits/{commit}".format(
             owner=owner,
             repository=repository,
             commit=commit
         )
+
+        return urljoin(api_url, endpoint)

--- a/test/plugins/test_github.py
+++ b/test/plugins/test_github.py
@@ -69,3 +69,8 @@ class GithubPluginTest(TestCase):
         self.build.status.save()
         state, _ = self.github.__get_finished_state__(self.build)
         self.assertEqual("failure", state)
+
+    def test_github_get_url(self):
+        expected_url = "https://api.github.com/repos/foo/bar/commits/deadbeef"
+        actual_url = self.github.get_url(self.build)
+        self.assertEqual(expected_url, actual_url)


### PR DESCRIPTION
Github API has changed since the plugin was created. The new URL fixes HTTP 404 status. It's still not ideal as it leads to the JSON object instead of the nice web UI.
https://docs.github.com/en/rest/commits/commits?apiVersion=2022-11-28#get-a-commit