### PR TITLE
Do not look oneliners twice

### DIFF
--- a/squad/plugins/linux_log_parser.py
+++ b/squad/plugins/linux_log_parser.py
@@ -131,19 +131,6 @@ class Plugin(BasePlugin):
             matches = regex.findall(log)
             snippets = self.__join_matches(matches, REGEXES)
 
-            # search onliners within multiliners
-            multiline_matches = []
-            for regex_id in range(len(MULTILINERS)):
-                multiline_matches += snippets[regex_id]
-
-            regex = self.__compile_regexes(ONELINERS)
-            matches = regex.findall('\n'.join(multiline_matches))
-            onliner_snippets = self.__join_matches(matches, ONELINERS)
-
-            regex_id_offset = len(MULTILINERS)
-            for regex_id in range(len(ONELINERS)):
-                snippets[regex_id + regex_id_offset] += onliner_snippets[regex_id]
-
             for regex_id in range(len(REGEXES)):
                 test_name = REGEXES[regex_id][REGEX_NAME]
                 self.__create_tests(testrun, suite, test_name, snippets[regex_id])

--- a/test/plugins/linux_log_parser/kernel_bug_and_invalid_opcode.log
+++ b/test/plugins/linux_log_parser/kernel_bug_and_invalid_opcode.log
@@ -2898,6 +2898,8 @@ version: 13_ #
 : _ #
 # # futex_wait_wouldblock Test the unexpected futex value in FUTEX_WAIT
 futex_wait_wouldblock: Test_the #
+-wait-wouldblock[  347.423535] invalid opcode: 0000 [#1] SMP PTI
+[  347.416924] kernel BUG at /usr/src/kernel/arch/x86/kvm/mmu/mmu.c:3722!
 # ok 1 futex[  347.411307] ------------[ cut here ]------------
 [  347.416924] kernel BUG at /usr/src/kernel/arch/x86/kvm/mmu/mmu.c:3722!
 -wait-wouldblock[  347.423535] invalid opcode: 0000 [#1] SMP PTI

--- a/test/plugins/linux_log_parser/oops.log
+++ b/test/plugins/linux_log_parser/oops.log
@@ -920,11 +920,11 @@ See 'systemctl status systemd-resolved.service' for details.
 See 'systemctl status systemd-resolved.service' for details.
 [  OK  ] Stopped Network Name Resolution.
          Starting Network Name Resolution...
+[   14.461360] Internal error: Oops - BUG: 0 [#0] PREEMPT SMP
 [   14.436996] IPv6: ADDRCONF(NETDEV_UP): wlan0: link is not ready
 [   14.446502] ------------[ cut here ]------------
 [   14.451213] kernel BUG at /srv/oe/build/tmp-rpb-glibc/work-shared/hikey/kernel-source/kernel/sched/walt.c:109!
-[   14.461360] Internal error: Oops - BUG: 0 [#1] PREEMPT SMP
-[  114.461360] Internal error: Oops - BUG: 1 [#1] PREEMPT SMP
+[  114.461360] Internal error: Oops - BUG: 99 [#99] PREEMPT SMP
 [   14.466921] Modules linked in:
 [   14.470030] CPU: 0 PID: 2270 Comm: NetworkManager Not tainted 4.4.89-01529-gb29bace #1
 [   14.478057] Hardware name: HiKey Development Board (DT)

--- a/test/plugins/test_linux_log_parser.py
+++ b/test/plugins/test_linux_log_parser.py
@@ -232,7 +232,7 @@ class TestLinuxLogParser(TestCase):
         self.assertFalse(test.result)
         self.assertIsNotNone(test.log)
         self.assertNotIn('Linux version 4.4.89-01529-gb29bace', test.log)
-        self.assertIn('Internal error: Oops - BUG: 0 [#1] PREEMPT SMP', test.log)
+        self.assertIn('Internal error: Oops - BUG: 0 [#0] PREEMPT SMP', test.log)
         self.assertNotIn('Kernel panic', test.log)
 
     def test_sha_name(self):
@@ -243,12 +243,12 @@ class TestLinuxLogParser(TestCase):
         self.assertFalse(test.result)
         self.assertIsNotNone(test.log)
         self.assertNotIn('Linux version 4.4.89-01529-gb29bace', test.log)
-        self.assertIn('Internal error: Oops - BUG: 0 [#1] PREEMPT SMP', test.log)
+        self.assertIn('Internal error: Oops - BUG: 0 [#0] PREEMPT SMP', test.log)
         self.assertNotIn('Kernel panic', test.log)
 
         # Now check if a test with sha digest in the name
         test = testrun.tests.get(suite__slug='log-parser-boot', metadata__name='check-kernel-oops-a1acf2f0467782c9c2f6aeadb1d1d3cec136642b13d7231824a66ef63ee62220')
         self.assertFalse(test.result)
         self.assertIsNotNone(test.log)
-        self.assertIn('Internal error: Oops - BUG: 0 [#1] PREEMPT SMP', test.log)
-        self.assertIn('Internal error: Oops - BUG: 1 [#1] PREEMPT SMP', test.log)
+        self.assertIn('Internal error: Oops - BUG: 0 [#0] PREEMPT SMP', test.log)
+        self.assertNotIn('Internal error: Oops - BUG: 99 [#1] PREEMPT SMP', test.log)


### PR DESCRIPTION
The plugin used to look oneliner regexes within multiliner matches, meaning more instances of tests being generated.

Now, the plugin does not look within multiliner matches.