### PR TITLE
Improve testcase show info

### DIFF
--- a/squad/ci/backend/lava.py
+++ b/squad/ci/backend/lava.py
@@ -659,11 +659,13 @@ class Backend(BaseBackend):
                     suite = result['suite'].split("_", 1)[-1]
                     res_name = "%s/%s" % (suite, result['name'])
                     res_log = None
-                    if 'log_start_line' in result.keys() and \
-                            'log_end_line' in result.keys() and \
-                            result['log_start_line'] is not None and \
-                            result['log_end_line'] is not None:
-                        res_log = self.__download_test_log__(raw_logs, result['log_start_line'], result['log_end_line'])
+                    if 'log_start_line' in result.keys():
+                        log_url = f"{self.job_url(test_job)}#L{result['log_start_line']}"
+                        res_log = f"Testcase log: <a href='{log_url}'>{log_url}</a>\n"
+                        if 'log_end_line' in result.keys() and \
+                                result['log_start_line'] is not None and \
+                                result['log_end_line'] is not None:
+                            res_log += self.__download_test_log__(raw_logs, result['log_start_line'], result['log_end_line'])
                     # YAML from LAVA has all values serialized to strings
                     if result['measurement'] == 'None' or result['measurement'] is None:
                         res_value = result['result']

--- a/squad/frontend/templates/squad/tests.jinja2
+++ b/squad/frontend/templates/squad/tests.jinja2
@@ -37,7 +37,7 @@
                 {% for status in test %}
                 <td class="{{status[0]}}"><a href="{{ test_history_url }}">{{status[0]}}{% if status[1] %} ({{status[1]}} %){% endif %}</a>
                   {% if status[2] %}
-                  <a href='#' data-toggle="modal" data-target="#info_modal" data-status="{{ status[1] }}"><span data-toggle="tooltip" data-placement="right" title="{{ _('Show info') }}" class='fa fa-info-circle'></span></a>
+                  <a href='#' data-toggle="modal" data-target="#info_modal" data-status="{{ status[2] }}"><span data-toggle="tooltip" data-placement="right" title="{{ _('Show info') }}" class='fa fa-info-circle'></span></a>
                   {% endif %}
                 </td>
                 {% endfor %}


### PR DESCRIPTION
This proposal adds the possibility to jump directly to the line of the testcase in the Lava log from the "Tests" tab by clicking on the "Test Info" modal view. It makes the analysis of an issue easier.

For this, it fixes the modal "Test Info" view from the build "Tests" tab, and adds the URL of the Lava log of the testcase in it.