### PR TITLE
api: rest: add filter created_at

### DIFF
--- a/squad/api/rest.py
+++ b/squad/api/rest.py
@@ -173,6 +173,7 @@ class TestJobFilter(filters.FilterSet):
                   "fetched": ['exact', 'in'],
                   "fetch_attempts": ['exact', 'in'],
                   "last_fetch_attempt": ['exact', 'in', 'lt', 'gt', 'lte', 'gte'],
+                  "created_at": ['exact', 'in', 'lt', 'gt', 'lte', 'gte'],
                   "failure": ['exact', 'in', 'startswith', 'contains', 'icontains'],
                   "can_resubmit": ['exact', 'in'],
                   "resubmitted_count": ['exact', 'in'],

--- a/test/api/test_rest.py
+++ b/test/api/test_rest.py
@@ -909,6 +909,11 @@ class RestApiTest(APITestCase):
         data = self.hit('/api/testjobs/%d/' % self.testjob.id)
         self.assertEqual('myenv', data['environment'])
 
+    def test_testjob_filter_by_created_at(self):
+        very_old_date = str(datetime.datetime.now() - datetime.timedelta(days=365))
+        data = self.hit('/api/testjobs/?created_at=%s' % very_old_date)
+        self.assertEqual(0, len(data['results']))
+
     def test_testjob_resubmitted_jobs(self):
         data = self.hit('/api/testjobs/%d/resubmitted_jobs/' % self.testjob5.id)
         self.assertIn(str(self.testjob5.id), data['results'][0]['parent_job'])


### PR DESCRIPTION
Make it possible to filter test jobs on 'created_at' date.