### PR TITLE
squad/ci: Remove resubmit / cancel buttons in TestJobs page for Tuxsuite jobs

### DIFF
--- a/squad/ci/backend/lava.py
+++ b/squad/ci/backend/lava.py
@@ -106,6 +106,9 @@ class Backend(BaseBackend):
             return job_id
         return [job_id]
 
+    def has_cancel(self):
+        return True
+
     def cancel(self, test_job):
         if test_job.submitted and test_job.job_id is not None:
             return self.__cancel_job__(test_job.job_id)
@@ -328,6 +331,9 @@ class Backend(BaseBackend):
             hostname = socket_url.hostname
         scheme = socket_url.scheme
         return '%s://%s:%s' % (scheme, hostname, port)
+
+    def has_resubmit(self):
+        return True
 
     def resubmit(self, test_job):
         with self.handle_job_submission():

--- a/squad/ci/backend/null.py
+++ b/squad/ci/backend/null.py
@@ -8,7 +8,7 @@ logger = logging.getLogger('squad.ci.backend')
 description = "None"
 
 
-class Backend(object):
+class Backend:
 
     """
     This is the interface that all backends must implement. Depending on the
@@ -38,6 +38,13 @@ class Backend(object):
               maintainance window).
         """
         raise NotImplementedError
+
+    def has_resubmit(self):
+        """
+        If the backend has a resubmit method implemented, override this to
+        return True.
+        """
+        return False
 
     def resubmit(self, test_job):
         """
@@ -83,6 +90,14 @@ class Backend(object):
         the received data is up to each specific backend implementation.
         """
         raise NotImplementedError
+
+
+    def has_cancel(self):
+        """
+        If the backend has a cancel method implemented, override this to
+        return True.
+        """
+        return False
 
     def cancel(self, test_job):
         """

--- a/squad/ci/backend/tuxsuite.py
+++ b/squad/ci/backend/tuxsuite.py
@@ -32,6 +32,11 @@ requests_session = None
 
 
 class Backend(BaseBackend):
+    def has_resubmit(self):
+        return False
+
+    def has_cancel(self):
+        return False
 
     @staticmethod
     def get_session():
@@ -407,14 +412,6 @@ class Backend(BaseBackend):
             ps = yaml.safe_load(test_job.target.project_settings) or {}
             result_settings.update(ps)
         return result_settings
-
-    def cancel(self, testjob):
-        result_type, tux_project, tux_uid = self.parse_job_id(testjob.job_id)
-        tux_group, tux_user = tux_project.split('@')
-        endpoint = f'groups/{tux_group}/projects/{tux_user}/{result_type.lower()}s/{tux_uid}/cancel'
-        url = urljoin(self.data.url, endpoint)
-        response = requests.post(url)
-        return response.status_code == 200
 
     def supports_callbacks(self):
         return True

--- a/squad/ci/models.py
+++ b/squad/ci/models.py
@@ -379,7 +379,7 @@ class TestJob(models.Model):
         if self.job_status == "Canceled":
             return False
 
-        if self.job_id is not None:
+        if self.job_id is not None and self.backend.has_cancel(self):
             return self.backend.get_implementation().cancel(self)
 
         self.fetched = True

--- a/squad/frontend/templates/squad/testjobs.jinja2
+++ b/squad/frontend/templates/squad/testjobs.jinja2
@@ -56,7 +56,7 @@
     <div class='pull-right clearfix' ng-controller='CancelController' title="{{ _('Cancel all jobs') }}">
         <a class="btn" ng-click="cancel_all({{ build.id }})" ng-class="{'btn-info': !done, 'btn-success': done, 'btn-danger': error}" ng-disabled="done" >
 	    <span ng-class="{'fa':true, 'fa-recycle':!done, 'fa-check': done && !error, 'fa-spin': loading, 'fa-close': error}" ng-disabled="done"></span>
-	    {{ _('Cancell all jobs') }}
+	    {{ _('Cancel all jobs') }}
 	</a>
     </div>
     <br />
@@ -107,7 +107,7 @@
                                 ng-class="{'fa':true, 'fa-recycle':!done, 'fa-check': done && !error, 'fa-spin': loading, 'fa-close': error}"
                                 ng-disabled="done">
                             </span>
-                            {{ _('%s - manual fetch')  % testjob.job_id }}
+                            {{ _('manual fetch') }}
                         </a>
                     </div>
                     {% endif %}
@@ -122,11 +122,12 @@
                                 ng-class="{'fa':true, 'fa-recycle':!done, 'fa-check': done && !error, 'fa-spin': loading, 'fa-close': error}"
                                 ng-disabled="done">
                             </span>
-                            {{ _('%s - cancel')  % testjob.job_id }}
+                            {{ _('cancel %s') % testjob.backend.get_implementation().has_cancel() }}
                         </a>
                     </div>
                     {% endif %}
                     <div class='pull-right' ng-controller='ResubmitController'>
+                        {% if testjob.backend.get_implementation().has_resubmit() %}
                         <a
                             class="btn"
                             ng-click="resubmit({{testjob.id}}, true)"
@@ -138,9 +139,10 @@
                                 ng-disabled="done"
                                 title="{{ _('Resubmit job no matter the status') }}">
                             </span>
-                            {{ _('%s - force resubmit') % testjob.job_id }}
+                            {{ _('force resubmit') }}
                         </a>
-                        {% if testjob.can_resubmit %}
+                        {% endif %}
+                        {% if testjob.can_resubmit and testjob.backend.get_implementation().has_resubmit() %}
                         <a
                             class="btn"
                             ng-click="resubmit({{testjob.id}}, false)"
@@ -152,7 +154,7 @@
                                 ng-disabled="done"
                                 title="{{ _('Resubmit job') }}">
                             </span>
-                            {{ _('%s - resubmit') % testjob.job_id }}
+                            {{ _('resubmit') }}
                         </a>
                         {% endif %}
                     </div>


### PR DESCRIPTION
- Resubmit button removed for TuxSuite jobs
- Cancel button changed so it just cancels the SQUAD lookup of the result, but does not try to cancel in TuxSuite
- Removed the logic for TuxSuite job cancel as Charles said it is not up to date and does not work any more
- job_id removed from buttons to make them a more suitable size