### PR TITLE
plugins: linux_log_parser: check-kernel-exception: add a new cut here

### DIFF
--- a/squad/plugins/linux_log_parser.py
+++ b/squad/plugins/linux_log_parser.py
@@ -13,6 +13,7 @@ REGEX_BODY = 1
 
 MULTILINERS = [
     ('check-kernel-exception', r'-+\[ cut here \]-+.*?-+\[ end trace \w* \]-+'),
+    ('check-kernel-exception', r'--- cut here ---+.*?-+\[ end trace \w* \]-+'),
     ('check-kernel-kasan', r'=+\n\[[\s\.\d]+\]\s+BUG: KASAN:.*?=+'),
     ('check-kernel-kfence', r'=+\n\[[\s\.\d]+\]\s+BUG: KFENCE:.*?=+'),
 ]


### PR DESCRIPTION
The linux log parser doesn't catch all 'cut here' kernel-exceptions. Today it catches cut here looking like:
'------------[ cut here ]------------'
Add another multiline that can catch:
'--- cut here ---' too.