### PR TITLE
requirements: add min version 'celery>=5.3'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aiohttp
-celery<5.0,>=4.4
+celery>=5.3
 cryptography
 coreapi
 django_crispy_forms==1.14.0


### PR DESCRIPTION
When running 'manage.py migrete' with Python version 3.11 the following Traceback could be seen:

$ ./manage.py migrate                                                                                                           [242/884]
Traceback (most recent call last):
  File "/home/anders/src/squad/venv-foo/lib/python3.11/site-packages/vine/five.py", line 361, in <module>
    from inspect import formatargspec, getfullargspec
ImportError: cannot import name 'formatargspec' from 'inspect' (/usr/lib/python3.11/inspect.py)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/anders/src/squad/./manage.py", line 3, in <module>
    from squad.manage import main
  File "/home/anders/src/squad/squad/__init__.py", line 10, in <module>
    raise e
  File "/home/anders/src/squad/squad/__init__.py", line 7, in <module>
    from .celery import app as celery_app  # noqa
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/anders/src/squad/squad/celery.py", line 9, in <module>
    from celery import Celery
  File "/home/anders/src/squad/venv-foo/lib/python3.11/site-packages/celery/__init__.py", line 19, in <module>
    from . import local  # noqa
    ^^^^^^^^^^^^^^^^^^^
  File "/home/anders/src/squad/venv-foo/lib/python3.11/site-packages/celery/local.py", line 17, in <module>
    from .five import PY3, bytes_if_py2, items, string, string_t
  File "/home/anders/src/squad/venv-foo/lib/python3.11/site-packages/celery/five.py", line 7, in <module>
    import vine.five
  File "/home/anders/src/squad/venv-foo/lib/python3.11/site-packages/vine/__init__.py", line 8, in <module>
    from .abstract import Thenable
  File "/home/anders/src/squad/venv-foo/lib/python3.11/site-packages/vine/abstract.py", line 6, in <module>
    from .five import with_metaclass, Callable
  File "/home/anders/src/squad/venv-foo/lib/python3.11/site-packages/vine/five.py", line 364, in <module>
    from inspect import formatargspec, getargspec as _getargspec  # noqa
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ImportError: cannot import name 'formatargspec' from 'inspect' (/usr/lib/python3.11/inspect.py)

When dropping the hardcoded version lock '>=5.3' it looks like it passed ok.