### PR TITLE
doc: Update authorization token header in SQUAD docs

### DIFF
--- a/doc/ci.rst
+++ b/doc/ci.rst
@@ -61,7 +61,7 @@ Example (with test job definition as POST parameter)::
 
     $ DEFINITION="$(cat /path/to/definition.txt)"
     $ curl \
-        --header "Auth-Token: $SQUAD_TOKEN" \
+        --header "Authorization: token $SQUAD_TOKEN" \
         --form backend=lava \
         --form definition="$DEFINITION" \
         https://squad.example.com/api/submitjob/my-group/my-project/x.y.z/my-ci-env
@@ -69,7 +69,7 @@ Example (with test job definition as POST parameter)::
 Example (with test job definition as file upload)::
 
     $ curl \
-        --header "Auth-Token: $SQUAD_TOKEN" \
+        --header "Authorization: token $SQUAD_TOKEN" \
         --form backend=lava \
         --form definition=@/path/to/definition.txt \
         https://squad.example.com/api/submitjob/my-group/my-project/x.y.z/my-ci-env
@@ -109,7 +109,7 @@ processing. The API is following:
 Example (with test job definition as POST parameter)::
 
     $ curl \
-        --header "Auth-Token: $SQUAD_TOKEN" \
+        --header "Authorization: token $SQUAD_TOKEN" \
         --form backend=lava \
         --form testjob_id=123456 \
         https://squad.example.com/api/watchjob/my-group/my-project/x.y.z/my-ci-env

--- a/doc/intro.rst
+++ b/doc/intro.rst
@@ -84,7 +84,7 @@ the format of the data files.
 Example with test data as file uploads::
 
     $ curl \
-        --header "Auth-Token: $SQUAD_TOKEN" \
+        --header "Authorization: token $SQUAD_TOKEN" \
         --form tests=@/path/to/test-results.json \
         --form metrics=@/path/to/metrics.json \
         --form metadata=@/path/to/metadata.json \
@@ -96,7 +96,7 @@ Example with test data as file uploads::
 Example with test data as regular ``POST`` parameters::
 
     $ curl \
-        --header "Auth-Token: $SQUAD_TOKEN" \
+        --header "Authorization: token $SQUAD_TOKEN" \
         --form tests='{"test1": "pass", "test2": "fail"}' \
         --form metrics='{"metric1": 21, "metric2": 4}' \
         --form metadata='{"foo": "bar", "baz": "qux", "job_id": 123}' \
@@ -118,7 +118,7 @@ Example with test data using Python's requests library:
     metadata = json.dumps({"foo": "bar", "baz": "qux", "job_id": 123})
     log = 'log text ...'
 
-    headers = {"Auth-Token": os.getenv('SQUAD_TOKEN')}
+    headers = {"Authorization": f"token {os.getenv('SQUAD_TOKEN')}"}
     url = 'https://squad.example.com/api/submit/my-group/my-project/x.y.z/my-ci-env'
     data = {"metadata": metadata, "log": log, "tests": tests_file}
 

--- a/doc/lava_usecase.rst
+++ b/doc/lava_usecase.rst
@@ -67,7 +67,7 @@ api for submitting a new test job::
 
     wget https://validation.linaro.org/static/docs/v2/examples/test-jobs/qemu-pipeline-first-job.yaml
     curl localhost:8000/api/submitjob/<group-slug>/<project-slug>/<build-version>/<env> \
-         --header "Auth-Token: $SQUAD_TOKEN" \
+         --header "Authorization: token $SQUAD_TOKEN" \
          --form "backend=<backend-name>" \
          --form "definition=@qemu-pipeline-first-job.yaml"
 

--- a/doc/plugins.rst
+++ b/doc/plugins.rst
@@ -118,7 +118,7 @@ by a freshly opened Github Pull Request::
 
     $ curl \
         -X POST \
-        --header "Auth-Token: $SQUAD_TOKEN" \
+        --header "Authorization: token $SQUAD_TOKEN" \
         -d patch_source=your-github-patch-source \
         -d patch_baseline=build-v1 \
         -d patch_id=the_owner/the_repo/8223a534d7bf \
@@ -150,7 +150,7 @@ by a freshly created change::
 
     $ curl \
         -X POST \
-        --header "Auth-Token: $SQUAD_TOKEN" \
+        --header "Authorization: token $SQUAD_TOKEN" \
         -d patch_source=your-gerrit-patch-source \
         -d patch_baseline=build-v1 \
         -d patch_id=change-id/patchset \

--- a/doc/tuxsuite_usecase.rst
+++ b/doc/tuxsuite_usecase.rst
@@ -63,7 +63,7 @@ to send to SQUAD's API for fetching::
     ...
 	 
     curl localhost:8000/api/watchjob/<group-slug>/<project-slug>/<build-version>/<env> \
-         --header "Auth-Token: $SQUAD_TOKEN" \
+         --header "Authorization: token $SQUAD_TOKEN" \
          --form "backend=tuxsuite.com" \
          --form "job_id=BUILD:linaro@lkft#2843VDPeVhg4yaTkgTur0T3ykmq"
 


### PR DESCRIPTION
Change the authorization token from "Auth-Token:" to "Authorization: token" in SQUAD's documentation, to align with Django Rest Framework's Authorization token format.

While both formats are currently supported by SQUAD, Django only treats requests with the "Authorization: token" as authenticated, and will treat requests made with "Auth-Token" as unauthenticated requests. This can sometimes lead to incorrect behavior when using "Auth-Token". For this reason documentation should be updated to change "Authorization: token" to the preferred header for authentication.