### PR TITLE
frontend/templatetags: Add handling for missing status

### DIFF
--- a/squad/frontend/templatetags/squad.py
+++ b/squad/frontend/templatetags/squad.py
@@ -150,7 +150,10 @@ def download_build_attachments_url(group_slug, project_slug, build_version, test
 @register_global_function
 def project_status(project):
     if project.latest_build is not None:
-        return project.latest_build.status
+        try:
+            return project.latest_build.status
+        except Build.status.RelatedObjectDoesNotExist:
+            return None
     return None
 
 

--- a/test/frontend/test_basics.py
+++ b/test/frontend/test_basics.py
@@ -115,6 +115,11 @@ class FrontendTest(TestCase):
     def test_project(self):
         self.hit('/mygroup/myproject/')
 
+    def test_project_list_no_status(self):
+        self.build = self.project.builds.create(version="mybuild")
+        self.build.status.delete()
+        self.hit('/mygroup/?all_projects=1')
+
     def test_project_badge(self):
         self.hit('/mygroup/myproject/badge')
 


### PR DESCRIPTION
If status was missing, this would previously cause a 500 error when loading the page, due to a RelatedObjectDoesNotExist error being raised when the project status function was called.

Now, add handling for the case where status is None, so the project_status will return None instead of raising an error.