### PR TITLE
Change important_metadata to follow order from "Important metadata keys"

### DIFF
--- a/squad/core/models.py
+++ b/squad/core/models.py
@@ -584,10 +584,11 @@ class Build(models.Model):
     def important_metadata(self):
         wanted = (self.project.important_metadata_keys or '').splitlines()
         m = self.metadata
+        metadata = self.metadata
         if len(wanted):
-            return {k: m[k] for k in wanted if k in m}
-        else:
-            return self.metadata
+            metadata = {k: m[k] for k in wanted if k in m}
+
+        return dict(sorted(metadata.items()))
 
     @property
     def has_extra_metadata(self):

--- a/squad/core/models.py
+++ b/squad/core/models.py
@@ -588,7 +588,7 @@ class Build(models.Model):
         if len(wanted):
             metadata = {k: m[k] for k in wanted if k in m}
 
-        return dict(sorted(metadata.items()))
+        return metadata
 
     @property
     def has_extra_metadata(self):

--- a/squad/frontend/views.py
+++ b/squad/frontend/views.py
@@ -157,7 +157,7 @@ def project_home(request, group_slug, project_slug):
     builds = [b for b in __get_builds_with_status__(project, 11)]
     last_build = len(builds) and builds[0] or None
 
-    metadata = last_build and sorted(last_build.important_metadata.items()) or ()
+    metadata = last_build and last_build.important_metadata.items() or ()
     context = {
         'project': project,
         'builds': builds,

--- a/squad/frontend/views.py
+++ b/squad/frontend/views.py
@@ -379,7 +379,7 @@ def build(request, group_slug, project_slug, version):
         'build': build,
         'test_results': test_results,
         'results_layout': results_layout,
-        'metadata': sorted(build.important_metadata.items()),
+        'metadata': build.important_metadata.items(),
         'has_extra_metadata': build.has_extra_metadata,
         'failures_only': failures_only,
         'testjobs_progress': testjobs_progress,

--- a/test/core/test_build.py
+++ b/test/core/test_build.py
@@ -300,7 +300,7 @@ class BuildTest(TestCase):
         m = {'key3': 'val3', 'key1': 'val1', 'key2': 'val2'}
         with patch('squad.core.models.Build.metadata', m):
             self.assertEqual({'key1': 'val1', 'key2': 'val2', 'key3': 'val3'}, build.important_metadata)
-            self.assertEqual(['key1', 'key2', 'key3'], list(build.important_metadata.keys()))
+            self.assertEqual(['key2', 'key1', 'key3'], list(build.important_metadata.keys()))
 
     def test_metadata(self):
         build = Build.objects.create(project=self.project, version='build-metadata')

--- a/test/core/test_build.py
+++ b/test/core/test_build.py
@@ -293,6 +293,15 @@ class BuildTest(TestCase):
         with patch('squad.core.models.Build.metadata', m):
             self.assertEqual({'my key': 'my value'}, build.important_metadata)
 
+    def test_important_metadata_order(self):
+        project = Project(important_metadata_keys='key2\nkey1\nkey3\n')
+        build = Build(project=project)
+
+        m = {'key3': 'val3', 'key1': 'val1', 'key2': 'val2'}
+        with patch('squad.core.models.Build.metadata', m):
+            self.assertEqual({'key1': 'val1', 'key2': 'val2', 'key3': 'val3'}, build.important_metadata)
+            self.assertEqual(['key1', 'key2', 'key3'], list(build.important_metadata.keys()))
+
     def test_metadata(self):
         build = Build.objects.create(project=self.project, version='build-metadata')
         env1 = self.project.environments.create(slug='env1')


### PR DESCRIPTION
Change the important_metadata field so the items are displayed in the order from the "Important metadata keys" project setting rather than alphabetically sorting the list.